### PR TITLE
Events

### DIFF
--- a/__fixtures__/notification.ts
+++ b/__fixtures__/notification.ts
@@ -39,6 +39,7 @@ import {
   SetTaxonomyTermNotificationEventPayload,
   SetThreadStateNotificationEventPayload,
   SetUuidStateNotificationEventPayload,
+  NotificationEventPayload,
 } from '../src/graphql/schema'
 import { Instance } from '../src/types'
 import {
@@ -53,6 +54,12 @@ import {
   thread,
   user,
 } from './uuid'
+
+export function getAbstractNotificationEventDataWithoutSubResolvers(
+  event: NotificationEventPayload
+) {
+  return R.pick(['__typename', 'id', 'date', 'instance'], event)
+}
 
 export const checkoutRevisionNotificationEvent: CheckoutRevisionNotificationEventPayload = {
   __typename: NotificationEventType.CheckoutRevision,

--- a/__tests-pacts__/__utils__/interactions.ts
+++ b/__tests-pacts__/__utils__/interactions.ts
@@ -19,7 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { Matchers } from '@pact-foundation/pact'
+import { Matchers, Query } from '@pact-foundation/pact'
 
 import { NavigationPayload, UuidPayload } from '../../src/graphql/schema'
 
@@ -57,10 +57,12 @@ export function addJsonInteraction({
   given,
   path,
   body,
+  query,
 }: {
   name: string
   given: string
   path: string
+  query?: Query
   body: unknown
 }) {
   return global.pact.addInteraction({
@@ -69,6 +71,7 @@ export function addJsonInteraction({
     withRequest: {
       method: 'GET',
       path,
+      query,
     },
     willRespondWith: {
       status: 200,

--- a/__tests-pacts__/serlo.org/event.ts
+++ b/__tests-pacts__/serlo.org/event.ts
@@ -21,8 +21,6 @@
  */
 import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
-import fetch from 'node-fetch'
-import * as R from 'ramda'
 
 import {
   checkoutRevisionNotificationEvent,
@@ -601,88 +599,4 @@ test('SetUuidStateNotificationEvent', async () => {
       ),
     },
   })
-})
-
-describe('/api/events', () => {
-  test('without a query string', async () => {
-    await addEventsInteraction({ name: 'fetch all event ids' })
-  })
-
-  test('with after', async () => {
-    await addEventsInteraction({
-      name: 'fetch first 10 event ids after event with id 100',
-      query: { after: '10' },
-    })
-  })
-
-  test('with first', async () => {
-    await addEventsInteraction({
-      name: 'fetch first 10 event',
-      query: { first: '10' },
-    })
-  })
-
-  test('with before', async () => {
-    await addEventsInteraction({
-      name: 'fetch before event with id 100',
-      query: { before: '100' },
-    })
-  })
-
-  test('with last', async () => {
-    await addEventsInteraction({
-      name: 'fetch last 10 event ids',
-      query: { last: '10' },
-    })
-  })
-
-  test('with userId', async () => {
-    await addEventsInteraction({
-      name: 'fetch all events of user with id 10',
-      query: { useId: '10' },
-    })
-  })
-
-  test('with entityId', async () => {
-    await addEventsInteraction({
-      name: 'fetch all events of entity with id 10',
-      query: { entityId: '10' },
-    })
-  })
-
-  async function addEventsInteraction({
-    name,
-    query,
-  }: {
-    name: string
-    query?: Record<string, string>
-  }) {
-    await addJsonInteraction({
-      name,
-      given: 'there is one matching event',
-      path: '/api/events',
-      query,
-      body: {
-        eventIds: Matchers.eachLike(1),
-        totalCount: Matchers.integer(1),
-        pageInfo: {
-          hasNextPage: Matchers.boolean(false),
-          hasPreviousPage: Matchers.boolean(false),
-          startCursor: Matchers.integer(1),
-          endCursor: Matchers.integer(1),
-        },
-      },
-    })
-
-    const queryString = query
-      ? '?' +
-        R.toPairs(query)
-          .map(([key, value]) => `${key}=${value}`)
-          .join('&')
-      : ''
-
-    await fetch(
-      `http://de.${process.env.SERLO_ORG_HOST}/api/events${queryString}`
-    )
-  }
 })

--- a/__tests-pacts__/serlo.org/event.ts
+++ b/__tests-pacts__/serlo.org/event.ts
@@ -621,6 +621,20 @@ describe('/api/events', () => {
     })
   })
 
+  test('with userId', async () => {
+    await addEventsInteraction({
+      name: 'fetch all events of user with id 10',
+      query: { useId: Matchers.integer(10) },
+    })
+  })
+
+  test('with entityId', async () => {
+    await addEventsInteraction({
+      name: 'fetch all events of entity with id 10',
+      query: { entityId: Matchers.integer(10) },
+    })
+  })
+
   afterEach(async () => {
     await fetch(`http://de.${process.env.SERLO_ORG_HOST}/api/events`)
   })

--- a/__tests-pacts__/serlo.org/event.ts
+++ b/__tests-pacts__/serlo.org/event.ts
@@ -19,9 +19,10 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { Matchers, Query } from '@pact-foundation/pact'
+import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
 import fetch from 'node-fetch'
+import * as R from 'ramda'
 
 import {
   checkoutRevisionNotificationEvent,
@@ -607,36 +608,46 @@ describe('/api/events', () => {
     await addEventsInteraction({ name: 'fetch all event ids' })
   })
 
-  test('with after and first', async () => {
+  test('with after', async () => {
     await addEventsInteraction({
       name: 'fetch first 10 event ids after event with id 100',
-      query: { after: Matchers.integer(100), first: Matchers.integer(10) },
+      query: { after: '10' },
     })
   })
 
-  test('with before and last', async () => {
+  test('with first', async () => {
     await addEventsInteraction({
-      name: 'fetch last 10 event ids before event with id 100',
-      query: { before: Matchers.integer(100), last: Matchers.integer(10) },
+      name: 'fetch first 10 event',
+      query: { first: '10' },
+    })
+  })
+
+  test('with before', async () => {
+    await addEventsInteraction({
+      name: 'fetch before event with id 100',
+      query: { before: '100' },
+    })
+  })
+
+  test('with last', async () => {
+    await addEventsInteraction({
+      name: 'fetch last 10 event ids',
+      query: { last: '10' },
     })
   })
 
   test('with userId', async () => {
     await addEventsInteraction({
       name: 'fetch all events of user with id 10',
-      query: { useId: Matchers.integer(10) },
+      query: { useId: '10' },
     })
   })
 
   test('with entityId', async () => {
     await addEventsInteraction({
       name: 'fetch all events of entity with id 10',
-      query: { entityId: Matchers.integer(10) },
+      query: { entityId: '10' },
     })
-  })
-
-  afterEach(async () => {
-    await fetch(`http://de.${process.env.SERLO_ORG_HOST}/api/events`)
   })
 
   async function addEventsInteraction({
@@ -644,7 +655,7 @@ describe('/api/events', () => {
     query,
   }: {
     name: string
-    query?: Query
+    query?: Record<string, string>
   }) {
     await addJsonInteraction({
       name,
@@ -662,5 +673,16 @@ describe('/api/events', () => {
         },
       },
     })
+
+    const queryString = query
+      ? '?' +
+        R.toPairs(query)
+          .map(([key, value]) => `${key}=${value}`)
+          .join('&')
+      : ''
+
+    await fetch(
+      `http://de.${process.env.SERLO_ORG_HOST}/api/events${queryString}`
+    )
   }
 })

--- a/__tests-pacts__/serlo.org/event.ts
+++ b/__tests-pacts__/serlo.org/event.ts
@@ -21,6 +21,7 @@
  */
 import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
+import fetch from 'node-fetch'
 
 import {
   checkoutRevisionNotificationEvent,
@@ -599,4 +600,16 @@ test('SetUuidStateNotificationEvent', async () => {
       ),
     },
   })
+})
+
+test('/api/current-event-id', async () => {
+  await addJsonInteraction({
+    name: 'fetch current event id',
+    given: 'current event id is 100',
+    path: '/api/current-event-id',
+    body: {
+      currentEventId: Matchers.integer(100),
+    },
+  })
+  await fetch(`http://de.${process.env.SERLO_ORG_HOST}/api/current-event-id`)
 })

--- a/__tests-pacts__/serlo.org/event.ts
+++ b/__tests-pacts__/serlo.org/event.ts
@@ -639,6 +639,13 @@ describe('/api/events', async () => {
       query,
       body: {
         eventIds: Matchers.eachLike(1),
+        totalCount: Matchers.integer(1),
+        pageInfo: {
+          hasNextPage: Matchers.boolean(false),
+          hasPreviousPage: Matchers.boolean(false),
+          startCursor: Matchers.integer(1),
+          endCursor: Matchers.integer(1),
+        },
       },
     })
   }

--- a/__tests-pacts__/serlo.org/event.ts
+++ b/__tests-pacts__/serlo.org/event.ts
@@ -602,7 +602,7 @@ test('SetUuidStateNotificationEvent', async () => {
   })
 })
 
-describe('/api/events', async () => {
+describe('/api/events', () => {
   test('without a query string', async () => {
     await addEventsInteraction({ name: 'fetch all event ids' })
   })

--- a/__tests-pacts__/serlo.org/events.ts
+++ b/__tests-pacts__/serlo.org/events.ts
@@ -28,7 +28,7 @@ test('without a query string', async () => {
   await addEventsInteraction({ name: 'fetch all event ids' })
 })
 
-test.each(['after', 'before', 'first', 'last', 'userId', 'entityId'])(
+test.each(['after', 'before', 'first', 'last', 'userId', 'uuid'])(
   'query parameter = %s',
   async (parameter) => {
     await addEventsInteraction({

--- a/__tests-pacts__/serlo.org/events.ts
+++ b/__tests-pacts__/serlo.org/events.ts
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { Matchers } from '@pact-foundation/pact'
+import fetch from 'node-fetch'
+
+import { addJsonInteraction } from '../__utils__'
+
+test('without a query string', async () => {
+  await addEventsInteraction({ name: 'fetch all event ids' })
+})
+
+test.each(['after', 'before', 'first', 'last', 'userId', 'entityId'])(
+  'query parameter = %s',
+  async (parameter) => {
+    await addEventsInteraction({
+      name: `fetch all events with filter "${parameter}"`,
+      queryString: `${parameter}=10`,
+    })
+  }
+)
+
+async function addEventsInteraction({
+  name,
+  queryString = '',
+}: {
+  name: string
+  queryString?: string
+}) {
+  await addJsonInteraction({
+    name,
+    given: 'there is one matching event',
+    path: '/api/events',
+    query: queryString,
+    body: {
+      eventIds: Matchers.eachLike(1),
+      totalCount: Matchers.integer(1),
+      pageInfo: {
+        hasNextPage: Matchers.boolean(false),
+        hasPreviousPage: Matchers.boolean(false),
+        startCursor: Matchers.integer(1),
+        endCursor: Matchers.integer(1),
+      },
+    },
+  })
+  await fetch(
+    `http://de.${process.env.SERLO_ORG_HOST}/api/events${
+      queryString ? '?' + queryString : ''
+    }`
+  )
+}

--- a/__tests-pacts__/serlo.org/events.ts
+++ b/__tests-pacts__/serlo.org/events.ts
@@ -56,8 +56,6 @@ async function addEventsInteraction({
       pageInfo: {
         hasNextPage: Matchers.boolean(false),
         hasPreviousPage: Matchers.boolean(false),
-        startCursor: Matchers.integer(1),
-        endCursor: Matchers.integer(1),
       },
     },
   })

--- a/__tests-pacts__/serlo.org/index.ts
+++ b/__tests-pacts__/serlo.org/index.ts
@@ -29,6 +29,9 @@ describe('GET /api/cache-keys', () => {
 describe('GET /api/event/:id', () => {
   require('./event')
 })
+describe('GET /api/events', () => {
+  require('./events')
+})
 describe('GET /api/license/:id', () => {
   require('./license')
 })

--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -48,17 +48,24 @@ export async function assertFailingGraphQLQuery({
   query,
   variables,
   client,
+  message,
 }: {
   query: string | DocumentNode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variables?: Record<string, any>
   client: Client
+  message?: unknown
 }) {
   const response = await client.query({
     query,
     variables,
   })
   expect(response.errors).toBeDefined()
+
+  if (message)
+    expect(response.errors?.map((error) => error.message)).toContainEqual(
+      message
+    )
 }
 
 export async function assertSuccessfulGraphQLMutation({

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -81,8 +81,6 @@ export function createEventsHandler(
       pageInfo: {
         hasNextPage: pageInfo?.hasNextPage ?? false,
         hasPreviousPage: pageInfo?.hasPreviousPage ?? false,
-        startCursor: pageInfo?.startCursor ?? eventIds[0] ?? null,
-        endCursor: pageInfo?.endCursor ?? R.last(eventIds) ?? null,
       },
     },
   })

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -63,6 +63,13 @@ export function createNotificationEventHandler(
   })
 }
 
+export function createCurrentEventIdHandler(currentEventId: number) {
+  return createJsonHandler({
+    path: '/api/current-event-id',
+    body: { currentEventId },
+  })
+}
+
 export function createUuidHandler(uuid: UuidPayload) {
   return createJsonHandler({
     path: `/api/uuid/${uuid.id}`,

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -19,7 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { rest } from 'msw'
+import { rest, MockedRequest } from 'msw'
 import * as R from 'ramda'
 
 import { LicensePayload } from '../../src/graphql/schema/license'
@@ -107,7 +107,7 @@ export function createJsonHandler({
 }) {
   return rest.get(
     `http://${instance}.${process.env.SERLO_ORG_HOST}${path}`,
-    (req, res, ctx) => {
+    (req: MockedRequest, res, ctx) => {
       return R.toPairs(query).every(([key, value]) => {
         return req.url.searchParams.get(key) === value
       })

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -68,10 +68,23 @@ export function createNotificationEventHandler(
 }
 
 export function createEventsHandler(
-  body: EventsPayload,
+  { eventIds = [], totalCount, pageInfo }: Partial<EventsPayload>,
   query?: Record<string, string>
 ) {
-  return createJsonHandler({ path: '/api/events', query, body })
+  return createJsonHandler({
+    path: '/api/events',
+    query,
+    body: {
+      eventIds,
+      totalCount: totalCount ?? eventIds.length,
+      pageInfo: {
+        hasNextPage: pageInfo?.hasNextPage ?? false,
+        hasPreviousPage: pageInfo?.hasPreviousPage ?? false,
+        startCursor: pageInfo?.startCursor ?? eventIds[0] ?? null,
+        endCursor: pageInfo?.endCursor ?? R.last(eventIds) ?? null,
+      },
+    },
+  })
 }
 
 export function createUuidHandler(uuid: UuidPayload) {

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -21,6 +21,7 @@
  */
 import { rest, MockedRequest } from 'msw'
 import * as R from 'ramda'
+import { DeepPartial } from 'ts-essentials'
 
 import { LicensePayload } from '../../src/graphql/schema/license'
 import {
@@ -68,7 +69,7 @@ export function createNotificationEventHandler(
 }
 
 export function createEventsHandler(
-  { eventIds = [], totalCount, pageInfo }: Partial<EventsPayload>,
+  { eventIds = [], totalCount, pageInfo }: DeepPartial<EventsPayload>,
   query?: Record<string, string>
 ) {
   return createJsonHandler({

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -23,7 +23,10 @@ import { rest } from 'msw'
 import * as R from 'ramda'
 
 import { LicensePayload } from '../../src/graphql/schema/license'
-import { NotificationEventPayload } from '../../src/graphql/schema/notification'
+import {
+  NotificationEventPayload,
+  EventsPayload,
+} from '../../src/graphql/schema/notification'
 import {
   AliasPayload,
   NavigationPayload,
@@ -64,11 +67,11 @@ export function createNotificationEventHandler(
   })
 }
 
-export function createEventIdsHandler(
-  eventIds: number[],
+export function createEventsHandler(
+  body: EventsPayload,
   query?: Record<string, string>
 ) {
-  return createJsonHandler({ path: '/api/events', query, body: { eventIds } })
+  return createJsonHandler({ path: '/api/events', query, body })
 }
 
 export function createUuidHandler(uuid: UuidPayload) {

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -113,7 +113,7 @@ export function createJsonHandler({
         return req.url.searchParams.get(key) === value
       })
         ? res(ctx.status(200), ctx.json(body as Record<string, unknown>))
-        : res(ctx.status(400))
+        : res(ctx.status(400, `Bad Request: ${req.url.toString()}`))
     }
   )
 }

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -109,9 +109,9 @@ export function createJsonHandler({
   return rest.get(
     `http://${instance}.${process.env.SERLO_ORG_HOST}${path}`,
     (req: MockedRequest, res, ctx) => {
-      return R.toPairs(query).every(([key, value]) => {
-        return req.url.searchParams.get(key) === value
-      })
+      const queryDict = R.fromPairs(Array.from(req.url.searchParams.entries()))
+
+      return R.equals(query, queryDict)
         ? res(ctx.status(200), ctx.json(body as Record<string, unknown>))
         : res(ctx.status(400, `Bad Request: ${req.url.toString()}`))
     }

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -163,6 +163,8 @@ describe('events', () => {
       ['before', '"10"'],
       ['first', '10'],
       ['last', '10'],
+      ['userId', '10'],
+      ['entityId', '10'],
     ])('query parameter = %s', async (filterName, filterValue) => {
       global.server.use(
         createNotificationEventHandler(event1),

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -34,6 +34,7 @@ import {
   createNotificationEventHandler,
   createEventsHandler,
   assertSuccessfulGraphQLQuery,
+  assertFailingGraphQLQuery,
 } from '../__utils__'
 
 let client: Client
@@ -152,8 +153,8 @@ describe('events', () => {
 
   describe('forward query arguments to serlo.org', () => {
     test.each([
-      ['after', '"10"'],
-      ['before', '"10"'],
+      ['after', `"MTA="`],
+      ['before', '"MTA="'],
       ['first', '10'],
       ['last', '10'],
       ['userId', '10'],
@@ -202,6 +203,22 @@ describe('events', () => {
             ],
           },
         },
+        client,
+      })
+    })
+  })
+
+  describe('returns an error when "after" or "before" is not an id.', () => {
+    test.each(['after', 'before'])('parameter = %s', async (parameter) => {
+      await assertFailingGraphQLQuery({
+        message: 'cannot parse "not-a-number" to an id',
+        query: gql`
+          query events {
+            events(${parameter}: "not-a-number") {
+              totalCount
+            }
+          }
+        `,
         client,
       })
     })

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -1,0 +1,66 @@
+import { gql } from 'apollo-server'
+
+import {
+  user,
+  createEntityNotificationEvent,
+  createTaxonomyTermNotificationEvent,
+  getAbstractNotificationEventDataWithoutSubResolvers,
+} from '../../__fixtures__'
+import { NotificationEventPayload } from '../../src/graphql/schema'
+import { Service } from '../../src/graphql/schema/types'
+import {
+  createTestClient,
+  Client,
+  createNotificationEventHandler,
+  createCurrentEventIdHandler,
+  assertSuccessfulGraphQLQuery,
+} from '../__utils__'
+
+let client: Client
+
+beforeEach(() => {
+  client = createTestClient({
+    service: Service.SerloCloudflareWorker,
+    user: user.id,
+  }).client
+})
+
+describe('events', () => {
+  test('returns list of current events', async () => {
+    const event1 = { ...createEntityNotificationEvent, id: 1 }
+    const event2 = { ...createTaxonomyTermNotificationEvent, id: 2 }
+    global.server.use(
+      createNotificationEventHandler(event1),
+      createNotificationEventHandler(event2),
+      createCurrentEventIdHandler(2)
+    )
+
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query events {
+          events {
+            totalCount
+            nodes {
+              ... on AbstractNotificationEvent {
+                __typename
+                id
+                instance
+                date
+              }
+            }
+          }
+        }
+      `,
+      data: {
+        events: {
+          totalCount: 2,
+          nodes: [
+            getAbstractNotificationEventDataWithoutSubResolvers(event2),
+            getAbstractNotificationEventDataWithoutSubResolvers(event1),
+          ],
+        },
+      },
+      client,
+    })
+  })
+})

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -1,3 +1,24 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
 import { gql } from 'apollo-server'
 
 import {

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -12,7 +12,7 @@ import {
   createTestClient,
   Client,
   createNotificationEventHandler,
-  createCurrentEventIdHandler,
+  createEventIdsHandler,
   assertSuccessfulGraphQLQuery,
 } from '../__utils__'
 
@@ -26,13 +26,14 @@ beforeEach(() => {
 })
 
 describe('events', () => {
+  const event1 = { ...createEntityNotificationEvent, id: 1 }
+  const event2 = { ...createTaxonomyTermNotificationEvent, id: 2 }
+
   test('returns list of current events', async () => {
-    const event1 = { ...createEntityNotificationEvent, id: 1 }
-    const event2 = { ...createTaxonomyTermNotificationEvent, id: 2 }
     global.server.use(
       createNotificationEventHandler(event1),
       createNotificationEventHandler(event2),
-      createCurrentEventIdHandler(2)
+      createEventIdsHandler([2, 1])
     )
 
     await assertSuccessfulGraphQLQuery({
@@ -64,108 +65,46 @@ describe('events', () => {
     })
   })
 
-  test('argument "first" is maximal 100', async () => {
-    const ids = R.range(101, 201).reverse()
-
-    ids.forEach((id) =>
+  describe('forward query arguments to serlo.org', () => {
+    test.each([
+      ['after', '"10"'],
+      ['before', '"10"'],
+      ['first', '10'],
+      ['last', '10'],
+    ])('query parameter = %s', async (filterName, filterValue) => {
       global.server.use(
-        createNotificationEventHandler({ ...createEntityNotificationEvent, id })
+        createNotificationEventHandler(event1),
+        createNotificationEventHandler(event2),
+        createEventIdsHandler([2, 1], { [filterName]: '10' })
       )
-    )
-    global.server.use(createCurrentEventIdHandler(200))
 
-    await assertSuccessfulGraphQLQuery({
-      query: gql`
-        query events {
-          events(first: 150) {
-            totalCount
-            nodes {
-              ... on AbstractNotificationEvent {
-                id
+      await assertSuccessfulGraphQLQuery({
+        query: gql`
+          query events {
+            events(${filterName}: ${filterValue}) {
+              totalCount
+              nodes {
+                ... on AbstractNotificationEvent {
+                  __typename
+                  id
+                  instance
+                  date
+                }
               }
             }
           }
-        }
-      `,
-      data: {
-        events: {
-          totalCount: 200,
-          nodes: ids.map((id) => {
-            return { id }
-          }),
+        `,
+        data: {
+          events: {
+            totalCount: 2,
+            nodes: [
+              getAbstractNotificationEventDataWithoutSubResolvers(event2),
+              getAbstractNotificationEventDataWithoutSubResolvers(event1),
+            ],
+          },
         },
-      },
-      client,
-    })
-  })
-
-  test('argument "last" is maximal 100', async () => {
-    const ids = R.range(1, 101).reverse()
-
-    ids.forEach((id) =>
-      global.server.use(
-        createNotificationEventHandler({ ...createEntityNotificationEvent, id })
-      )
-    )
-    global.server.use(createCurrentEventIdHandler(200))
-
-    await assertSuccessfulGraphQLQuery({
-      query: gql`
-        query events {
-          events(last: 150) {
-            totalCount
-            nodes {
-              ... on AbstractNotificationEvent {
-                id
-              }
-            }
-          }
-        }
-      `,
-      data: {
-        events: {
-          totalCount: 200,
-          nodes: ids.map((id) => {
-            return { id }
-          }),
-        },
-      },
-      client,
-    })
-  })
-
-  test('maximal 100 events are returned', async () => {
-    const ids = R.range(101, 201).reverse()
-
-    ids.forEach((id) =>
-      global.server.use(
-        createNotificationEventHandler({ ...createEntityNotificationEvent, id })
-      )
-    )
-    global.server.use(createCurrentEventIdHandler(200))
-
-    await assertSuccessfulGraphQLQuery({
-      query: gql`
-        query events {
-          events {
-            totalCount
-            nodes {
-              ... on AbstractNotificationEvent {
-                id
-              }
-            }
-          }
-        }
-      `,
-      data: {
-        events: {
-          totalCount: 200,
-          nodes: ids.map((id) => {
-            return { id }
-          }),
-        },
-      },
-      client,
+        client,
+      })
     })
   })
 })

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -157,7 +157,7 @@ describe('events', () => {
       ['first', '10'],
       ['last', '10'],
       ['userId', '10'],
-      ['entityId', '10'],
+      ['uuid', '10'],
     ])('query parameter = %s', async (filterName, filterValue) => {
       global.server.use(
         createNotificationEventHandler(event1),

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -32,16 +32,7 @@ describe('events', () => {
     global.server.use(
       createNotificationEventHandler(event1),
       createNotificationEventHandler(event2),
-      createEventsHandler({
-        eventIds: [2, 1],
-        totalCount: 2,
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: 1,
-          endCursor: 2,
-        },
-      })
+      createEventsHandler({ eventIds: [2, 1] })
     )
 
     await assertSuccessfulGraphQLQuery({
@@ -76,7 +67,6 @@ describe('events', () => {
   test('forwards results of serlo.org', async () => {
     global.server.use(
       createEventsHandler({
-        eventIds: [],
         totalCount: 100,
         pageInfo: {
           hasNextPage: true,
@@ -119,11 +109,9 @@ describe('events', () => {
   test('forwards results of serlo.org (start and end cursor is null)', async () => {
     global.server.use(
       createEventsHandler({
-        eventIds: [],
-        totalCount: 100,
         pageInfo: {
-          hasNextPage: true,
-          hasPreviousPage: true,
+          hasPreviousPage: false,
+          hasNextPage: false,
           startCursor: null,
           endCursor: null,
         },

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -129,14 +129,7 @@ describe('events', () => {
 
   test('forwards results of serlo.org (start and end cursor is null)', async () => {
     global.server.use(
-      createEventsHandler({
-        pageInfo: {
-          hasPreviousPage: false,
-          hasNextPage: false,
-          startCursor: null,
-          endCursor: null,
-        },
-      })
+      createEventsHandler({ pageInfo: { startCursor: null, endCursor: null } })
     )
 
     await assertSuccessfulGraphQLQuery({

--- a/__tests__/schema/notification.ts
+++ b/__tests__/schema/notification.ts
@@ -95,7 +95,7 @@ describe('notifications', () => {
     global.server.use(
       rest.get(
         `http://de.${process.env.SERLO_ORG_HOST}/api/notifications/${user.id}`,
-        (req, res, ctx) => {
+        (_req, res, ctx) => {
           return res(
             ctx.status(200),
             ctx.json({
@@ -225,7 +225,7 @@ describe('notifications', () => {
     global.server.use(
       rest.get(
         `http://de.${process.env.SERLO_ORG_HOST}/api/notifications/${user.id}`,
-        (req, res, ctx) => {
+        (_req, res, ctx) => {
           return res(
             ctx.status(200),
             ctx.json({
@@ -2198,7 +2198,7 @@ describe('setNotificationState', () => {
     global.server.use(
       rest.post(
         `http://de.${process.env.SERLO_ORG_HOST}/api/set-notification-state/1`,
-        (req, res, ctx) => {
+        (_req, res, ctx) => {
           return res(ctx.status(403), ctx.json({}))
         }
       )
@@ -2222,7 +2222,7 @@ describe('setNotificationState', () => {
     global.server.use(
       rest.get(
         `http://de.${process.env.SERLO_ORG_HOST}/api/notifications/${user.id}`,
-        (req, res, ctx) => {
+        (_req, res, ctx) => {
           return res(
             ctx.status(200),
             ctx.json({
@@ -2240,7 +2240,7 @@ describe('setNotificationState', () => {
       ),
       rest.post(
         `http://de.${process.env.SERLO_ORG_HOST}/api/set-notification-state/1`,
-        (req, res, ctx) => {
+        (_req, res, ctx) => {
           return res(
             ctx.status(200),
             ctx.json({

--- a/__tests__/schema/uuid/abstract-uuid.ts
+++ b/__tests__/schema/uuid/abstract-uuid.ts
@@ -1,0 +1,213 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { gql } from 'apollo-server'
+import * as R from 'ramda'
+
+import {
+  event,
+  user,
+  page,
+  pageRevision,
+  taxonomyTermRoot,
+  applet,
+  article,
+  video,
+  course,
+  coursePage,
+  groupedExercise,
+  exercise,
+  exerciseGroup,
+  solution,
+  appletRevision,
+  articleRevision,
+  courseRevision,
+  coursePageRevision,
+  exerciseRevision,
+  exerciseGroupRevision,
+  groupedExerciseRevision,
+  solutionRevision,
+  videoRevision,
+  eventRevision,
+  getAbstractNotificationEventDataWithoutSubResolvers,
+  createEntityNotificationEvent,
+  createTaxonomyTermNotificationEvent,
+} from '../../../__fixtures__'
+import { EntityType, EntityRevisionType } from '../../../src/graphql/schema'
+import { Service } from '../../../src/graphql/schema/types'
+import {
+  DiscriminatorType,
+  UuidType,
+  UuidPayload,
+} from '../../../src/graphql/schema/uuid/abstract-uuid/types'
+import {
+  assertSuccessfulGraphQLQuery,
+  Client,
+  createTestClient,
+  createUuidHandler,
+  createNotificationEventHandler,
+  createEventsHandler,
+} from '../../__utils__'
+
+let client: Client
+
+beforeEach(() => {
+  client = createTestClient({
+    service: Service.SerloCloudflareWorker,
+    user: null,
+  }).client
+})
+
+const abstractUuidFixtures: Record<UuidType, UuidPayload> = {
+  [DiscriminatorType.Page]: page,
+  [DiscriminatorType.PageRevision]: pageRevision,
+  [DiscriminatorType.TaxonomyTerm]: taxonomyTermRoot,
+  [DiscriminatorType.User]: user,
+  [EntityType.Applet]: applet,
+  [EntityType.Article]: article,
+  [EntityType.Course]: course,
+  [EntityType.CoursePage]: coursePage,
+  [EntityType.Exercise]: exercise,
+  [EntityType.ExerciseGroup]: exerciseGroup,
+  [EntityType.Event]: event,
+  [EntityType.GroupedExercise]: groupedExercise,
+  [EntityType.Solution]: solution,
+  [EntityType.Video]: video,
+  [EntityRevisionType.AppletRevision]: appletRevision,
+  [EntityRevisionType.ArticleRevision]: articleRevision,
+  [EntityRevisionType.CourseRevision]: courseRevision,
+  [EntityRevisionType.CoursePageRevision]: coursePageRevision,
+  [EntityRevisionType.ExerciseRevision]: exerciseRevision,
+  [EntityRevisionType.ExerciseGroupRevision]: exerciseGroupRevision,
+  [EntityRevisionType.EventRevision]: eventRevision,
+  [EntityRevisionType.GroupedExerciseRevision]: groupedExerciseRevision,
+  [EntityRevisionType.SolutionRevision]: solutionRevision,
+  [EntityRevisionType.VideoRevision]: videoRevision,
+}
+const abstractUuidRepository = R.toPairs(abstractUuidFixtures)
+
+describe('property "uuidEvents"', () => {
+  const event1 = { ...createEntityNotificationEvent, id: 1 }
+  const event2 = { ...createTaxonomyTermNotificationEvent, id: 2 }
+
+  describe.each(abstractUuidRepository)('type %s', (_type, payload) => {
+    beforeEach(() => {
+      global.server.use(
+        createUuidHandler(payload),
+        createNotificationEventHandler(event1),
+        createNotificationEventHandler(event2)
+      )
+    })
+
+    test('without any filter', async () => {
+      global.server.use(
+        createEventsHandler(
+          { eventIds: [2, 1], totalCount: 2 },
+          { uuid: payload.id.toString() }
+        )
+      )
+
+      await assertSuccessfulGraphQLQuery({
+        query: gql`
+          query events($id: Int) {
+            uuid(id: $id) {
+              ... on AbstractUuid {
+                uuidEvents {
+                  totalCount
+                  nodes {
+                    ... on AbstractNotificationEvent {
+                      __typename
+                      id
+                      instance
+                      date
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `,
+        data: {
+          uuid: {
+            uuidEvents: {
+              totalCount: 2,
+              nodes: [
+                getAbstractNotificationEventDataWithoutSubResolvers(event2),
+                getAbstractNotificationEventDataWithoutSubResolvers(event1),
+              ],
+            },
+          },
+        },
+        variables: { id: payload.id },
+        client,
+      })
+    })
+
+    test.each([
+      ['after', `"MTA="`],
+      ['before', '"MTA="'],
+      ['first', '10'],
+      ['last', '10'],
+    ])('with filter %s', async (filterName, filterValue) => {
+      global.server.use(
+        createEventsHandler(
+          { eventIds: [2, 1], totalCount: 2 },
+          { uuid: payload.id.toString(), [filterName]: '10' }
+        )
+      )
+
+      await assertSuccessfulGraphQLQuery({
+        query: gql`
+        query events($id: Int) {
+          uuid(id: $id) {
+            ... on AbstractUuid {
+              uuidEvents(${filterName}: ${filterValue}) {
+                totalCount
+                nodes {
+                  ... on AbstractNotificationEvent {
+                    __typename
+                    id
+                    instance
+                    date
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+        data: {
+          uuid: {
+            uuidEvents: {
+              totalCount: 2,
+              nodes: [
+                getAbstractNotificationEventDataWithoutSubResolvers(event2),
+                getAbstractNotificationEventDataWithoutSubResolvers(event1),
+              ],
+            },
+          },
+        },
+        variables: { id: payload.id },
+        client,
+      })
+    })
+  })
+})

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -331,7 +331,7 @@ describe('User', () => {
     })
   })
 
-  describe('property "events"', () => {
+  describe('by id (w/ property "userEvents")', () => {
     const event1 = { ...createEntityNotificationEvent, id: 1 }
     const event2 = { ...createTaxonomyTermNotificationEvent, id: 2 }
 
@@ -352,10 +352,10 @@ describe('User', () => {
 
       await assertSuccessfulGraphQLQuery({
         query: gql`
-          query events($id: Int) {
+          query userEvents($id: Int) {
             uuid(id: $id) {
               ... on User {
-                events {
+                userEvents {
                   totalCount
                   nodes {
                     ... on AbstractNotificationEvent {
@@ -372,7 +372,7 @@ describe('User', () => {
         `,
         data: {
           uuid: {
-            events: {
+            userEvents: {
               totalCount: 2,
               nodes: [
                 getAbstractNotificationEventDataWithoutSubResolvers(event2),
@@ -401,10 +401,10 @@ describe('User', () => {
 
       await assertSuccessfulGraphQLQuery({
         query: gql`
-        query events($id: Int) {
+        query userEvents($id: Int) {
           uuid(id: $id) {
             ... on User {
-              events(${filterName}: ${filterValue}) {
+              userEvents(${filterName}: ${filterValue}) {
                 totalCount
                 nodes {
                   ... on AbstractNotificationEvent {
@@ -421,7 +421,7 @@ describe('User', () => {
       `,
         data: {
           uuid: {
-            events: {
+            userEvents: {
               totalCount: 2,
               nodes: [
                 getAbstractNotificationEventDataWithoutSubResolvers(event2),

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -58,6 +58,22 @@ export type AbstractNotificationEvent = {
 };
 
 // @public (undocumented)
+export type AbstractNotificationEventConnection = {
+    __typename?: 'AbstractNotificationEventConnection';
+    edges: Array<AbstractNotificationEventEdge>;
+    nodes: Array<AbstractNotificationEvent>;
+    totalCount: Scalars['Int'];
+    pageInfo: PageInfo;
+};
+
+// @public (undocumented)
+export type AbstractNotificationEventEdge = {
+    __typename?: 'AbstractNotificationEventEdge';
+    cursor: Scalars['String'];
+    node: AbstractNotificationEvent;
+};
+
+// @public (undocumented)
 export type AbstractRepository = {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -648,6 +664,7 @@ export type Query = {
     activeAuthors: UserConnection;
     activeDonors: UserConnection;
     activeReviewers: UserConnection;
+    events: AbstractNotificationEventConnection;
     license?: Maybe<License>;
     notificationEvent?: Maybe<AbstractNotificationEvent>;
     notifications: NotificationConnection;
@@ -680,6 +697,14 @@ export type QueryActiveDonorsArgs = {
 
 // @public (undocumented)
 export type QueryActiveReviewersArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type QueryEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -114,6 +114,7 @@ export type AbstractTaxonomyTermChildTaxonomyTermsArgs = {
 export type AbstractUuid = {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
 };
 
 // @public (undocumented)
@@ -133,6 +134,14 @@ export type AbstractUuidCursor = {
 };
 
 // @public (undocumented)
+export type AbstractUuidUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type AliasInput = {
     instance: Instance;
     path: Scalars['String'];
@@ -149,6 +158,7 @@ export type Applet = AbstractUuid & AbstractRepository & AbstractEntity & Abstra
     license: License;
     currentRevision?: Maybe<AppletRevision>;
     revisions: AppletRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -158,6 +168,7 @@ export type AppletRevision = AbstractUuid & AbstractRevision & AbstractEntityRev
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: Applet;
     url: Scalars['String'];
@@ -194,7 +205,23 @@ export type AppletRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type AppletRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type AppletTaxonomyTermsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type AppletUuidEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;
@@ -212,6 +239,7 @@ export type Article = AbstractUuid & AbstractRepository & AbstractEntity & Abstr
     license: License;
     currentRevision?: Maybe<ArticleRevision>;
     revisions: ArticleRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -221,6 +249,7 @@ export type ArticleRevision = AbstractUuid & AbstractRevision & AbstractEntityRe
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: Article;
     title: Scalars['String'];
@@ -256,7 +285,23 @@ export type ArticleRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type ArticleRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type ArticleTaxonomyTermsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type ArticleUuidEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;
@@ -286,6 +331,7 @@ export type Course = AbstractUuid & AbstractRepository & AbstractEntity & Abstra
     license: License;
     currentRevision?: Maybe<CourseRevision>;
     revisions: CourseRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     taxonomyTerms: TaxonomyTermConnection;
     pages: Array<CoursePage>;
 };
@@ -301,6 +347,7 @@ export type CoursePage = AbstractUuid & AbstractRepository & AbstractEntity & {
     license: License;
     currentRevision?: Maybe<CoursePageRevision>;
     revisions: CoursePageRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     course: Course;
 };
 
@@ -310,6 +357,7 @@ export type CoursePageRevision = AbstractUuid & AbstractRevision & AbstractEntit
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: CoursePage;
     title: Scalars['String'];
@@ -343,11 +391,28 @@ export type CoursePageRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type CoursePageRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type CoursePageUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type CourseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
     __typename?: 'CourseRevision';
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: Course;
     title: Scalars['String'];
@@ -382,7 +447,23 @@ export type CourseRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type CourseRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type CourseTaxonomyTermsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type CourseUuidEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;
@@ -475,6 +556,7 @@ export type Event = AbstractUuid & AbstractRepository & AbstractEntity & Abstrac
     license: License;
     currentRevision?: Maybe<EventRevision>;
     revisions: EventRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -484,6 +566,7 @@ export type EventRevision = AbstractUuid & AbstractRevision & AbstractEntityRevi
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: Event;
     title: Scalars['String'];
@@ -519,7 +602,23 @@ export type EventRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type EventRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type EventTaxonomyTermsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type EventUuidEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;
@@ -544,6 +643,7 @@ export type Exercise = AbstractUuid & AbstractRepository & AbstractEntity & Abst
     license: License;
     currentRevision?: Maybe<ExerciseRevision>;
     revisions: ExerciseRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     taxonomyTerms: TaxonomyTermConnection;
     solution?: Maybe<Solution>;
 };
@@ -559,6 +659,7 @@ export type ExerciseGroup = AbstractUuid & AbstractRepository & AbstractEntity &
     license: License;
     currentRevision?: Maybe<ExerciseGroupRevision>;
     revisions: ExerciseGroupRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     taxonomyTerms: TaxonomyTermConnection;
     exercises: Array<GroupedExercise>;
 };
@@ -569,6 +670,7 @@ export type ExerciseGroupRevision = AbstractUuid & AbstractRevision & AbstractEn
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: ExerciseGroup;
     content: Scalars['String'];
@@ -601,7 +703,23 @@ export type ExerciseGroupRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type ExerciseGroupRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type ExerciseGroupTaxonomyTermsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type ExerciseGroupUuidEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;
@@ -614,6 +732,7 @@ export type ExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityR
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: Exercise;
     content: Scalars['String'];
@@ -646,7 +765,23 @@ export type ExerciseRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type ExerciseRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type ExerciseTaxonomyTermsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type ExerciseUuidEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;
@@ -664,6 +799,7 @@ export type GroupedExercise = AbstractUuid & AbstractRepository & AbstractEntity
     license: License;
     currentRevision?: Maybe<GroupedExerciseRevision>;
     revisions: GroupedExerciseRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     solution?: Maybe<Solution>;
     exerciseGroup: ExerciseGroup;
 };
@@ -674,6 +810,7 @@ export type GroupedExerciseRevision = AbstractUuid & AbstractRevision & Abstract
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: GroupedExercise;
     content: Scalars['String'];
@@ -703,6 +840,22 @@ export type GroupedExerciseRevisionsArgs = {
     first?: Maybe<Scalars['Int']>;
     last?: Maybe<Scalars['Int']>;
     unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+// @public (undocumented)
+export type GroupedExerciseRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type GroupedExerciseUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)
@@ -842,6 +995,7 @@ export type Page = AbstractUuid & AbstractRepository & AbstractNavigationChild &
     license: License;
     currentRevision?: Maybe<PageRevision>;
     revisions: PageRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     navigation?: Maybe<Navigation>;
 };
 
@@ -860,6 +1014,7 @@ export type PageRevision = AbstractUuid & AbstractRevision & {
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     title: Scalars['String'];
     content: Scalars['String'];
@@ -889,6 +1044,22 @@ export type PageRevisionsArgs = {
     first?: Maybe<Scalars['Int']>;
     last?: Maybe<Scalars['Int']>;
     unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+// @public (undocumented)
+export type PageRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type PageUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)
@@ -1083,6 +1254,7 @@ export type Solution = AbstractUuid & AbstractRepository & AbstractEntity & {
     license: License;
     currentRevision?: Maybe<SolutionRevision>;
     revisions?: Maybe<SolutionRevisionConnection>;
+    uuidEvents: AbstractNotificationEventConnection;
     exercise: AbstractExercise;
 };
 
@@ -1092,6 +1264,7 @@ export type SolutionRevision = AbstractUuid & AbstractRevision & AbstractEntityR
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: Solution;
     content: Scalars['String'];
@@ -1124,6 +1297,22 @@ export type SolutionRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type SolutionRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type SolutionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type StringConnection = {
     __typename?: 'StringConnection';
     edges: Array<StringEdge>;
@@ -1147,6 +1336,7 @@ export type TaxonomyTerm = AbstractUuid & AbstractNavigationChild & {
     type: TaxonomyTermType;
     instance: Instance;
     alias?: Maybe<Scalars['String']>;
+    uuidEvents: AbstractNotificationEventConnection;
     name: Scalars['String'];
     description?: Maybe<Scalars['String']>;
     weight: Scalars['Int'];
@@ -1206,6 +1396,14 @@ export enum TaxonomyTermType {
 }
 
 // @public (undocumented)
+export type TaxonomyTermUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type UnsupportedComment = {
     __typename?: 'UnsupportedComment';
     id: Scalars['Int'];
@@ -1224,6 +1422,7 @@ export type User = AbstractUuid & {
     trashed: Scalars['Boolean'];
     alias: Scalars['String'];
     userEvents: AbstractNotificationEventConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     username: Scalars['String'];
     date: Scalars['DateTime'];
     lastLogin?: Maybe<Scalars['DateTime']>;
@@ -1258,6 +1457,14 @@ export type UserUserEventsArgs = {
 };
 
 // @public (undocumented)
+export type UserUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type Video = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & {
     __typename?: 'Video';
     id: Scalars['Int'];
@@ -1268,6 +1475,7 @@ export type Video = AbstractUuid & AbstractRepository & AbstractEntity & Abstrac
     license: License;
     currentRevision?: Maybe<VideoRevision>;
     revisions: VideoRevisionConnection;
+    uuidEvents: AbstractNotificationEventConnection;
     taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -1277,6 +1485,7 @@ export type VideoRevision = AbstractUuid & AbstractRevision & AbstractEntityRevi
     id: Scalars['Int'];
     author: User;
     trashed: Scalars['Boolean'];
+    uuidEvents: AbstractNotificationEventConnection;
     date: Scalars['DateTime'];
     repository: Video;
     url: Scalars['String'];
@@ -1311,7 +1520,23 @@ export type VideoRevisionsArgs = {
 };
 
 // @public (undocumented)
+export type VideoRevisionUuidEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type VideoTaxonomyTermsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type VideoUuidEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -1223,6 +1223,7 @@ export type User = AbstractUuid & {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
     alias: Scalars['String'];
+    userEvents: AbstractNotificationEventConnection;
     username: Scalars['String'];
     date: Scalars['DateTime'];
     lastLogin?: Maybe<Scalars['DateTime']>;
@@ -1230,7 +1231,6 @@ export type User = AbstractUuid & {
     activeAuthor: Scalars['Boolean'];
     activeDonor: Scalars['Boolean'];
     activeReviewer: Scalars['Boolean'];
-    events: AbstractNotificationEventConnection;
 };
 
 // @public (undocumented)
@@ -1250,7 +1250,7 @@ export type UserEdge = {
 };
 
 // @public (undocumented)
-export type UserEventsArgs = {
+export type UserUserEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -944,7 +944,7 @@ export type QueryEventsArgs = {
     first?: Maybe<Scalars['Int']>;
     last?: Maybe<Scalars['Int']>;
     userId?: Maybe<Scalars['Int']>;
-    entityId?: Maybe<Scalars['Int']>;
+    uuid?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -943,6 +943,8 @@ export type QueryEventsArgs = {
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;
     last?: Maybe<Scalars['Int']>;
+    userId?: Maybe<Scalars['Int']>;
+    entityId?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -1230,6 +1230,7 @@ export type User = AbstractUuid & {
     activeAuthor: Scalars['Boolean'];
     activeDonor: Scalars['Boolean'];
     activeReviewer: Scalars['Boolean'];
+    events: AbstractNotificationEventConnection;
 };
 
 // @public (undocumented)
@@ -1246,6 +1247,14 @@ export type UserEdge = {
     __typename?: 'UserEdge';
     cursor: Scalars['String'];
     node: User;
+};
+
+// @public (undocumented)
+export type UserEventsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)

--- a/jest.d.ts
+++ b/jest.d.ts
@@ -1,0 +1,6 @@
+interface URL {
+  readonly pathname: string
+  readonly searchParams: {
+    get(key: string): string | null
+  }
+}

--- a/jest.d.ts
+++ b/jest.d.ts
@@ -1,3 +1,24 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
 interface URL {
   readonly pathname: string
   readonly searchParams: {

--- a/jest.d.ts
+++ b/jest.d.ts
@@ -21,6 +21,7 @@
  */
 interface URL {
   readonly pathname: string
+  readonly search: string
   readonly searchParams: {
     get(key: string): string | null
   }

--- a/jest.d.ts
+++ b/jest.d.ts
@@ -23,6 +23,6 @@ interface URL {
   readonly pathname: string
   readonly search: string
   readonly searchParams: {
-    get(key: string): string | null
+    entries(): [string, string][]
   }
 }

--- a/jest.setup-pacts.ts
+++ b/jest.setup-pacts.ts
@@ -25,7 +25,6 @@ import { setupServer } from 'msw/node'
 import fetch from 'node-fetch'
 import path from 'path'
 import rimraf from 'rimraf'
-import { Url } from 'url'
 import util from 'util'
 
 import { createTestClient } from './__tests__/__utils__'
@@ -41,16 +40,16 @@ const server = setupServer(
   rest.get(
     new RegExp(process.env.SERLO_ORG_HOST.replace('.', '\\.')),
     async (req, res, ctx) => {
-      const url = req.url as Url
-      const pactRes = await fetch(`http://localhost:${port}/${url.pathname!}`)
+      const url = req.url
+      const pactRes = await fetch(`http://localhost:${port}/${url.pathname}`)
       return res(ctx.status(pactRes.status), ctx.json(await pactRes.json()))
     }
   ),
   rest.post(
     new RegExp(process.env.SERLO_ORG_HOST.replace('.', '\\.')),
     async (req, res, ctx) => {
-      const url = req.url as Url
-      const pactRes = await fetch(`http://localhost:${port}/${url.pathname!}`, {
+      const url = req.url
+      const pactRes = await fetch(`http://localhost:${port}/${url.pathname}`, {
         method: 'POST',
         body:
           typeof req.body === 'object' ? JSON.stringify(req.body) : req.body,

--- a/jest.setup-pacts.ts
+++ b/jest.setup-pacts.ts
@@ -40,23 +40,26 @@ const server = setupServer(
   rest.get(
     new RegExp(process.env.SERLO_ORG_HOST.replace('.', '\\.')),
     async (req, res, ctx) => {
-      const url = req.url
-      const pactRes = await fetch(`http://localhost:${port}/${url.pathname}`)
+      const pactRes = await fetch(
+        `http://localhost:${port}/${req.url.pathname}${req.url.search}`
+      )
       return res(ctx.status(pactRes.status), ctx.json(await pactRes.json()))
     }
   ),
   rest.post(
     new RegExp(process.env.SERLO_ORG_HOST.replace('.', '\\.')),
     async (req, res, ctx) => {
-      const url = req.url
-      const pactRes = await fetch(`http://localhost:${port}/${url.pathname}`, {
-        method: 'POST',
-        body:
-          typeof req.body === 'object' ? JSON.stringify(req.body) : req.body,
-        headers: {
-          'Content-Type': req.headers.get('Content-Type')!,
-        },
-      })
+      const pactRes = await fetch(
+        `http://localhost:${port}/${req.url.pathname}${req.url.search}`,
+        {
+          method: 'POST',
+          body:
+            typeof req.body === 'object' ? JSON.stringify(req.body) : req.body,
+          headers: {
+            'Content-Type': req.headers.get('Content-Type')!,
+          },
+        }
+      )
       return res(ctx.status(pactRes.status), ctx.json(await pactRes.json()))
     }
   )

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "node-fetch": "^2.6.1",
     "ramda": "^0.27.0",
     "redis": "^3.0.0",
+    "ts-essentials": "^7.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -38,6 +38,7 @@ import {
   NavigationPayload,
   NodeData,
   NotificationsPayload,
+  EventsPayload,
 } from '../schema'
 import { Service } from '../schema/types'
 import { CacheableDataSource } from './cacheable-data-source'
@@ -168,7 +169,7 @@ export class SerloDataSource extends CacheableDataSource {
     first?: number
     last?: number
   }) {
-    return await this.cacheAwareGet<{ eventIds: number[] }>({
+    return await this.cacheAwareGet<EventsPayload>({
       path: '/api/events',
       ttl: 5 * 60,
       query,

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -161,10 +161,17 @@ export class SerloDataSource extends CacheableDataSource {
     return uuid === null || isUnsupportedUuid(uuid) ? null : uuid
   }
 
-  public async getCurrentEventId(): Promise<{ currentEventId: number }> {
-    return await this.cacheAwareGet<{ currentEventId: number }>({
-      path: '/api/current-event-id',
-      ttl: 60 * 60 * 24,
+  // Todo: string => number
+  public async getEventIds(query?: {
+    after?: string
+    before?: string
+    first?: number
+    last?: number
+  }) {
+    return await this.cacheAwareGet<{ eventIds: number[] }>({
+      path: '/api/events',
+      ttl: 5 * 60,
+      query,
     })
   }
 
@@ -251,11 +258,13 @@ export class SerloDataSource extends CacheableDataSource {
     instance = Instance.De,
     ttl,
     ignoreCache,
+    query = {},
   }: {
     path: string
     instance?: Instance
     ttl?: number
     ignoreCache?: boolean
+    query?: Record<string, string | number | undefined>
   }): Promise<T> {
     const cacheKey = this.getCacheKey(path, instance)
 
@@ -271,7 +280,7 @@ export class SerloDataSource extends CacheableDataSource {
     })
     const data = await super.get<T>(
       `http://${instance}.${process.env.SERLO_ORG_HOST}${path}`,
-      {},
+      query,
       {
         headers: {
           Authorization: `Serlo Service=${token}`,

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -22,8 +22,9 @@
 import { isSome } from 'fp-ts/lib/Option'
 import jwt from 'jsonwebtoken'
 import * as R from 'ramda'
+import { DeepNonNullable } from 'ts-essentials'
 
-import { Instance, License } from '../../types'
+import { Instance, License, QueryEventsArgs } from '../../types'
 import { Environment } from '../environment'
 import {
   AbstractNotificationEventPayload,
@@ -163,14 +164,7 @@ export class SerloDataSource extends CacheableDataSource {
   }
 
   // Todo: string => number
-  public async getEventIds(query?: {
-    after?: string
-    before?: string
-    first?: number
-    last?: number
-    userId?: number
-    entityId?: number
-  }) {
+  public async getEventIds(query?: Partial<DeepNonNullable<QueryEventsArgs>>) {
     return await this.cacheAwareGet<EventsPayload>({
       path: '/api/events',
       ttl: 5 * 60,

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -22,7 +22,6 @@
 import { isSome } from 'fp-ts/lib/Option'
 import jwt from 'jsonwebtoken'
 import * as R from 'ramda'
-import { DeepNonNullable } from 'ts-essentials'
 
 import { Instance, License, QueryEventsArgs } from '../../types'
 import { Environment } from '../environment'
@@ -163,8 +162,7 @@ export class SerloDataSource extends CacheableDataSource {
     return uuid === null || isUnsupportedUuid(uuid) ? null : uuid
   }
 
-  // Todo: string => number
-  public async getEventIds(query?: Partial<DeepNonNullable<QueryEventsArgs>>) {
+  public async getEventIds(query?: { [P in keyof QueryEventsArgs]?: number }) {
     return await this.cacheAwareGet<EventsPayload>({
       path: '/api/events',
       ttl: 5 * 60,

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -161,6 +161,13 @@ export class SerloDataSource extends CacheableDataSource {
     return uuid === null || isUnsupportedUuid(uuid) ? null : uuid
   }
 
+  public async getCurrentEventId(): Promise<{ currentEventId: number }> {
+    return await this.cacheAwareGet<{ currentEventId: number }>({
+      path: '/api/current-event-id',
+      ttl: 60 * 60 * 24,
+    })
+  }
+
   public async getNotificationEvent<
     T extends AbstractNotificationEventPayload
   >({ id }: { id: number }): Promise<T | null> {

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -168,6 +168,8 @@ export class SerloDataSource extends CacheableDataSource {
     before?: string
     first?: number
     last?: number
+    userId?: number
+    entityId?: number
   }) {
     return await this.cacheAwareGet<EventsPayload>({
       path: '/api/events',

--- a/src/graphql/schema/connection/utils.ts
+++ b/src/graphql/schema/connection/utils.ts
@@ -28,27 +28,13 @@ export function resolveConnection<T>({
   nodes,
   payload,
   createCursor,
-  maxNumberOfNodes,
 }: {
   nodes: T[]
   payload: ConnectionPayload
   createCursor(node: T): string
-  maxNumberOfNodes?: number
 }): Connection<T> {
   const { before, after } = payload
-  let { first, last } = payload
-
-  if (maxNumberOfNodes) {
-    if (first) {
-      first = Math.min(first, maxNumberOfNodes)
-    } else if (!last) {
-      first = maxNumberOfNodes
-    }
-
-    if (last) {
-      last = Math.min(last, maxNumberOfNodes)
-    }
-  }
+  const { first, last } = payload
 
   const allEdges = nodes.map((node) => {
     return {
@@ -113,17 +99,4 @@ export function resolveConnection<T>({
     if (before != null) return getBeforeIndex() + 1 < allEdges.length
     return false
   }
-}
-
-export async function mapConnectionAsync<A, B>(
-  mapFunc: (a: A) => Promise<B>,
-  connection: Connection<A>
-): Promise<Connection<B>> {
-  const edges = await Promise.all(
-    connection.edges.map(async (edge) => {
-      return { node: await mapFunc(edge.node), cursor: edge.cursor }
-    })
-  )
-
-  return { ...connection, edges, nodes: edges.map((edge) => edge.node) }
 }

--- a/src/graphql/schema/connection/utils.ts
+++ b/src/graphql/schema/connection/utils.ts
@@ -28,12 +28,28 @@ export function resolveConnection<T>({
   nodes,
   payload,
   createCursor,
+  maxNumberOfNodes,
 }: {
   nodes: T[]
   payload: ConnectionPayload
   createCursor(node: T): string
+  maxNumberOfNodes?: number
 }): Connection<T> {
-  const { before, after, first, last } = payload
+  const { before, after } = payload
+  let { first, last } = payload
+
+  if (maxNumberOfNodes) {
+    if (first) {
+      first = Math.min(first, maxNumberOfNodes)
+    } else if (!last) {
+      first = maxNumberOfNodes
+    }
+
+    if (last) {
+      last = Math.min(last, maxNumberOfNodes)
+    }
+  }
+
   const allEdges = nodes.map((node) => {
     return {
       cursor: Buffer.from(createCursor(node)).toString('base64'),

--- a/src/graphql/schema/connection/utils.ts
+++ b/src/graphql/schema/connection/utils.ts
@@ -37,10 +37,7 @@ export function resolveConnection<T>({
   const { first, last } = payload
 
   const allEdges = nodes.map((node) => {
-    return {
-      cursor: Buffer.from(createCursor(node)).toString('base64'),
-      node,
-    }
+    return { cursor: encodeCursor(createCursor(node)), node }
   })
   const applyCursorToEdgesResult = applyCursorToEdges()
   const edges = R.pipe(handleFirst, handleLast)(applyCursorToEdgesResult)
@@ -99,4 +96,8 @@ export function resolveConnection<T>({
     if (before != null) return getBeforeIndex() + 1 < allEdges.length
     return false
   }
+}
+
+export function encodeCursor(cursor: string): string {
+  return Buffer.from(cursor).toString('base64')
 }

--- a/src/graphql/schema/connection/utils.ts
+++ b/src/graphql/schema/connection/utils.ts
@@ -98,3 +98,16 @@ export function resolveConnection<T>({
     return false
   }
 }
+
+export async function mapConnectionAsync<A, B>(
+  mapFunc: (a: A) => Promise<B>,
+  connection: Connection<A>
+): Promise<Connection<B>> {
+  const edges = await Promise.all(
+    connection.edges.map(async (edge) => {
+      return { node: await mapFunc(edge.node), cursor: edge.cursor }
+    })
+  )
+
+  return { ...connection, edges, nodes: edges.map((edge) => edge.node) }
+}

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -56,7 +56,7 @@ export const resolvers: NotificationResolvers = {
         first: cursorPayload.first ?? undefined,
         last: cursorPayload.last ?? undefined,
         userId: cursorPayload.userId ?? undefined,
-        entityId: cursorPayload.entityId ?? undefined,
+        uuid: cursorPayload.uuid ?? undefined,
       })
       const eventsFromSerlo = await Promise.all(
         eventIds.map((id) => dataSources.serlo.getNotificationEvent({ id }))

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -55,6 +55,8 @@ export const resolvers: NotificationResolvers = {
         before: cursorPayload.before ?? undefined,
         first: cursorPayload.first ?? undefined,
         last: cursorPayload.last ?? undefined,
+        userId: cursorPayload.userId ?? undefined,
+        entityId: cursorPayload.entityId ?? undefined,
       })
       const eventsFromSerlo = await Promise.all(
         eventIds.map((id) => dataSources.serlo.getNotificationEvent({ id }))

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -20,6 +20,7 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { AuthenticationError, UserInputError } from 'apollo-server'
+import * as R from 'ramda'
 
 import { resolveConnection, encodeCursor } from '../connection'
 import { Context } from '../types'
@@ -50,14 +51,13 @@ export const resolvers: NotificationResolvers = {
         eventIds,
         totalCount,
         pageInfo,
-      } = await dataSources.serlo.getEventIds({
-        after: parseId(cursorPayload.after),
-        before: parseId(cursorPayload.before),
-        first: cursorPayload.first ?? undefined,
-        last: cursorPayload.last ?? undefined,
-        userId: cursorPayload.userId ?? undefined,
-        uuid: cursorPayload.uuid ?? undefined,
-      })
+      } = await dataSources.serlo.getEventIds(
+        R.filter((value) => !R.isNil(value), {
+          ...cursorPayload,
+          after: parseId(cursorPayload.after),
+          before: parseId(cursorPayload.before),
+        })
+      )
       const eventsFromSerlo = await Promise.all(
         eventIds.map((id) => dataSources.serlo.getNotificationEvent({ id }))
       )

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -47,22 +47,12 @@ export const resolvers: NotificationResolvers = {
   },
   Query: {
     async events(_parent, cursorPayload, { dataSources }) {
-      const maxNumberOfEvents = 100
       const { currentEventId } = await dataSources.serlo.getCurrentEventId()
       const eventIdConnection = resolveConnection<number>({
         nodes: R.range(1, currentEventId + 1).reverse(),
-        payload: {
-          ...cursorPayload,
-          first: cursorPayload.first
-            ? Math.min(cursorPayload.first, maxNumberOfEvents)
-            : cursorPayload.last
-            ? undefined
-            : maxNumberOfEvents,
-          last: cursorPayload.last
-            ? Math.min(cursorPayload.last, maxNumberOfEvents)
-            : undefined,
-        },
+        payload: cursorPayload,
         createCursor: (id: number) => id.toString(),
+        maxNumberOfNodes: 100
       })
 
       return await mapConnectionAsync(

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -47,10 +47,21 @@ export const resolvers: NotificationResolvers = {
   },
   Query: {
     async events(_parent, cursorPayload, { dataSources }) {
+      const maxNumberOfEvents = 100
       const { currentEventId } = await dataSources.serlo.getCurrentEventId()
       const eventIdConnection = resolveConnection<number>({
         nodes: R.range(1, currentEventId + 1).reverse(),
-        payload: cursorPayload,
+        payload: {
+          ...cursorPayload,
+          first: cursorPayload.first
+            ? Math.min(cursorPayload.first, maxNumberOfEvents)
+            : cursorPayload.last
+            ? undefined
+            : maxNumberOfEvents,
+          last: cursorPayload.last
+            ? Math.min(cursorPayload.last, maxNumberOfEvents)
+            : undefined,
+        },
         createCursor: (id: number) => id.toString(),
       })
 

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -51,13 +51,11 @@ export const resolvers: NotificationResolvers = {
         eventIds,
         totalCount,
         pageInfo,
-      } = await dataSources.serlo.getEventIds(
-        R.filter((value) => !R.isNil(value), {
+      } = await dataSources.serlo.getEventIds({
           ...cursorPayload,
           after: parseId(cursorPayload.after),
           before: parseId(cursorPayload.before),
-        })
-      )
+      })
       const eventsFromSerlo = await Promise.all(
         eventIds.map((id) => dataSources.serlo.getNotificationEvent({ id }))
       )

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -79,17 +79,6 @@ export const resolvers: NotificationResolvers = {
       function encodePageInfoCursor(value: number | null) {
         return value !== null ? encodeCursor(value.toString()) : null
       }
-
-      function parseId(value?: string | null): number | undefined {
-        if (value == null) return undefined
-
-        const result = parseInt(Buffer.from(value, 'base64').toString('utf-8'))
-
-        if (isNaN(result))
-          throw new UserInputError(`cannot parse "${value}" to an id`)
-
-        return result
-      }
     },
     async notifications(
       _parent,
@@ -131,4 +120,15 @@ export const resolvers: NotificationResolvers = {
       return null
     },
   },
+}
+
+function parseId(value?: string | null): number | undefined {
+  if (value == null) return undefined
+
+  const result = parseInt(Buffer.from(value, 'base64').toString('utf-8'))
+
+  if (isNaN(result))
+    throw new UserInputError(`cannot parse "${value}" to an id`)
+
+  return result
 }

--- a/src/graphql/schema/notification/resolvers.ts
+++ b/src/graphql/schema/notification/resolvers.ts
@@ -63,6 +63,9 @@ export const resolvers: NotificationResolvers = {
       )
       const events = eventsFromSerlo.filter(isNotNil)
 
+      const firstId = R.head(eventIds)
+      const lastId = R.last(eventIds)
+
       return {
         edges: events.map((event) => {
           return { node: event, cursor: encodeCursor(event.id.toString()) }
@@ -71,13 +74,11 @@ export const resolvers: NotificationResolvers = {
         totalCount,
         pageInfo: {
           ...pageInfo,
-          startCursor: encodePageInfoCursor(pageInfo.startCursor),
-          endCursor: encodePageInfoCursor(pageInfo.endCursor),
+          startCursor:
+            firstId === undefined ? null : encodeCursor(firstId.toString()),
+          endCursor:
+            lastId === undefined ? null : encodeCursor(lastId.toString()),
         },
-      }
-
-      function encodePageInfoCursor(value: number | null) {
-        return value !== null ? encodeCursor(value.toString()) : null
       }
     },
     async notifications(

--- a/src/graphql/schema/notification/types.graphql
+++ b/src/graphql/schema/notification/types.graphql
@@ -12,6 +12,12 @@ interface AbstractNotificationEvent {
 }
 
 extend type Query {
+  events(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   notifications(
     after: String
     before: String
@@ -36,4 +42,16 @@ type NotificationConnection {
 type NotificationEdge {
   cursor: String!
   node: Notification!
+}
+
+type AbstractNotificationEventConnection {
+  edges: [AbstractNotificationEventEdge!]!
+  nodes: [AbstractNotificationEvent!]!
+  totalCount: Int!
+  pageInfo: PageInfo!
+}
+
+type AbstractNotificationEventEdge {
+  cursor: String!
+  node: AbstractNotificationEvent!
 }

--- a/src/graphql/schema/notification/types.graphql
+++ b/src/graphql/schema/notification/types.graphql
@@ -18,7 +18,7 @@ extend type Query {
     first: Int
     last: Int
     userId: Int
-    entityId: Int
+    uuid: Int
   ): AbstractNotificationEventConnection!
   notifications(
     after: String

--- a/src/graphql/schema/notification/types.graphql
+++ b/src/graphql/schema/notification/types.graphql
@@ -17,6 +17,8 @@ extend type Query {
     before: String
     first: Int
     last: Int
+    userId: Int
+    entityId: Int
   ): AbstractNotificationEventConnection!
   notifications(
     after: String

--- a/src/graphql/schema/notification/types.ts
+++ b/src/graphql/schema/notification/types.ts
@@ -121,7 +121,8 @@ export interface NotificationResolvers {
     event: Resolver<NotificationPayload, never, NotificationEventPayload | null>
   }
   Query: {
-    events: QueryResolver<
+    events: Resolver<
+      undefined,
       QueryEventsArgs,
       Connection<AbstractNotificationEventPayload>
     >

--- a/src/graphql/schema/notification/types.ts
+++ b/src/graphql/schema/notification/types.ts
@@ -52,6 +52,17 @@ import { SetTaxonomyTermNotificationEventPayload } from './set-taxonomy-term-not
 import { SetThreadStateNotificationEventPayload } from './set-thread-state-notification-event'
 import { SetUuidStateNotificationEventPayload } from './set-uuid-state-notification-event'
 
+export interface EventsPayload {
+  eventIds: number[]
+  totalCount: number
+  pageInfo: {
+    hasNextPage: boolean
+    hasPreviousPage: boolean
+    startCursor: number | null
+    endCursor: number | null
+  }
+}
+
 export interface NotificationPayload
   extends Omit<Notification, keyof NotificationResolvers['Notification']> {
   eventId: number

--- a/src/graphql/schema/notification/types.ts
+++ b/src/graphql/schema/notification/types.ts
@@ -58,8 +58,6 @@ export interface EventsPayload {
   pageInfo: {
     hasNextPage: boolean
     hasPreviousPage: boolean
-    startCursor: number | null
-    endCursor: number | null
   }
 }
 

--- a/src/graphql/schema/notification/types.ts
+++ b/src/graphql/schema/notification/types.ts
@@ -25,6 +25,7 @@ import {
   Notification,
   QueryNotificationEventArgs,
   QueryNotificationsArgs,
+  QueryEventsArgs,
 } from '../../../types'
 import { Connection } from '../connection'
 import {
@@ -111,6 +112,10 @@ export interface NotificationResolvers {
     event: Resolver<NotificationPayload, never, NotificationEventPayload | null>
   }
   Query: {
+    events: QueryResolver<
+      QueryEventsArgs,
+      Connection<AbstractNotificationEventPayload>
+    >
     notifications: QueryResolver<
       QueryNotificationsArgs,
       Connection<NotificationPayload>

--- a/src/graphql/schema/uuid/abstract-repository/types.ts
+++ b/src/graphql/schema/uuid/abstract-repository/types.ts
@@ -43,7 +43,7 @@ import {
   EntityRevisionType,
   EntityType,
 } from '../abstract-entity'
-import { DiscriminatorType } from '../abstract-uuid'
+import { DiscriminatorType, AbstractUuidResolvers } from '../abstract-uuid'
 import { AliasResolvers } from '../alias'
 import { PagePayload, PageRevisionPayload } from '../page'
 import { UserPayload } from '../user'
@@ -95,7 +95,7 @@ type RevisionsConnectionArgs =
 export interface RepositoryResolvers<
   E extends AbstractRepositoryPayload,
   R extends AbstractRevisionPayload
-> extends AliasResolvers<E> {
+> extends AliasResolvers<E>, AbstractUuidResolvers<E> {
   currentRevision: Resolver<E, never, R | null>
   revisions: Resolver<E, RevisionsConnectionArgs, Connection<R>>
   license: Resolver<E, never, Partial<License>>
@@ -104,7 +104,7 @@ export interface RepositoryResolvers<
 export interface RevisionResolvers<
   E extends AbstractRepositoryPayload,
   R extends AbstractRevisionPayload
-> {
+> extends AbstractUuidResolvers<E> {
   author: Resolver<R, never, Partial<UserPayload> | null>
   repository: Resolver<R, never, E | null>
 }

--- a/src/graphql/schema/uuid/abstract-repository/utils.ts
+++ b/src/graphql/schema/uuid/abstract-repository/utils.ts
@@ -21,6 +21,7 @@
  */
 import { resolveConnection } from '../..'
 import { requestsOnlyFields, isNotNil } from '../../utils'
+import { createAbstractUuidResolvers } from '../abstract-uuid'
 import { createAliasResolvers } from '../alias'
 import { resolveUser } from '../user'
 import {
@@ -35,6 +36,7 @@ export function createRepositoryResolvers<
   R extends AbstractRevisionPayload
 >(): RepositoryResolvers<E, R> {
   return {
+    ...createAbstractUuidResolvers<E>(),
     ...createAliasResolvers<E>(),
     async currentRevision(entity, _args, { dataSources }) {
       if (!entity.currentRevisionId) return null
@@ -78,6 +80,7 @@ export function createRevisionResolvers<
   R extends AbstractRevisionPayload
 >(): RevisionResolvers<E, R> {
   return {
+    ...createAbstractUuidResolvers<E>(),
     author(entityRevision, _args, context, info) {
       return resolveUser({ id: entityRevision.authorId }, context, info)
     },

--- a/src/graphql/schema/uuid/abstract-uuid/types.graphql
+++ b/src/graphql/schema/uuid/abstract-uuid/types.graphql
@@ -1,6 +1,12 @@
 interface AbstractUuid {
   id: Int!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
 }
 
 type Query {

--- a/src/graphql/schema/uuid/abstract-uuid/types.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/types.ts
@@ -19,8 +19,13 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { AbstractUuid, QueryUuidArgs } from '../../../../types'
-import { QueryResolver, TypeResolver } from '../../types'
+import { Connection, AbstractNotificationEventPayload } from '../..'
+import {
+  AbstractUuid,
+  QueryUuidArgs,
+  AbstractUuidUuidEventsArgs,
+} from '../../../../types'
+import { QueryResolver, TypeResolver, Resolver } from '../../types'
 import {
   EntityPayload,
   EntityRevisionPayload,
@@ -47,8 +52,16 @@ export type UuidPayload =
   | PageRevisionPayload
   | UserPayload
   | TaxonomyTermPayload
-export interface AbstractUuidPayload extends AbstractUuid {
+export interface AbstractUuidPayload extends Omit<AbstractUuid, 'uuidEvents'> {
   __typename: UuidType
+}
+
+export interface AbstractUuidResolvers<Payload extends AbstractUuidPayload> {
+  uuidEvents: Resolver<
+    Payload,
+    AbstractUuidUuidEventsArgs,
+    Connection<AbstractNotificationEventPayload>
+  >
 }
 
 export interface UuidResolvers {

--- a/src/graphql/schema/uuid/abstract-uuid/utils.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/utils.ts
@@ -19,10 +19,18 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
+import { GraphQLResolveInfo } from 'graphql'
 import * as R from 'ramda'
 
+import { AbstractUuidUuidEventsArgs } from '../../../../types'
+import { resolvers as notificationResolvers } from '../../notification/resolvers'
+import { Context } from '../../types'
 import { EntityRevisionType, EntityType } from '../abstract-entity'
-import { AbstractUuidPayload, DiscriminatorType } from './types'
+import {
+  AbstractUuidPayload,
+  DiscriminatorType,
+  AbstractUuidResolvers,
+} from './types'
 
 const validTypes = [
   ...Object.values(DiscriminatorType),
@@ -32,4 +40,24 @@ const validTypes = [
 
 export function isUnsupportedUuid(payload: AbstractUuidPayload) {
   return !R.includes(payload.__typename, validTypes)
+}
+
+export function createAbstractUuidResolvers<
+  Payload extends AbstractUuidPayload
+>(): AbstractUuidResolvers<Payload> {
+  return {
+    async uuidEvents(
+      uuid: AbstractUuidPayload,
+      payload: AbstractUuidUuidEventsArgs,
+      context: Context,
+      info: GraphQLResolveInfo
+    ) {
+      return notificationResolvers.Query.events(
+        undefined,
+        { ...payload, uuid: uuid.id },
+        context,
+        info
+      )
+    },
+  }
 }

--- a/src/graphql/schema/uuid/applet/types.graphql
+++ b/src/graphql/schema/uuid/applet/types.graphql
@@ -13,6 +13,12 @@ type Applet implements AbstractUuid & AbstractRepository & AbstractEntity & Abst
     last: Int
     unrevised: Boolean
   ): AppletRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   taxonomyTerms(
     after: String
     before: String
@@ -25,6 +31,12 @@ type AppletRevision implements AbstractUuid & AbstractRevision & AbstractEntityR
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: Applet!
   url: String!

--- a/src/graphql/schema/uuid/article/types.graphql
+++ b/src/graphql/schema/uuid/article/types.graphql
@@ -13,6 +13,12 @@ type Article implements AbstractUuid & AbstractRepository & AbstractEntity & Abs
     last: Int
     unrevised: Boolean
   ): ArticleRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   taxonomyTerms(
     after: String
     before: String
@@ -25,6 +31,12 @@ type ArticleRevision implements AbstractUuid & AbstractRevision & AbstractEntity
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: Article!
   title: String!

--- a/src/graphql/schema/uuid/course-page/types.graphql
+++ b/src/graphql/schema/uuid/course-page/types.graphql
@@ -13,6 +13,12 @@ type CoursePage implements AbstractUuid & AbstractRepository & AbstractEntity {
     last: Int
     unrevised: Boolean
   ): CoursePageRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   course: Course!
 }
 
@@ -20,6 +26,12 @@ type CoursePageRevision implements AbstractUuid & AbstractRevision & AbstractEnt
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: CoursePage!
   title: String!

--- a/src/graphql/schema/uuid/course/types.graphql
+++ b/src/graphql/schema/uuid/course/types.graphql
@@ -13,6 +13,12 @@ type Course implements AbstractUuid & AbstractRepository & AbstractEntity & Abst
     last: Int
     unrevised: Boolean
   ): CourseRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   taxonomyTerms(
     after: String
     before: String
@@ -26,6 +32,12 @@ type CourseRevision implements AbstractUuid & AbstractRevision & AbstractEntityR
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: Course!
   title: String!

--- a/src/graphql/schema/uuid/event/types.graphql
+++ b/src/graphql/schema/uuid/event/types.graphql
@@ -13,6 +13,12 @@ type Event implements AbstractUuid & AbstractRepository & AbstractEntity & Abstr
     last: Int
     unrevised: Boolean
   ): EventRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   taxonomyTerms(
     after: String
     before: String
@@ -25,6 +31,12 @@ type EventRevision implements AbstractUuid & AbstractRevision & AbstractEntityRe
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: Event!
   title: String!

--- a/src/graphql/schema/uuid/exercise-group/types.graphql
+++ b/src/graphql/schema/uuid/exercise-group/types.graphql
@@ -13,6 +13,12 @@ type ExerciseGroup implements AbstractUuid & AbstractRepository & AbstractEntity
     last: Int
     unrevised: Boolean
   ): ExerciseGroupRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   taxonomyTerms(
     after: String
     before: String
@@ -26,6 +32,12 @@ type ExerciseGroupRevision implements AbstractUuid & AbstractRevision & Abstract
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: ExerciseGroup!
   content: String!

--- a/src/graphql/schema/uuid/exercise/types.graphql
+++ b/src/graphql/schema/uuid/exercise/types.graphql
@@ -13,6 +13,12 @@ type Exercise implements AbstractUuid & AbstractRepository & AbstractEntity & Ab
     last: Int
     unrevised: Boolean
   ): ExerciseRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   taxonomyTerms(
     after: String
     before: String
@@ -26,6 +32,12 @@ type ExerciseRevision implements AbstractUuid & AbstractRevision & AbstractEntit
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: Exercise!
   content: String!

--- a/src/graphql/schema/uuid/grouped-exercise/types.graphql
+++ b/src/graphql/schema/uuid/grouped-exercise/types.graphql
@@ -13,6 +13,12 @@ type GroupedExercise implements AbstractUuid & AbstractRepository & AbstractEnti
     last: Int
     unrevised: Boolean
   ): GroupedExerciseRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   solution: Solution
   exerciseGroup: ExerciseGroup!
 }
@@ -21,6 +27,12 @@ type GroupedExerciseRevision implements AbstractUuid & AbstractRevision & Abstra
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: GroupedExercise!
   content: String!

--- a/src/graphql/schema/uuid/page/types.graphql
+++ b/src/graphql/schema/uuid/page/types.graphql
@@ -13,6 +13,12 @@ type Page implements AbstractUuid & AbstractRepository & AbstractNavigationChild
     last: Int
     unrevised: Boolean
   ): PageRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   navigation: Navigation
 }
 
@@ -20,6 +26,12 @@ type PageRevision implements AbstractUuid & AbstractRevision {
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   title: String!
   content: String!

--- a/src/graphql/schema/uuid/solution/types.graphql
+++ b/src/graphql/schema/uuid/solution/types.graphql
@@ -13,6 +13,12 @@ type Solution implements AbstractUuid & AbstractRepository & AbstractEntity {
     last: Int
     unrevised: Boolean
   ): SolutionRevisionConnection
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   exercise: AbstractExercise!
 }
 
@@ -20,6 +26,12 @@ type SolutionRevision implements AbstractUuid & AbstractRevision & AbstractEntit
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: Solution!
   content: String!

--- a/src/graphql/schema/uuid/taxonomy-term/resolvers.ts
+++ b/src/graphql/schema/uuid/taxonomy-term/resolvers.ts
@@ -22,11 +22,13 @@
 import { resolveConnection } from '../../connection'
 import { Context } from '../../types'
 import { isNotNil } from '../../utils'
+import { createAbstractUuidResolvers } from '../abstract-uuid'
 import { createAliasResolvers } from '../alias'
 import { TaxonomyTermPayload, TaxonomyTermResolvers } from './types'
 
 export const resolvers: TaxonomyTermResolvers = {
   TaxonomyTerm: {
+    ...createAbstractUuidResolvers<TaxonomyTermPayload>(),
     ...createAliasResolvers<TaxonomyTermPayload>(),
     async parent(taxonomyTerm, _args, { dataSources }) {
       if (!taxonomyTerm.parentId) return null

--- a/src/graphql/schema/uuid/taxonomy-term/types.graphql
+++ b/src/graphql/schema/uuid/taxonomy-term/types.graphql
@@ -18,6 +18,12 @@ type TaxonomyTerm implements AbstractUuid & AbstractNavigationChild {
   type: TaxonomyTermType!
   instance: Instance!
   alias: String
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   name: String!
   description: String
   weight: Int!

--- a/src/graphql/schema/uuid/taxonomy-term/types.ts
+++ b/src/graphql/schema/uuid/taxonomy-term/types.ts
@@ -23,7 +23,11 @@ import { TaxonomyTermChildrenArgs, TaxonomyTerm } from '../../../../types'
 import { Connection } from '../../connection'
 import { Resolver } from '../../types'
 import { NavigationChildResolvers } from '../abstract-navigation-child'
-import { AbstractUuidPayload, DiscriminatorType } from '../abstract-uuid'
+import {
+  AbstractUuidPayload,
+  DiscriminatorType,
+  AbstractUuidResolvers,
+} from '../abstract-uuid'
 import { AliasResolvers } from '../alias'
 
 export interface TaxonomyTermPayload
@@ -43,5 +47,6 @@ export interface TaxonomyTermResolvers {
       Connection<AbstractUuidPayload>
     >
   } & AliasResolvers<TaxonomyTermPayload> &
-    NavigationChildResolvers<TaxonomyTermPayload>
+    NavigationChildResolvers<TaxonomyTermPayload> &
+    AbstractUuidResolvers<TaxonomyTermPayload>
 }

--- a/src/graphql/schema/uuid/user/resolvers.ts
+++ b/src/graphql/schema/uuid/user/resolvers.ts
@@ -72,7 +72,7 @@ export const resolvers: UserResolvers = {
     async activeReviewer(user, _args, { dataSources }) {
       return (await dataSources.serlo.getActiveReviewerIds()).includes(user.id)
     },
-    async events(user, payload, context, info) {
+    async userEvents(user, payload, context, info) {
       return notificationResolvers.Query.events(
         undefined,
         { ...payload, userId: user.id },

--- a/src/graphql/schema/uuid/user/resolvers.ts
+++ b/src/graphql/schema/uuid/user/resolvers.ts
@@ -31,6 +31,7 @@ import {
 import { ConnectionPayload, resolveConnection } from '../../connection'
 import { resolvers as notificationResolvers } from '../../notification/resolvers'
 import { Context } from '../../types'
+import { createAbstractUuidResolvers } from '../abstract-uuid'
 import { UserResolvers, isUserPayload } from './types'
 
 export const resolvers: UserResolvers = {
@@ -58,6 +59,7 @@ export const resolvers: UserResolvers = {
     },
   },
   User: {
+    ...createAbstractUuidResolvers<UserPayload>(),
     alias(user) {
       return Promise.resolve(encodePath(`/user/profile/${user.username}`))
     },

--- a/src/graphql/schema/uuid/user/resolvers.ts
+++ b/src/graphql/schema/uuid/user/resolvers.ts
@@ -29,6 +29,7 @@ import {
   CellValues,
 } from '../../../data-sources/google-spreadsheet-api'
 import { ConnectionPayload, resolveConnection } from '../../connection'
+import { resolvers as notificationResolvers } from '../../notification/resolvers'
 import { Context } from '../../types'
 import { UserResolvers, isUserPayload } from './types'
 
@@ -70,6 +71,14 @@ export const resolvers: UserResolvers = {
     },
     async activeReviewer(user, _args, { dataSources }) {
       return (await dataSources.serlo.getActiveReviewerIds()).includes(user.id)
+    },
+    async events(user, payload, context, info) {
+      return notificationResolvers.Query.events(
+        undefined,
+        { ...payload, userId: user.id },
+        context,
+        info
+      )
     },
   },
 }

--- a/src/graphql/schema/uuid/user/types.graphql
+++ b/src/graphql/schema/uuid/user/types.graphql
@@ -9,6 +9,12 @@ type User implements AbstractUuid {
   activeAuthor: Boolean!
   activeDonor: Boolean!
   activeReviewer: Boolean!
+  events(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
 }
 
 extend type Query {

--- a/src/graphql/schema/uuid/user/types.graphql
+++ b/src/graphql/schema/uuid/user/types.graphql
@@ -2,6 +2,12 @@ type User implements AbstractUuid {
   id: Int!
   trashed: Boolean!
   alias: String!
+  userEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   username: String!
   date: DateTime!
   lastLogin: DateTime
@@ -9,12 +15,6 @@ type User implements AbstractUuid {
   activeAuthor: Boolean!
   activeDonor: Boolean!
   activeReviewer: Boolean!
-  events(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): AbstractNotificationEventConnection!
 }
 
 extend type Query {

--- a/src/graphql/schema/uuid/user/types.graphql
+++ b/src/graphql/schema/uuid/user/types.graphql
@@ -8,6 +8,12 @@ type User implements AbstractUuid {
     first: Int
     last: Int
   ): AbstractNotificationEventConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   username: String!
   date: DateTime!
   lastLogin: DateTime

--- a/src/graphql/schema/uuid/user/types.ts
+++ b/src/graphql/schema/uuid/user/types.ts
@@ -20,11 +20,13 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 
+import { AbstractNotificationEventPayload } from '../..'
 import {
   QueryActiveDonorsArgs,
   User,
   QueryActiveReviewersArgs,
   QueryActiveAuthorsArgs,
+  UserEventsArgs,
 } from '../../../../types'
 import { Connection } from '../../connection'
 import { QueryResolver, Resolver } from '../../types'
@@ -51,6 +53,11 @@ export interface UserResolvers {
     activeAuthor: Resolver<UserPayload, never, boolean>
     activeDonor: Resolver<UserPayload, never, boolean>
     activeReviewer: Resolver<UserPayload, never, boolean>
+    events: Resolver<
+      UserPayload,
+      UserEventsArgs,
+      Connection<AbstractNotificationEventPayload>
+    >
   }
 }
 

--- a/src/graphql/schema/uuid/user/types.ts
+++ b/src/graphql/schema/uuid/user/types.ts
@@ -26,7 +26,7 @@ import {
   User,
   QueryActiveReviewersArgs,
   QueryActiveAuthorsArgs,
-  UserEventsArgs,
+  UserUserEventsArgs,
 } from '../../../../types'
 import { Connection } from '../../connection'
 import { QueryResolver, Resolver } from '../../types'
@@ -53,9 +53,9 @@ export interface UserResolvers {
     activeAuthor: Resolver<UserPayload, never, boolean>
     activeDonor: Resolver<UserPayload, never, boolean>
     activeReviewer: Resolver<UserPayload, never, boolean>
-    events: Resolver<
+    userEvents: Resolver<
       UserPayload,
-      UserEventsArgs,
+      UserUserEventsArgs,
       Connection<AbstractNotificationEventPayload>
     >
   }

--- a/src/graphql/schema/uuid/user/types.ts
+++ b/src/graphql/schema/uuid/user/types.ts
@@ -30,7 +30,11 @@ import {
 } from '../../../../types'
 import { Connection } from '../../connection'
 import { QueryResolver, Resolver } from '../../types'
-import { AbstractUuidPayload, DiscriminatorType } from '../abstract-uuid'
+import {
+  AbstractUuidPayload,
+  DiscriminatorType,
+  AbstractUuidResolvers,
+} from '../abstract-uuid'
 
 export interface UserPayload extends Omit<User, keyof UserResolvers['User']> {
   __typename: DiscriminatorType.User
@@ -58,7 +62,7 @@ export interface UserResolvers {
       UserUserEventsArgs,
       Connection<AbstractNotificationEventPayload>
     >
-  }
+  } & AbstractUuidResolvers<UserPayload>
 }
 
 export function isUserPayload(

--- a/src/graphql/schema/uuid/video/types.graphql
+++ b/src/graphql/schema/uuid/video/types.graphql
@@ -13,6 +13,12 @@ type Video implements AbstractUuid & AbstractRepository & AbstractEntity & Abstr
     last: Int
     unrevised: Boolean
   ): VideoRevisionConnection!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   taxonomyTerms(
     after: String
     before: String
@@ -25,6 +31,12 @@ type VideoRevision implements AbstractUuid & AbstractRevision & AbstractEntityRe
   id: Int!
   author: User!
   trashed: Boolean!
+  uuidEvents(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AbstractNotificationEventConnection!
   date: DateTime!
   repository: Video!
   url: String!

--- a/src/types.ts
+++ b/src/types.ts
@@ -495,6 +495,15 @@ export type TaxonomyTermEdge = {
 export type AbstractUuid = {
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
+};
+
+
+export type AbstractUuidUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type AliasInput = {
@@ -512,6 +521,7 @@ export type Applet = AbstractUuid & AbstractRepository & AbstractEntity & Abstra
   license: License;
   currentRevision?: Maybe<AppletRevision>;
   revisions: AppletRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -522,6 +532,14 @@ export type AppletRevisionsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type AppletUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -537,6 +555,7 @@ export type AppletRevision = AbstractUuid & AbstractRevision & AbstractEntityRev
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: Applet;
   url: Scalars['String'];
@@ -545,6 +564,14 @@ export type AppletRevision = AbstractUuid & AbstractRevision & AbstractEntityRev
   changes: Scalars['String'];
   metaTitle: Scalars['String'];
   metaDescription: Scalars['String'];
+};
+
+
+export type AppletRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type AppletRevisionConnection = {
@@ -571,6 +598,7 @@ export type Article = AbstractUuid & AbstractRepository & AbstractEntity & Abstr
   license: License;
   currentRevision?: Maybe<ArticleRevision>;
   revisions: ArticleRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -581,6 +609,14 @@ export type ArticleRevisionsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ArticleUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -596,6 +632,7 @@ export type ArticleRevision = AbstractUuid & AbstractRevision & AbstractEntityRe
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: Article;
   title: Scalars['String'];
@@ -603,6 +640,14 @@ export type ArticleRevision = AbstractUuid & AbstractRevision & AbstractEntityRe
   changes: Scalars['String'];
   metaTitle: Scalars['String'];
   metaDescription: Scalars['String'];
+};
+
+
+export type ArticleRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type ArticleRevisionConnection = {
@@ -629,6 +674,7 @@ export type CoursePage = AbstractUuid & AbstractRepository & AbstractEntity & {
   license: License;
   currentRevision?: Maybe<CoursePageRevision>;
   revisions: CoursePageRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   course: Course;
 };
 
@@ -641,16 +687,33 @@ export type CoursePageRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
+
+export type CoursePageUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
 export type CoursePageRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
   __typename?: 'CoursePageRevision';
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: CoursePage;
   title: Scalars['String'];
   content: Scalars['String'];
   changes: Scalars['String'];
+};
+
+
+export type CoursePageRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type CoursePageRevisionConnection = {
@@ -677,6 +740,7 @@ export type Course = AbstractUuid & AbstractRepository & AbstractEntity & Abstra
   license: License;
   currentRevision?: Maybe<CourseRevision>;
   revisions: CourseRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   taxonomyTerms: TaxonomyTermConnection;
   pages: Array<CoursePage>;
 };
@@ -688,6 +752,14 @@ export type CourseRevisionsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type CourseUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -703,12 +775,21 @@ export type CourseRevision = AbstractUuid & AbstractRevision & AbstractEntityRev
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: Course;
   title: Scalars['String'];
   content: Scalars['String'];
   changes: Scalars['String'];
   metaDescription: Scalars['String'];
+};
+
+
+export type CourseRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type CourseRevisionConnection = {
@@ -735,6 +816,7 @@ export type Event = AbstractUuid & AbstractRepository & AbstractEntity & Abstrac
   license: License;
   currentRevision?: Maybe<EventRevision>;
   revisions: EventRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -745,6 +827,14 @@ export type EventRevisionsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type EventUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -760,6 +850,7 @@ export type EventRevision = AbstractUuid & AbstractRevision & AbstractEntityRevi
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: Event;
   title: Scalars['String'];
@@ -767,6 +858,14 @@ export type EventRevision = AbstractUuid & AbstractRevision & AbstractEntityRevi
   changes: Scalars['String'];
   metaTitle: Scalars['String'];
   metaDescription: Scalars['String'];
+};
+
+
+export type EventRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type EventRevisionConnection = {
@@ -793,6 +892,7 @@ export type ExerciseGroup = AbstractUuid & AbstractRepository & AbstractEntity &
   license: License;
   currentRevision?: Maybe<ExerciseGroupRevision>;
   revisions: ExerciseGroupRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   taxonomyTerms: TaxonomyTermConnection;
   exercises: Array<GroupedExercise>;
 };
@@ -804,6 +904,14 @@ export type ExerciseGroupRevisionsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ExerciseGroupUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -819,10 +927,19 @@ export type ExerciseGroupRevision = AbstractUuid & AbstractRevision & AbstractEn
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: ExerciseGroup;
   content: Scalars['String'];
   changes: Scalars['String'];
+};
+
+
+export type ExerciseGroupRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type ExerciseGroupRevisionConnection = {
@@ -849,6 +966,7 @@ export type Exercise = AbstractUuid & AbstractRepository & AbstractEntity & Abst
   license: License;
   currentRevision?: Maybe<ExerciseRevision>;
   revisions: ExerciseRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   taxonomyTerms: TaxonomyTermConnection;
   solution?: Maybe<Solution>;
 };
@@ -860,6 +978,14 @@ export type ExerciseRevisionsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ExerciseUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -875,10 +1001,19 @@ export type ExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityR
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: Exercise;
   content: Scalars['String'];
   changes: Scalars['String'];
+};
+
+
+export type ExerciseRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type ExerciseRevisionConnection = {
@@ -905,6 +1040,7 @@ export type GroupedExercise = AbstractUuid & AbstractRepository & AbstractEntity
   license: License;
   currentRevision?: Maybe<GroupedExerciseRevision>;
   revisions: GroupedExerciseRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   solution?: Maybe<Solution>;
   exerciseGroup: ExerciseGroup;
 };
@@ -918,15 +1054,32 @@ export type GroupedExerciseRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
+
+export type GroupedExerciseUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
 export type GroupedExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & {
   __typename?: 'GroupedExerciseRevision';
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: GroupedExercise;
   content: Scalars['String'];
   changes: Scalars['String'];
+};
+
+
+export type GroupedExerciseRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type GroupedExerciseRevisionConnection = {
@@ -953,6 +1106,7 @@ export type Page = AbstractUuid & AbstractRepository & AbstractNavigationChild &
   license: License;
   currentRevision?: Maybe<PageRevision>;
   revisions: PageRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   navigation?: Maybe<Navigation>;
 };
 
@@ -965,15 +1119,32 @@ export type PageRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
+
+export type PageUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
 export type PageRevision = AbstractUuid & AbstractRevision & {
   __typename?: 'PageRevision';
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   title: Scalars['String'];
   content: Scalars['String'];
   repository: Page;
+};
+
+
+export type PageRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type PageRevisionConnection = {
@@ -1000,6 +1171,7 @@ export type Solution = AbstractUuid & AbstractRepository & AbstractEntity & {
   license: License;
   currentRevision?: Maybe<SolutionRevision>;
   revisions?: Maybe<SolutionRevisionConnection>;
+  uuidEvents: AbstractNotificationEventConnection;
   exercise: AbstractExercise;
 };
 
@@ -1012,15 +1184,32 @@ export type SolutionRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
+
+export type SolutionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
 export type SolutionRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
   __typename?: 'SolutionRevision';
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: Solution;
   content: Scalars['String'];
   changes: Scalars['String'];
+};
+
+
+export type SolutionRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type SolutionRevisionConnection = {
@@ -1058,12 +1247,21 @@ export type TaxonomyTerm = AbstractUuid & AbstractNavigationChild & {
   type: TaxonomyTermType;
   instance: Instance;
   alias?: Maybe<Scalars['String']>;
+  uuidEvents: AbstractNotificationEventConnection;
   name: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   weight: Scalars['Int'];
   parent?: Maybe<TaxonomyTerm>;
   children: AbstractUuidConnection;
   navigation?: Maybe<Navigation>;
+};
+
+
+export type TaxonomyTermUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -1104,6 +1302,7 @@ export type User = AbstractUuid & {
   trashed: Scalars['Boolean'];
   alias: Scalars['String'];
   userEvents: AbstractNotificationEventConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   username: Scalars['String'];
   date: Scalars['DateTime'];
   lastLogin?: Maybe<Scalars['DateTime']>;
@@ -1115,6 +1314,14 @@ export type User = AbstractUuid & {
 
 
 export type UserUserEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
+
+export type UserUuidEventsArgs = {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
@@ -1145,6 +1352,7 @@ export type Video = AbstractUuid & AbstractRepository & AbstractEntity & Abstrac
   license: License;
   currentRevision?: Maybe<VideoRevision>;
   revisions: VideoRevisionConnection;
+  uuidEvents: AbstractNotificationEventConnection;
   taxonomyTerms: TaxonomyTermConnection;
 };
 
@@ -1155,6 +1363,14 @@ export type VideoRevisionsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   unrevised?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type VideoUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 
@@ -1170,12 +1386,21 @@ export type VideoRevision = AbstractUuid & AbstractRevision & AbstractEntityRevi
   id: Scalars['Int'];
   author: User;
   trashed: Scalars['Boolean'];
+  uuidEvents: AbstractNotificationEventConnection;
   date: Scalars['DateTime'];
   repository: Video;
   url: Scalars['String'];
   title: Scalars['String'];
   content: Scalars['String'];
   changes: Scalars['String'];
+};
+
+
+export type VideoRevisionUuidEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type VideoRevisionConnection = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1110,6 +1110,15 @@ export type User = AbstractUuid & {
   activeAuthor: Scalars['Boolean'];
   activeDonor: Scalars['Boolean'];
   activeReviewer: Scalars['Boolean'];
+  events: AbstractNotificationEventConnection;
+};
+
+
+export type UserEventsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type UserConnection = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1103,6 +1103,7 @@ export type User = AbstractUuid & {
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
   alias: Scalars['String'];
+  userEvents: AbstractNotificationEventConnection;
   username: Scalars['String'];
   date: Scalars['DateTime'];
   lastLogin?: Maybe<Scalars['DateTime']>;
@@ -1110,11 +1111,10 @@ export type User = AbstractUuid & {
   activeAuthor: Scalars['Boolean'];
   activeDonor: Scalars['Boolean'];
   activeReviewer: Scalars['Boolean'];
-  events: AbstractNotificationEventConnection;
 };
 
 
-export type UserEventsArgs = {
+export type UserUserEventsArgs = {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,8 @@ export type QueryEventsArgs = {
   before?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  entityId?: Maybe<Scalars['Int']>;
 };
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export type QueryEventsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  entityId?: Maybe<Scalars['Int']>;
+  uuid?: Maybe<Scalars['Int']>;
 };
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type Query = {
   activeAuthors: UserConnection;
   activeDonors: UserConnection;
   activeReviewers: UserConnection;
+  events: AbstractNotificationEventConnection;
   license?: Maybe<License>;
   notificationEvent?: Maybe<AbstractNotificationEvent>;
   notifications: NotificationConnection;
@@ -50,6 +51,14 @@ export type QueryActiveDonorsArgs = {
 
 
 export type QueryActiveReviewersArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryEventsArgs = {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
@@ -342,6 +351,20 @@ export type NotificationEdge = {
   __typename?: 'NotificationEdge';
   cursor: Scalars['String'];
   node: Notification;
+};
+
+export type AbstractNotificationEventConnection = {
+  __typename?: 'AbstractNotificationEventConnection';
+  edges: Array<AbstractNotificationEventEdge>;
+  nodes: Array<AbstractNotificationEvent>;
+  totalCount: Scalars['Int'];
+  pageInfo: PageInfo;
+};
+
+export type AbstractNotificationEventEdge = {
+  __typename?: 'AbstractNotificationEventEdge';
+  cursor: Scalars['String'];
+  node: AbstractNotificationEvent;
 };
 
 export type AbstractEntity = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "importHelpers": true,
-    "lib": ["esnext", "dom"],
+    "lib": ["esnext"],
     "module": "commonjs",
     "moduleResolution": "node",
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "importHelpers": true,
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,6 +10687,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-essentials@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.0.tgz#eb807945d65e258bae8914f541543758f879f6c5"
+  integrity sha512-DptrzFAwb5afnsTdKxfScHqLbVZHl7YsxvDT+iT8tbXWFGSzbXALhfWlal25HBesqlX0NZd6wz9KBGnJcWScdQ==
+
 ts-invariant@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"


### PR DESCRIPTION
Fixes #69 
(Needs #87 and #84 )

Todos:

- [ ] Rename `AbstractUuid.uuidEvents` to `AbstractUuid.events` (wait for discussion https://github.com/serlo/api.serlo.org/pull/88#discussion_r500891164 )
- [ ] Add `instance` filter to `Query.events`
- [x] Make http://de.serlo.localhost:4567/api/event/86590 independent of instance (shall always return the event data)