### PR TITLE
Alias polyfills

### DIFF
--- a/__fixtures__/uuid/abstract-repository.ts
+++ b/__fixtures__/uuid/abstract-repository.ts
@@ -26,6 +26,7 @@ import {
   RepositoryPayload,
   RevisionPayload,
 } from '../../src/graphql/schema/uuid/abstract-repository'
+import { encodePath } from '../../src/graphql/schema/uuid/alias'
 import { getUuidDataWithoutSubResolvers } from './abstract-uuid'
 
 export function createRepositoryLicenseQuery(variables: RepositoryPayload) {
@@ -57,7 +58,8 @@ export function getRepositoryDataWithoutSubResolvers(
 ) {
   return {
     ...getUuidDataWithoutSubResolvers(repository),
-    ...R.pick(['alias', 'date'], repository),
+    ...R.pick(['date'], repository),
+    alias: repository['alias'] ? encodePath(repository['alias']) : null,
   }
 }
 

--- a/__fixtures__/uuid/abstract-repository.ts
+++ b/__fixtures__/uuid/abstract-repository.ts
@@ -26,8 +26,8 @@ import {
   RepositoryPayload,
   RevisionPayload,
 } from '../../src/graphql/schema/uuid/abstract-repository'
-import { encodePath } from '../../src/graphql/schema/uuid/alias'
 import { getUuidDataWithoutSubResolvers } from './abstract-uuid'
+import { getAliasDataWithoutSubResolvers } from './alias'
 
 export function createRepositoryLicenseQuery(variables: RepositoryPayload) {
   return {
@@ -58,8 +58,8 @@ export function getRepositoryDataWithoutSubResolvers(
 ) {
   return {
     ...getUuidDataWithoutSubResolvers(repository),
+    ...getAliasDataWithoutSubResolvers(repository),
     ...R.pick(['date'], repository),
-    alias: repository['alias'] ? encodePath(repository['alias']) : null,
   }
 }
 

--- a/__fixtures__/uuid/alias.ts
+++ b/__fixtures__/uuid/alias.ts
@@ -19,32 +19,17 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { DiscriminatorType, UserPayload } from '../../src/graphql/schema'
-import { getAliasDataWithoutSubResolvers } from './alias'
+import { UserPayload, isUserPayload } from '../../src/graphql/schema'
+import { RepositoryPayload } from '../../src/graphql/schema/uuid/abstract-repository'
+import { encodePath } from '../../src/graphql/schema/uuid/alias'
 
-export const user: UserPayload = {
-  __typename: DiscriminatorType.User,
-  id: 1,
-  trashed: false,
-  username: 'username',
-  date: '2014-03-01T20:36:21Z',
-  lastLogin: '2020-03-24T09:40:55Z',
-  description: null,
-}
+export function getAliasDataWithoutSubResolvers(
+  payload: RepositoryPayload | UserPayload
+) {
+  const decodedAlias = isUserPayload(payload)
+    ? `/user/profile/${payload.username}`
+    : payload.alias
+  const alias = decodedAlias === null ? null : encodePath(decodedAlias)
 
-export const user2: UserPayload = {
-  __typename: DiscriminatorType.User,
-  id: 23,
-  trashed: false,
-  username: 'second user',
-  date: '2015-02-01T20:35:21Z',
-  lastLogin: '2019-03-23T09:20:55Z',
-  description: null,
-}
-
-export function getUserDataWithoutSubResolver(user: UserPayload) {
-  return {
-    ...user,
-    ...getAliasDataWithoutSubResolvers(user),
-  }
+  return { alias }
 }

--- a/__fixtures__/uuid/article.ts
+++ b/__fixtures__/uuid/article.ts
@@ -29,13 +29,14 @@ import {
 } from '../../src/graphql/schema'
 import { Instance } from '../../src/types'
 import { license } from '../license'
+import { getRepositoryDataWithoutSubResolvers } from './abstract-repository'
 
 export const article: ArticlePayload = {
   __typename: EntityType.Article,
   id: 1855,
   trashed: false,
   instance: Instance.De,
-  alias: '/mathe/funktionen/uebersicht-aller-artikel-zu-funktionen/parabel',
+  alias: '/mathe/funktionen/übersicht-aller-artikel-zu-funktionen/parabel',
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: 30674,
   licenseId: license.id,
@@ -57,7 +58,10 @@ export const articleRevision: ArticleRevisionPayload = {
 }
 
 export function getArticleDataWithoutSubResolvers(article: ArticlePayload) {
-  return R.omit(['currentRevisionId', 'licenseId', 'taxonomyTermIds'], article)
+  return {
+    ...R.omit(['currentRevisionId', 'licenseId', 'taxonomyTermIds'], article),
+    ...getRepositoryDataWithoutSubResolvers(article),
+  }
 }
 
 export function getArticleRevisionDataWithoutSubResolvers(

--- a/__fixtures__/uuid/user.ts
+++ b/__fixtures__/uuid/user.ts
@@ -42,7 +42,7 @@ export const user2: UserPayload = {
   description: null,
 }
 
-export function getUserDataWithoutSubResolver(user: UserPayload) {
+export function getUserDataWithoutSubResolvers(user: UserPayload) {
   return {
     ...user,
     ...getAliasDataWithoutSubResolvers(user),

--- a/__fixtures__/uuid/user.ts
+++ b/__fixtures__/uuid/user.ts
@@ -19,7 +19,11 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { DiscriminatorType, UserPayload } from '../../src/graphql/schema'
+import {
+  DiscriminatorType,
+  encodePath,
+  UserPayload,
+} from '../../src/graphql/schema'
 
 export const user: UserPayload = {
   __typename: DiscriminatorType.User,
@@ -39,4 +43,11 @@ export const user2: UserPayload = {
   date: '2015-02-01T20:35:21Z',
   lastLogin: '2019-03-23T09:20:55Z',
   description: null,
+}
+
+export function getUserDataWithoutSubResolver(user: UserPayload) {
+  return {
+    ...user,
+    alias: encodePath(`/user/profile/${user.username}`),
+  }
 }

--- a/__tests-pacts__/serlo.org/alias.ts
+++ b/__tests-pacts__/serlo.org/alias.ts
@@ -49,3 +49,27 @@ test('Alias', async () => {
   })
   await fetch(`http://de.${process.env.SERLO_ORG_HOST}/api/alias/mathe`)
 })
+
+test('Alias (URL /user/profile/:username)', async () => {
+  await addJsonInteraction({
+    name: 'fetch data of alias /user/profile/admin',
+    given: 'user "admin" has id 1',
+    path: '/api/alias/user/profile/admin',
+    body: {
+      id: Matchers.integer(1),
+      instance: Matchers.string('de'),
+      path: Matchers.term({
+        matcher: '\\/user\\/profile\\/.*',
+        generate: '/user/profile/admin',
+      }),
+      source: Matchers.term({
+        matcher: '\\/user\\/profile\\/.*',
+        generate: '/user/profile/admin',
+      }),
+      timestamp: Matchers.iso8601DateTime('2014-03-01T20:36:21+01:00'),
+    },
+  })
+  await fetch(
+    `http://de.${process.env.SERLO_ORG_HOST}/api/alias/user/profile/admin`
+  )
+})

--- a/__tests-pacts__/serlo.org/alias.ts
+++ b/__tests-pacts__/serlo.org/alias.ts
@@ -58,13 +58,10 @@ test('Alias (URL /user/profile/:username)', async () => {
     body: {
       id: Matchers.integer(1),
       instance: Matchers.string('de'),
-      path: Matchers.term({
-        matcher: '\\/user\\/profile\\/.*',
-        generate: '/user/profile/admin',
-      }),
+      path: '/user/profile/admin',
       source: Matchers.term({
-        matcher: '\\/user\\/profile\\/.*',
-        generate: '/user/profile/admin',
+        matcher: '\\/user\\/profile\\/\\d+',
+        generate: '/user/profile/1',
       }),
       timestamp: Matchers.iso8601DateTime('2014-03-01T20:36:21+01:00'),
     },

--- a/__tests-pacts__/serlo.org/uuid/user.ts
+++ b/__tests-pacts__/serlo.org/uuid/user.ts
@@ -22,7 +22,7 @@
 import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
 
-import { user } from '../../../__fixtures__'
+import { getUserDataWithoutSubResolver, user } from '../../../__fixtures__'
 import { UserPayload } from '../../../src/graphql/schema/uuid/user'
 import {
   addUuidInteraction,
@@ -47,6 +47,7 @@ test('User', async () => {
           ... on User {
             id
             trashed
+            alias
             username
             date
             lastLogin
@@ -57,7 +58,7 @@ test('User', async () => {
     `,
     variables: user,
     data: {
-      uuid: user,
+      uuid: getUserDataWithoutSubResolver(user),
     },
   })
 })

--- a/__tests-pacts__/serlo.org/uuid/user.ts
+++ b/__tests-pacts__/serlo.org/uuid/user.ts
@@ -22,7 +22,7 @@
 import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
 
-import { getUserDataWithoutSubResolver, user } from '../../../__fixtures__'
+import { getUserDataWithoutSubResolvers, user } from '../../../__fixtures__'
 import { UserPayload } from '../../../src/graphql/schema/uuid/user'
 import {
   addUuidInteraction,
@@ -58,7 +58,7 @@ test('User', async () => {
     `,
     variables: user,
     data: {
-      uuid: getUserDataWithoutSubResolver(user),
+      uuid: getUserDataWithoutSubResolvers(user),
     },
   })
 })

--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -48,17 +48,24 @@ export async function assertFailingGraphQLQuery({
   query,
   variables,
   client,
+  message,
 }: {
   query: string | DocumentNode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variables?: Record<string, any>
   client: Client
+  message?: unknown
 }) {
   const response = await client.query({
     query,
     variables,
   })
   expect(response.errors).toBeDefined()
+
+  if (message)
+    expect(response.errors?.map((error) => error.message)).toContainEqual(
+      message
+    )
 }
 
 export async function assertSuccessfulGraphQLMutation({

--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -44,6 +44,23 @@ export async function assertSuccessfulGraphQLQuery({
   expect(response.data).toEqual(data)
 }
 
+export async function assertFailingGraphQLQuery({
+  query,
+  variables,
+  client,
+}: {
+  query: string | DocumentNode
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  variables?: Record<string, any>
+  client: Client
+}) {
+  const response = await client.query({
+    query,
+    variables,
+  })
+  expect(response.errors).toBeDefined()
+}
+
 export async function assertSuccessfulGraphQLMutation({
   mutation,
   variables,

--- a/__tests__/schema/notification.ts
+++ b/__tests__/schema/notification.ts
@@ -56,7 +56,7 @@ import {
   getSetUuidStateNotificationEventDataWithoutSubResolvers,
   getSolutionDataWithoutSubResolvers,
   getTaxonomyTermDataWithoutSubResolvers,
-  getUserDataWithoutSubResolver,
+  getUserDataWithoutSubResolvers,
   rejectRevisionNotificationEvent,
   removeEntityLinkNotificationEvent,
   removeTaxonomyLinkNotificationEvent,
@@ -350,7 +350,7 @@ describe('notificationEvent', () => {
         variables: checkoutRevisionNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -481,7 +481,7 @@ describe('notificationEvent', () => {
         variables: rejectRevisionNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -611,7 +611,7 @@ describe('notificationEvent', () => {
         variables: createCommentNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -720,7 +720,7 @@ describe('notificationEvent', () => {
         variables: createEntityNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -814,7 +814,7 @@ describe('notificationEvent', () => {
         variables: createEntityLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -939,7 +939,7 @@ describe('notificationEvent', () => {
         variables: removeEntityLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1064,7 +1064,7 @@ describe('notificationEvent', () => {
         variables: createEntityRevisionNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1194,7 +1194,7 @@ describe('notificationEvent', () => {
         variables: createTaxonomyTermNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1291,7 +1291,7 @@ describe('notificationEvent', () => {
         variables: setTaxonomyTermNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1388,7 +1388,7 @@ describe('notificationEvent', () => {
         variables: createTaxonomyLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1516,7 +1516,7 @@ describe('notificationEvent', () => {
         variables: removeTaxonomyLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1644,7 +1644,7 @@ describe('notificationEvent', () => {
         variables: setTaxonomyParentNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1807,7 +1807,7 @@ describe('notificationEvent', () => {
         variables: createThreadNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -1924,7 +1924,7 @@ describe('notificationEvent', () => {
         variables: setLicenseNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -2019,7 +2019,7 @@ describe('notificationEvent', () => {
         variables: setThreadStateNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,
@@ -2106,7 +2106,7 @@ describe('notificationEvent', () => {
         variables: setUuidStateNotificationEvent,
         data: {
           notificationEvent: {
-            actor: getUserDataWithoutSubResolver(user),
+            actor: getUserDataWithoutSubResolvers(user),
           },
         },
         client,

--- a/__tests__/schema/notification.ts
+++ b/__tests__/schema/notification.ts
@@ -56,6 +56,7 @@ import {
   getSetUuidStateNotificationEventDataWithoutSubResolvers,
   getSolutionDataWithoutSubResolvers,
   getTaxonomyTermDataWithoutSubResolvers,
+  getUserDataWithoutSubResolver,
   rejectRevisionNotificationEvent,
   removeEntityLinkNotificationEvent,
   removeTaxonomyLinkNotificationEvent,
@@ -336,6 +337,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -348,7 +350,7 @@ describe('notificationEvent', () => {
         variables: checkoutRevisionNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -466,6 +468,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -478,7 +481,7 @@ describe('notificationEvent', () => {
         variables: rejectRevisionNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -595,6 +598,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -607,7 +611,7 @@ describe('notificationEvent', () => {
         variables: createCommentNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -703,6 +707,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -715,7 +720,7 @@ describe('notificationEvent', () => {
         variables: createEntityNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -796,6 +801,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -808,7 +814,7 @@ describe('notificationEvent', () => {
         variables: createEntityLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -920,6 +926,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -932,7 +939,7 @@ describe('notificationEvent', () => {
         variables: removeEntityLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1044,6 +1051,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1056,7 +1064,7 @@ describe('notificationEvent', () => {
         variables: createEntityRevisionNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1173,6 +1181,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1185,7 +1194,7 @@ describe('notificationEvent', () => {
         variables: createTaxonomyTermNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1269,6 +1278,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1281,7 +1291,7 @@ describe('notificationEvent', () => {
         variables: setTaxonomyTermNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1365,6 +1375,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1377,7 +1388,7 @@ describe('notificationEvent', () => {
         variables: createTaxonomyLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1492,6 +1503,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1504,7 +1516,7 @@ describe('notificationEvent', () => {
         variables: removeTaxonomyLinkNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1619,6 +1631,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1631,7 +1644,7 @@ describe('notificationEvent', () => {
         variables: setTaxonomyParentNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1781,6 +1794,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1793,7 +1807,7 @@ describe('notificationEvent', () => {
         variables: createThreadNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1897,6 +1911,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -1909,7 +1924,7 @@ describe('notificationEvent', () => {
         variables: setLicenseNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -1991,6 +2006,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -2003,7 +2019,7 @@ describe('notificationEvent', () => {
         variables: setThreadStateNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,
@@ -2077,6 +2093,7 @@ describe('notificationEvent', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -2089,7 +2106,7 @@ describe('notificationEvent', () => {
         variables: setUuidStateNotificationEvent,
         data: {
           notificationEvent: {
-            actor: user,
+            actor: getUserDataWithoutSubResolver(user),
           },
         },
         client,

--- a/__tests__/schema/uuid/abstract-repository.ts
+++ b/__tests__/schema/uuid/abstract-repository.ts
@@ -40,7 +40,7 @@ import {
   exerciseRevision,
   getRepositoryDataWithoutSubResolvers,
   getRevisionDataWithoutSubResolvers,
-  getUserDataWithoutSubResolver,
+  getUserDataWithoutSubResolvers,
   groupedExercise,
   groupedExerciseRevision,
   license,
@@ -180,44 +180,6 @@ describe('Repository', () => {
     })
   })
 
-  test.each(repositoryCases)('%s by alias', async (type, { repository }) => {
-    global.server.use(
-      createUuidHandler(repository),
-      createAliasHandler({
-        id: repository.id,
-        instance: repository.instance,
-        path: '/path',
-        source: `source`,
-        timestamp: 'timestamp',
-      })
-    )
-    await assertSuccessfulGraphQLQuery({
-      query: gql`
-        query repository($alias: AliasInput!) {
-          uuid(alias: $alias) {
-            __typename
-            ... on AbstractRepository {
-              id
-              trashed
-              alias
-              date
-            }
-          }
-        }
-      `,
-      variables: {
-        alias: {
-          instance: repository.instance,
-          path: '/path',
-        },
-      },
-      data: {
-        uuid: getRepositoryDataWithoutSubResolvers(repository),
-      },
-      client,
-    })
-  })
-
   test.each(repositoryCases)(
     '%s by alias (url-encoded)',
     async (type, { repository }) => {
@@ -227,7 +189,7 @@ describe('Repository', () => {
           id: repository.id,
           instance: repository.instance,
           path: '/ü',
-          source: `source`,
+          source: `/source`,
           timestamp: 'timestamp',
         })
       )
@@ -267,8 +229,8 @@ describe('Repository', () => {
         createAliasHandler({
           id: repository.id,
           instance: repository.instance,
-          path: 'path',
-          source: `source`,
+          path: '/path',
+          source: `/source`,
           timestamp: 'timestamp',
         })
       )
@@ -380,7 +342,7 @@ describe('Revision', () => {
         variables: revision,
         data: {
           uuid: {
-            author: getUserDataWithoutSubResolver(user),
+            author: getUserDataWithoutSubResolvers(user),
           },
         },
         client,

--- a/__tests__/schema/uuid/abstract-repository.ts
+++ b/__tests__/schema/uuid/abstract-repository.ts
@@ -40,6 +40,7 @@ import {
   exerciseRevision,
   getRepositoryDataWithoutSubResolvers,
   getRevisionDataWithoutSubResolvers,
+  getUserDataWithoutSubResolver,
   groupedExercise,
   groupedExerciseRevision,
   license,
@@ -279,6 +280,7 @@ describe('Revision', () => {
                   __typename
                   id
                   trashed
+                  alias
                   username
                   date
                   lastLogin
@@ -291,7 +293,7 @@ describe('Revision', () => {
         variables: revision,
         data: {
           uuid: {
-            author: user,
+            author: getUserDataWithoutSubResolver(user),
           },
         },
         client,

--- a/__tests__/schema/uuid/index.ts
+++ b/__tests__/schema/uuid/index.ts
@@ -117,7 +117,7 @@ describe('uuid', () => {
           }
         }
       `,
-      message: 'uuid: you need to provide an id or an alias',
+      message: 'you need to provide an id or an alias',
       client,
     })
   })

--- a/__tests__/schema/uuid/index.ts
+++ b/__tests__/schema/uuid/index.ts
@@ -123,4 +123,20 @@ describe('uuid', () => {
       client,
     })
   })
+
+  test('returns null when no arguments are given', async () => {
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query emptyUuidRequest {
+          uuid {
+            __typename
+          }
+        }
+      `,
+      data: {
+        uuid: null,
+      },
+      client,
+    })
+  })
 })

--- a/__tests__/schema/uuid/index.ts
+++ b/__tests__/schema/uuid/index.ts
@@ -117,6 +117,7 @@ describe('uuid', () => {
           }
         }
       `,
+      message: 'uuid: you need to provide an id or an alias',
       client,
     })
   })

--- a/__tests__/schema/uuid/index.ts
+++ b/__tests__/schema/uuid/index.ts
@@ -21,7 +21,7 @@
  */
 import { gql } from 'apollo-server'
 
-import { taxonomyTermRoot, article } from '../../../__fixtures__'
+import { taxonomyTermRoot } from '../../../__fixtures__'
 import { Service } from '../../../src/graphql/schema/types'
 import {
   assertSuccessfulGraphQLQuery,
@@ -41,45 +41,6 @@ beforeEach(() => {
 })
 
 describe('uuid', () => {
-  describe('returns alias encoded', () => {
-    test('TaxonomyTerm', async () => {
-      await doTestWithUuid(taxonomyTermRoot)
-    })
-
-    test('AbstractRepository', async () => {
-      await doTestWithUuid(article)
-    })
-
-    // TODO: I need to fix the type of uuid here
-    async function doTestWithUuid(
-      uuid: typeof article | typeof taxonomyTermRoot
-    ) {
-      global.server.use(createUuidHandler({ ...uuid, alias: '/ü/ä' }))
-
-      await assertSuccessfulGraphQLQuery({
-        query: gql`
-          query getAliasOf($id: Int!) {
-            uuid(id: $id) {
-              ... on AbstractRepository {
-                alias
-              }
-              ... on TaxonomyTerm {
-                alias
-              }
-            }
-          }
-        `,
-        variables: { id: uuid.id },
-        data: {
-          uuid: {
-            alias: '/%C3%BC/%C3%A4',
-          },
-        },
-        client,
-      })
-    }
-  })
-
   test('can handle decoded alias with percent signs', async () => {
     global.server.use(
       createUuidHandler({ ...taxonomyTermRoot, alias: '/math/%%x%%' })

--- a/__tests__/schema/uuid/index.ts
+++ b/__tests__/schema/uuid/index.ts
@@ -24,6 +24,7 @@ import { gql } from 'apollo-server'
 import { taxonomyTermRoot } from '../../../__fixtures__'
 import { Service } from '../../../src/graphql/schema/types'
 import {
+  assertFailingGraphQLQuery,
   assertSuccessfulGraphQLQuery,
   Client,
   createTestClient,
@@ -107,8 +108,8 @@ describe('uuid', () => {
     })
   })
 
-  test('returns null when no arguments are given', async () => {
-    await assertSuccessfulGraphQLQuery({
+  test('returns an error when no arguments are given', async () => {
+    await assertFailingGraphQLQuery({
       query: gql`
         query emptyUuidRequest {
           uuid {
@@ -116,9 +117,6 @@ describe('uuid', () => {
           }
         }
       `,
-      data: {
-        uuid: null,
-      },
       client,
     })
   })

--- a/__tests__/schema/uuid/index.ts
+++ b/__tests__/schema/uuid/index.ts
@@ -66,6 +66,28 @@ describe('uuid', () => {
     })
   })
 
+  test('returns null when alias cannot be found', async () => {
+    global.server.use(
+      createJsonHandler({
+        path: '/api/alias/not-existing',
+        body: null,
+      })
+    )
+
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query notExistingUuid($alias: AliasInput) {
+          uuid(alias: $alias) {
+            __typename
+          }
+        }
+      `,
+      variables: { alias: { instance: 'de', path: '/not-existing' } },
+      data: { uuid: null },
+      client,
+    })
+  })
+
   test('returns null when uuid does not exist', async () => {
     global.server.use(createJsonHandler({ path: '/api/uuid/666', body: null }))
 

--- a/__tests__/schema/uuid/taxonomy-term.ts
+++ b/__tests__/schema/uuid/taxonomy-term.ts
@@ -525,3 +525,26 @@ describe('TaxonomyTerm curriculumTopic', () => {
     })
   })
 })
+
+test('alias property is encoded', async () => {
+  global.server.use(createUuidHandler({ ...taxonomyTermRoot, alias: '/ü/ä' }))
+
+  await assertSuccessfulGraphQLQuery({
+    query: gql`
+      query taxonomyAlias($id: Int!) {
+        uuid(id: $id) {
+          ... on TaxonomyTerm {
+            alias
+          }
+        }
+      }
+    `,
+    variables: { id: taxonomyTermRoot.id },
+    data: {
+      uuid: {
+        alias: '/%C3%BC/%C3%A4',
+      },
+    },
+    client,
+  })
+})

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -25,7 +25,7 @@ import { rest } from 'msw'
 
 import {
   article,
-  getUserDataWithoutSubResolver,
+  getUserDataWithoutSubResolvers,
   user,
   user2,
 } from '../../../__fixtures__'
@@ -79,7 +79,7 @@ describe('User', () => {
         },
       },
       data: {
-        uuid: getUserDataWithoutSubResolver(user),
+        uuid: getUserDataWithoutSubResolvers(user),
       },
       client,
     })
@@ -159,7 +159,7 @@ describe('User', () => {
         },
       },
       data: {
-        uuid: getUserDataWithoutSubResolver(user),
+        uuid: getUserDataWithoutSubResolvers(user),
       },
       client,
     })
@@ -185,7 +185,7 @@ describe('User', () => {
       `,
       variables: user,
       data: {
-        uuid: getUserDataWithoutSubResolver(user),
+        uuid: getUserDataWithoutSubResolvers(user),
       },
       client,
     })
@@ -357,8 +357,8 @@ describe('endpoint activeAuthors', () => {
       data: {
         activeAuthors: {
           nodes: [
-            getUserDataWithoutSubResolver(user),
-            getUserDataWithoutSubResolver(user2),
+            getUserDataWithoutSubResolvers(user),
+            getUserDataWithoutSubResolvers(user2),
           ],
           totalCount: 2,
         },
@@ -377,7 +377,7 @@ describe('endpoint activeAuthors', () => {
       query: activeAuthorsQuery,
       data: {
         activeAuthors: {
-          nodes: [getUserDataWithoutSubResolver(user)],
+          nodes: [getUserDataWithoutSubResolvers(user)],
           totalCount: 1,
         },
       },
@@ -392,7 +392,7 @@ describe('endpoint activeAuthors', () => {
       query: activeAuthorsQuery,
       data: {
         activeAuthors: {
-          nodes: [getUserDataWithoutSubResolver(user)],
+          nodes: [getUserDataWithoutSubResolvers(user)],
           totalCount: 1,
         },
       },
@@ -414,7 +414,7 @@ describe('endpoint activeAuthors', () => {
       query: activeAuthorsQuery,
       data: {
         activeAuthors: {
-          nodes: [getUserDataWithoutSubResolver(user)],
+          nodes: [getUserDataWithoutSubResolvers(user)],
           totalCount: 1,
         },
       },
@@ -452,8 +452,8 @@ describe('endpoint activeDonors', () => {
       data: {
         activeDonors: {
           nodes: [
-            getUserDataWithoutSubResolver(user),
-            getUserDataWithoutSubResolver(user2),
+            getUserDataWithoutSubResolvers(user),
+            getUserDataWithoutSubResolvers(user2),
           ],
           totalCount: 2,
         },
@@ -471,7 +471,7 @@ describe('endpoint activeDonors', () => {
       query: activeDonorsQuery,
       data: {
         activeDonors: {
-          nodes: [getUserDataWithoutSubResolver(user)],
+          nodes: [getUserDataWithoutSubResolvers(user)],
           totalCount: 1,
         },
       },
@@ -590,8 +590,8 @@ describe('endpoint activeReviewers', () => {
       data: {
         activeReviewers: {
           nodes: [
-            getUserDataWithoutSubResolver(user),
-            getUserDataWithoutSubResolver(user2),
+            getUserDataWithoutSubResolvers(user),
+            getUserDataWithoutSubResolvers(user2),
           ],
           totalCount: 2,
         },
@@ -610,7 +610,7 @@ describe('endpoint activeReviewers', () => {
       query: activeReviewersQuery,
       data: {
         activeReviewers: {
-          nodes: [getUserDataWithoutSubResolver(user)],
+          nodes: [getUserDataWithoutSubResolvers(user)],
           totalCount: 1,
         },
       },
@@ -625,7 +625,7 @@ describe('endpoint activeReviewers', () => {
       query: activeReviewersQuery,
       data: {
         activeReviewers: {
-          nodes: [getUserDataWithoutSubResolver(user)],
+          nodes: [getUserDataWithoutSubResolvers(user)],
           totalCount: 1,
         },
       },
@@ -647,7 +647,7 @@ describe('endpoint activeReviewers', () => {
       query: activeReviewersQuery,
       data: {
         activeReviewers: {
-          nodes: [getUserDataWithoutSubResolver(user)],
+          nodes: [getUserDataWithoutSubResolvers(user)],
           totalCount: 1,
         },
       },

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -85,6 +85,55 @@ describe('User', () => {
     })
   })
 
+  test('by alias /user/profile/:id returns null when user does not exist', async () => {
+    global.server.use(
+      createJsonHandler({
+        path: `/api/uuid/${user.id}`,
+        body: null,
+      })
+    )
+
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query user($alias: AliasInput!) {
+          uuid(alias: $alias) {
+            __typename
+          }
+        }
+      `,
+      variables: {
+        alias: {
+          instance: Instance.De,
+          path: `/user/profile/${user.id}`,
+        },
+      },
+      data: { uuid: null },
+      client,
+    })
+  })
+
+  test('by alias /user/profile/:id returns null when uuid :id is no user', async () => {
+    global.server.use(createUuidHandler(article))
+
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query user($alias: AliasInput!) {
+          uuid(alias: $alias) {
+            __typename
+          }
+        }
+      `,
+      variables: {
+        alias: {
+          instance: Instance.De,
+          path: `/user/profile/${article.id}`,
+        },
+      },
+      data: { uuid: null },
+      client,
+    })
+  })
+
   test('by alias (/:id)', async () => {
     await assertSuccessfulGraphQLQuery({
       query: gql`

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -142,6 +142,27 @@ describe('User', () => {
     })
   })
 
+  test('alias property is encoded', async () => {
+    global.server.use(createUuidHandler({ ...user, username: 'Günther' }))
+
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query userAlias($id: Int!) {
+          uuid(id: $id) {
+            ... on User {
+              alias
+            }
+          }
+        }
+      `,
+      variables: { id: user.id },
+      data: {
+        uuid: { alias: '/user/profile/G%C3%BCnther' },
+      },
+      client,
+    })
+  })
+
   describe('property "activeAuthor"', () => {
     const query = gql`
       query propertyActiveAuthor($id: Int!) {

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -85,6 +85,37 @@ describe('User', () => {
     })
   })
 
+  test('by alias (/:id)', async () => {
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query user($alias: AliasInput!) {
+          uuid(alias: $alias) {
+            __typename
+            ... on User {
+              id
+              trashed
+              alias
+              username
+              date
+              lastLogin
+              description
+            }
+          }
+        }
+      `,
+      variables: {
+        alias: {
+          instance: Instance.De,
+          path: `/${user.id}`,
+        },
+      },
+      data: {
+        uuid: getUserDataWithoutSubResolver(user),
+      },
+      client,
+    })
+  })
+
   test('by id', async () => {
     await assertSuccessfulGraphQLQuery({
       query: gql`

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -32,6 +32,7 @@ import {
 import { Cache } from '../../../src/graphql/environment'
 import { Service } from '../../../src/graphql/schema/types'
 import { UuidPayload } from '../../../src/graphql/schema/uuid/abstract-uuid'
+import { Instance } from '../../../src/types'
 import {
   assertSuccessfulGraphQLQuery,
   Client,
@@ -53,10 +54,41 @@ beforeEach(() => {
 })
 
 describe('User', () => {
+  test('by alias (/user/profile/:id)', async () => {
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query user($alias: AliasInput!) {
+          uuid(alias: $alias) {
+            __typename
+            ... on User {
+              id
+              trashed
+              alias
+              username
+              date
+              lastLogin
+              description
+            }
+          }
+        }
+      `,
+      variables: {
+        alias: {
+          instance: Instance.De,
+          path: `/user/profile/${user.id}`,
+        },
+      },
+      data: {
+        uuid: getUserDataWithoutSubResolver(user),
+      },
+      client,
+    })
+  })
+
   test('by id', async () => {
     await assertSuccessfulGraphQLQuery({
       query: gql`
-        query article($id: Int!) {
+        query user($id: Int!) {
           uuid(id: $id) {
             __typename
             ... on User {

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -23,7 +23,12 @@ import { gql } from 'apollo-server'
 import { option as O } from 'fp-ts'
 import { rest } from 'msw'
 
-import { article, user, user2 } from '../../../__fixtures__'
+import {
+  article,
+  getUserDataWithoutSubResolver,
+  user,
+  user2,
+} from '../../../__fixtures__'
 import { Cache } from '../../../src/graphql/environment'
 import { Service } from '../../../src/graphql/schema/types'
 import { UuidPayload } from '../../../src/graphql/schema/uuid/abstract-uuid'
@@ -57,6 +62,7 @@ describe('User', () => {
             ... on User {
               id
               trashed
+              alias
               username
               date
               lastLogin
@@ -67,7 +73,7 @@ describe('User', () => {
       `,
       variables: user,
       data: {
-        uuid: user,
+        uuid: getUserDataWithoutSubResolver(user),
       },
       client,
     })
@@ -196,6 +202,7 @@ describe('endpoint activeAuthors', () => {
           __typename
           id
           trashed
+          alias
           username
           date
           lastLogin
@@ -215,7 +222,13 @@ describe('endpoint activeAuthors', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeAuthorsQuery,
       data: {
-        activeAuthors: { nodes: [user, user2], totalCount: 2 },
+        activeAuthors: {
+          nodes: [
+            getUserDataWithoutSubResolver(user),
+            getUserDataWithoutSubResolver(user2),
+          ],
+          totalCount: 2,
+        },
       },
       client,
     })
@@ -230,7 +243,10 @@ describe('endpoint activeAuthors', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeAuthorsQuery,
       data: {
-        activeAuthors: { nodes: [user], totalCount: 1 },
+        activeAuthors: {
+          nodes: [getUserDataWithoutSubResolver(user)],
+          totalCount: 1,
+        },
       },
       client,
     })
@@ -242,7 +258,10 @@ describe('endpoint activeAuthors', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeAuthorsQuery,
       data: {
-        activeAuthors: { nodes: [user], totalCount: 1 },
+        activeAuthors: {
+          nodes: [getUserDataWithoutSubResolver(user)],
+          totalCount: 1,
+        },
       },
       client,
     })
@@ -261,7 +280,10 @@ describe('endpoint activeAuthors', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeAuthorsQuery,
       data: {
-        activeAuthors: { nodes: [user], totalCount: 1 },
+        activeAuthors: {
+          nodes: [getUserDataWithoutSubResolver(user)],
+          totalCount: 1,
+        },
       },
       client,
     })
@@ -276,6 +298,7 @@ describe('endpoint activeDonors', () => {
           __typename
           id
           trashed
+          alias
           username
           date
           lastLogin
@@ -294,7 +317,13 @@ describe('endpoint activeDonors', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeDonorsQuery,
       data: {
-        activeDonors: { nodes: [user, user2], totalCount: 2 },
+        activeDonors: {
+          nodes: [
+            getUserDataWithoutSubResolver(user),
+            getUserDataWithoutSubResolver(user2),
+          ],
+          totalCount: 2,
+        },
       },
       client,
     })
@@ -308,7 +337,10 @@ describe('endpoint activeDonors', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeDonorsQuery,
       data: {
-        activeDonors: { nodes: [user], totalCount: 1 },
+        activeDonors: {
+          nodes: [getUserDataWithoutSubResolver(user)],
+          totalCount: 1,
+        },
       },
       client,
     })
@@ -403,6 +435,7 @@ describe('endpoint activeReviewers', () => {
           __typename
           id
           trashed
+          alias
           username
           date
           lastLogin
@@ -422,7 +455,13 @@ describe('endpoint activeReviewers', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeReviewersQuery,
       data: {
-        activeReviewers: { nodes: [user, user2], totalCount: 2 },
+        activeReviewers: {
+          nodes: [
+            getUserDataWithoutSubResolver(user),
+            getUserDataWithoutSubResolver(user2),
+          ],
+          totalCount: 2,
+        },
       },
       client,
     })
@@ -437,7 +476,10 @@ describe('endpoint activeReviewers', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeReviewersQuery,
       data: {
-        activeReviewers: { nodes: [user], totalCount: 1 },
+        activeReviewers: {
+          nodes: [getUserDataWithoutSubResolver(user)],
+          totalCount: 1,
+        },
       },
       client,
     })
@@ -449,7 +491,10 @@ describe('endpoint activeReviewers', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeReviewersQuery,
       data: {
-        activeReviewers: { nodes: [user], totalCount: 1 },
+        activeReviewers: {
+          nodes: [getUserDataWithoutSubResolver(user)],
+          totalCount: 1,
+        },
       },
       client,
     })
@@ -468,7 +513,10 @@ describe('endpoint activeReviewers', () => {
     await assertSuccessfulGraphQLQuery({
       query: activeReviewersQuery,
       data: {
-        activeReviewers: { nodes: [user], totalCount: 1 },
+        activeReviewers: {
+          nodes: [getUserDataWithoutSubResolver(user)],
+          totalCount: 1,
+        },
       },
       client,
     })

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -935,6 +935,7 @@ export type User = AbstractUuid & {
     __typename?: 'User';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
+    alias: Scalars['String'];
     username: Scalars['String'];
     date: Scalars['DateTime'];
     lastLogin?: Maybe<Scalars['DateTime']>;

--- a/src/graphql/schema/uuid/abstract-repository/types.ts
+++ b/src/graphql/schema/uuid/abstract-repository/types.ts
@@ -32,6 +32,7 @@ import {
   EntityType,
 } from '../abstract-entity'
 import { DiscriminatorType } from '../abstract-uuid'
+import { AliasResolvers } from '../alias'
 import { PagePayload, PageRevisionPayload } from '../page'
 import { UserPayload } from '../user'
 
@@ -68,8 +69,7 @@ export interface AbstractRepositoryResolvers {
 export interface RepositoryResolvers<
   E extends AbstractRepositoryPayload,
   R extends AbstractRevisionPayload
-> {
-  alias: Resolver<E, never, string | null>
+> extends AliasResolvers<E> {
   currentRevision: Resolver<E, never, R | null>
   license: Resolver<E, never, Partial<License>>
 }

--- a/src/graphql/schema/uuid/abstract-repository/utils.ts
+++ b/src/graphql/schema/uuid/abstract-repository/utils.ts
@@ -20,7 +20,7 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { requestsOnlyFields } from '../../utils'
-import { decodePath } from '../alias'
+import { createAliasResolvers } from '../alias'
 import { resolveUser } from '../user'
 import {
   AbstractRepositoryPayload,
@@ -34,11 +34,7 @@ export function createRepositoryResolvers<
   R extends AbstractRevisionPayload
 >(): RepositoryResolvers<E, R> {
   return {
-    alias(repository) {
-      return Promise.resolve(
-        repository.alias ? decodePath(repository.alias) : null
-      )
-    },
+    ...createAliasResolvers<E>(),
     async currentRevision(entity, _args, { dataSources }) {
       if (!entity.currentRevisionId) return null
       return dataSources.serlo.getUuid<R>({ id: entity.currentRevisionId })

--- a/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
@@ -55,7 +55,7 @@ export const resolvers: UuidResolvers = {
       } else if (payload.id) {
         return dataSources.serlo.getUuid<UuidPayload>({ id: payload.id })
       } else {
-        throw new UserInputError('uuid: you need to provide an id or an alias')
+        throw new UserInputError('you need to provide an id or an alias')
       }
     },
   },

--- a/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
@@ -50,11 +50,11 @@ export const resolvers: UuidResolvers = {
         return alias
           ? dataSources.serlo.getUuid<UuidPayload>({ id: alias.id })
           : null
+      } else if (payload.id) {
+        return dataSources.serlo.getUuid<UuidPayload>({ id: payload.id })
+      } else {
+        return null
       }
-
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const id = payload.id!
-      return dataSources.serlo.getUuid<UuidPayload>({ id })
     },
   },
 }

--- a/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
@@ -55,7 +55,7 @@ export const resolvers: UuidResolvers = {
       } else if (payload.id) {
         return dataSources.serlo.getUuid<UuidPayload>({ id: payload.id })
       } else {
-        throw new UserInputError('You need to provide an id or an alias')
+        throw new UserInputError('uuid: you need to provide an id or an alias')
       }
     },
   },

--- a/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
@@ -19,6 +19,8 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
+import { UserInputError } from 'apollo-server'
+
 import { decodePath, UuidPayload } from '..'
 import { UuidResolvers } from './types'
 
@@ -53,7 +55,7 @@ export const resolvers: UuidResolvers = {
       } else if (payload.id) {
         return dataSources.serlo.getUuid<UuidPayload>({ id: payload.id })
       } else {
-        return null
+        throw new UserInputError('You need to provide an id or an alias')
       }
     },
   },

--- a/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
@@ -20,8 +20,6 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { decodePath, UuidPayload } from '..'
-import { QueryUuidArgs } from '../../../../types'
-import { Context } from '../../types'
 import { UuidResolvers } from './types'
 
 export const resolvers: UuidResolvers = {
@@ -32,28 +30,31 @@ export const resolvers: UuidResolvers = {
   },
   Query: {
     async uuid(_parent, payload, { dataSources }) {
-      const id = payload.alias
-        ? await getIdFromAlias(payload, dataSources)
-        : (payload.id as number)
+      if (payload.alias) {
+        const cleanPath = decodePath(payload.alias.path)
+        const match = /^\/(\d+)$/.exec(cleanPath)
+        if (match) {
+          const id = parseInt(match[1], 10)
+          return dataSources.serlo.getUuid<UuidPayload>({ id })
+        }
+
+        if (cleanPath.startsWith('/user/profile/')) {
+          const match = /^\/user\/profile\/(\d+)$/.exec(cleanPath)
+          if (match) {
+            const id = parseInt(match[1], 10)
+            const uuid = await dataSources.serlo.getUuid<UuidPayload>({ id })
+            return uuid && uuid.__typename === 'User' ? uuid : null
+          }
+        }
+        const alias = await dataSources.serlo.getAlias(payload.alias)
+        return alias
+          ? dataSources.serlo.getUuid<UuidPayload>({ id: alias.id })
+          : null
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const id = payload.id!
       return dataSources.serlo.getUuid<UuidPayload>({ id })
     },
   },
-}
-
-async function getIdFromAlias(
-  payload: QueryUuidArgs,
-  dataSources: Context['dataSources']
-): Promise<number> {
-  if (payload.alias) {
-    const cleanPath = decodePath(payload.alias.path)
-    if (cleanPath.startsWith('/user/profile/')) {
-      const match = /^\/user\/profile\/(\d+)$/.exec(cleanPath)
-      if (match) {
-        return parseInt(match[1], 10)
-      }
-    }
-    return (await dataSources.serlo.getAlias(payload.alias)).id
-  }
-
-  return payload.id as number
 }

--- a/src/graphql/schema/uuid/alias/types.ts
+++ b/src/graphql/schema/uuid/alias/types.ts
@@ -20,6 +20,7 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { Instance, Scalars } from '../../../../types'
+import { Resolver } from '../../types'
 
 export interface AliasPayload {
   id: number
@@ -27,4 +28,8 @@ export interface AliasPayload {
   path: string
   source: string
   timestamp: Scalars['DateTime']
+}
+
+export interface AliasResolvers<T extends { alias: string | null }> {
+  alias: Resolver<T, never, string | null>
 }

--- a/src/graphql/schema/uuid/alias/utils.ts
+++ b/src/graphql/schema/uuid/alias/utils.ts
@@ -1,3 +1,5 @@
+import { AliasResolvers } from './types'
+
 /**
  * This file is part of Serlo.org API
  *
@@ -25,4 +27,14 @@ export function decodePath(path: string) {
 
 export function encodePath(path: string) {
   return encodeURIComponent(path).replace(/%2F/g, '/')
+}
+
+export function createAliasResolvers<
+  T extends { alias: string | null }
+>(): AliasResolvers<T> {
+  return {
+    alias(entity) {
+      return Promise.resolve(entity.alias ? encodePath(entity.alias) : null)
+    },
+  }
 }

--- a/src/graphql/schema/uuid/taxonomy-term/resolvers.ts
+++ b/src/graphql/schema/uuid/taxonomy-term/resolvers.ts
@@ -19,18 +19,15 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { decodePath, UuidPayload } from '..'
 import { resolveConnection } from '../../connection'
 import { Context } from '../../types'
+import { UuidPayload } from '../abstract-uuid'
+import { createAliasResolvers } from '../alias'
 import { TaxonomyTermPayload, TaxonomyTermResolvers } from './types'
 
 export const resolvers: TaxonomyTermResolvers = {
   TaxonomyTerm: {
-    alias(taxonomyTerm) {
-      return Promise.resolve(
-        taxonomyTerm.alias ? decodePath(taxonomyTerm.alias) : null
-      )
-    },
+    ...createAliasResolvers<TaxonomyTermPayload>(),
     async parent(taxonomyTerm, _args, { dataSources }) {
       if (!taxonomyTerm.parentId) return null
       return dataSources.serlo.getUuid<TaxonomyTermPayload>({

--- a/src/graphql/schema/uuid/taxonomy-term/types.ts
+++ b/src/graphql/schema/uuid/taxonomy-term/types.ts
@@ -24,6 +24,7 @@ import { Connection } from '../../connection'
 import { Resolver } from '../../types'
 import { NavigationChildResolvers } from '../abstract-navigation-child'
 import { AbstractUuidPayload, DiscriminatorType } from '../abstract-uuid'
+import { AliasResolvers } from '../alias'
 
 export interface TaxonomyTermPayload
   extends Omit<TaxonomyTerm, keyof TaxonomyTermResolvers['TaxonomyTerm']> {
@@ -35,12 +36,12 @@ export interface TaxonomyTermPayload
 
 export interface TaxonomyTermResolvers {
   TaxonomyTerm: {
-    alias: Resolver<TaxonomyTermPayload, never, string | null>
     parent: Resolver<TaxonomyTermPayload, never, TaxonomyTermPayload | null>
     children: Resolver<
       TaxonomyTermPayload,
       TaxonomyTermChildrenArgs,
       Connection<AbstractUuidPayload>
     >
-  } & NavigationChildResolvers<TaxonomyTermPayload>
+  } & AliasResolvers<TaxonomyTermPayload> &
+    NavigationChildResolvers<TaxonomyTermPayload>
 }

--- a/src/graphql/schema/uuid/user/resolvers.ts
+++ b/src/graphql/schema/uuid/user/resolvers.ts
@@ -21,7 +21,7 @@
  */
 import { pipeable, either } from 'fp-ts'
 
-import { AbstractUuidPayload, UserPayload } from '..'
+import { AbstractUuidPayload, encodePath, UserPayload } from '..'
 import { ErrorEvent } from '../../../../error-event'
 import {
   MajorDimension,
@@ -57,6 +57,9 @@ export const resolvers: UserResolvers = {
     },
   },
   User: {
+    alias(user) {
+      return Promise.resolve(encodePath(`/user/profile/${user.username}`))
+    },
     async activeAuthor(user, _args, { dataSources }) {
       return (await dataSources.serlo.getActiveAuthorIds()).includes(user.id)
     },

--- a/src/graphql/schema/uuid/user/types.graphql
+++ b/src/graphql/schema/uuid/user/types.graphql
@@ -1,6 +1,7 @@
 type User implements AbstractUuid {
   id: Int!
   trashed: Boolean!
+  alias: String!
   username: String!
   date: DateTime!
   lastLogin: DateTime

--- a/src/graphql/schema/uuid/user/types.ts
+++ b/src/graphql/schema/uuid/user/types.ts
@@ -47,6 +47,7 @@ export interface UserResolvers {
     >
   }
   User: {
+    alias: Resolver<UserPayload, never, string>
     activeAuthor: Resolver<UserPayload, never, boolean>
     activeDonor: Resolver<UserPayload, never, boolean>
     activeReviewer: Resolver<UserPayload, never, boolean>

--- a/src/types.ts
+++ b/src/types.ts
@@ -837,6 +837,7 @@ export type User = AbstractUuid & {
   __typename?: 'User';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
+  alias: Scalars['String'];
   username: Scalars['String'];
   date: Scalars['DateTime'];
   lastLogin?: Maybe<Scalars['DateTime']>;


### PR DESCRIPTION
Fixes #67 
Fixes #68

Task "`uuid` should be abe to resolve `/user/profile/:username` to the specific user (might need a mapping from username to id)." is implemented by https://github.com/serlo/serlo.org/pull/502 by adding support for `/user/profile/:username` in the alias endpoint.

- [x] `uuid` without arguments shall be an error