### PR TITLE
tests: Add onUnhandledRequest=error to mws

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -23,7 +23,7 @@ import { setupServer } from 'msw/node'
 
 global.server = setupServer()
 
-beforeAll(() => global.server.listen())
+beforeAll(() => global.server.listen({ onUnhandledRequest: 'error' }))
 
 afterEach(() => global.server.resetHandlers())
 


### PR DESCRIPTION
Adds the option `onUnhandledRequest` to msw so that unhandeld requests are printed to `std.err`. (Thus we can better detect them). See https://mswjs.io/docs/api/setup-server/listen#onunhandledrequest