### PR TITLE
Refactor __tests__/schema/connection.ts

### DIFF
--- a/__tests__/schema/connection.ts
+++ b/__tests__/schema/connection.ts
@@ -21,91 +21,121 @@
  */
 import * as R from 'ramda'
 
-import { ConnectionPayload, resolveConnection } from '../../src/graphql/schema'
+import {
+  ConnectionPayload,
+  resolveConnection,
+  Connection,
+} from '../../src/graphql/schema'
 
 describe('resolveConnection', () => {
-  const nodes = R.range(1, 10)
-  const edges = R.map((node) => {
-    return {
-      cursor: Buffer.from(node.toString()).toString('base64'),
-      node,
-    }
-  }, nodes)
-  function getResult(payload: ConnectionPayload) {
-    return resolveConnection({
-      nodes,
-      payload,
-      createCursor(node: number) {
-        return node.toString()
-      },
+  describe('cursor', () => {
+    let cursors: string[]
+
+    beforeAll(() => {
+      cursors = getCursors(R.range(0, 1000))
     })
+
+    test('is uniq for each node', () => {
+      expect(R.uniq(cursors).length).toBe(1000)
+    })
+
+    test('is a short string (length < 7)', () => {
+      const maxLength = cursors.map((cursor) => cursor.length).reduce(R.max)
+
+      expect(maxLength).toBeLessThan(7)
+    })
+  })
+
+  describe('results', () => {
+    const nodes = R.range(1, 10)
+    let edges: Connection<number>['edges']
+
+    beforeAll(() => {
+      edges = R.zip(nodes, getCursors(nodes)).map(([node, cursor]) => {
+        return { node, cursor }
+      })
+    })
+
+    test('without payload', () => {
+      expect(getResult({})).toEqual({
+        edges,
+        nodes,
+        totalCount: 9,
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: edges[0].cursor,
+          endCursor: edges[8].cursor,
+        },
+      })
+    })
+
+    test('forward pagination (by 5)', () => {
+      const page1 = getResult({ first: 5 })
+      expect(page1).toEqual({
+        edges: edges.slice(0, 5),
+        nodes: nodes.slice(0, 5),
+        totalCount: 9,
+        pageInfo: {
+          hasNextPage: true,
+          hasPreviousPage: false,
+          startCursor: edges[0].cursor,
+          endCursor: edges[4].cursor,
+        },
+      })
+
+      const page2 = getResult({ first: 5, after: page1.pageInfo.endCursor! })
+      expect(page2).toEqual({
+        edges: edges.slice(5, 9),
+        nodes: nodes.slice(5, 9),
+        totalCount: 9,
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: true,
+          startCursor: edges[5].cursor,
+          endCursor: edges[8].cursor,
+        },
+      })
+    })
+
+    test('backward pagination (by 5)', () => {
+      const page1 = getResult({ last: 5 })
+      expect(page1).toEqual({
+        edges: edges.slice(4, 9),
+        nodes: nodes.slice(4, 9),
+        totalCount: 9,
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: true,
+          startCursor: edges[4].cursor,
+          endCursor: edges[8].cursor,
+        },
+      })
+
+      const page2 = getResult({ last: 5, before: page1.pageInfo.startCursor! })
+      expect(page2).toEqual({
+        edges: edges.slice(0, 4),
+        nodes: nodes.slice(0, 4),
+        totalCount: 9,
+        pageInfo: {
+          hasNextPage: true,
+          hasPreviousPage: false,
+          startCursor: edges[0].cursor,
+          endCursor: edges[3].cursor,
+        },
+      })
+    })
+
+    function getResult(payload: ConnectionPayload) {
+      return createConnection(nodes, payload)
+    }
+  })
+
+  function getCursors(nodes: number[]) {
+    return createConnection(nodes).edges.map((edge) => edge.cursor)
   }
 
-  test('without payload', () => {
-    expect(getResult({})).toEqual({
-      edges,
-      nodes,
-      totalCount: 9,
-      pageInfo: {
-        hasNextPage: false,
-        hasPreviousPage: false,
-        startCursor: edges[0].cursor,
-        endCursor: edges[8].cursor,
-      },
-    })
-  })
-
-  test('forward pagination (by 5)', () => {
-    const page1 = getResult({ first: 5 })
-    expect(page1).toEqual({
-      edges: edges.slice(0, 5),
-      nodes: nodes.slice(0, 5),
-      totalCount: 9,
-      pageInfo: {
-        hasNextPage: true,
-        hasPreviousPage: false,
-        startCursor: edges[0].cursor,
-        endCursor: edges[4].cursor,
-      },
-    })
-    const page2 = getResult({ first: 5, after: page1.pageInfo.endCursor! })
-    expect(page2).toEqual({
-      edges: edges.slice(5, 9),
-      nodes: nodes.slice(5, 9),
-      totalCount: 9,
-      pageInfo: {
-        hasNextPage: false,
-        hasPreviousPage: true,
-        startCursor: edges[5].cursor,
-        endCursor: edges[8].cursor,
-      },
-    })
-  })
-
-  test('backward pagination (by 5)', () => {
-    const page1 = getResult({ last: 5 })
-    expect(page1).toEqual({
-      edges: edges.slice(4, 9),
-      nodes: nodes.slice(4, 9),
-      totalCount: 9,
-      pageInfo: {
-        hasNextPage: false,
-        hasPreviousPage: true,
-        startCursor: edges[4].cursor,
-        endCursor: edges[8].cursor,
-      },
-    })
-    const page2 = getResult({ last: 5, before: page1.pageInfo.startCursor! })
-    expect(page2).toEqual({
-      edges: edges.slice(0, 4),
-      nodes: nodes.slice(0, 4),
-      totalCount: 9,
-      pageInfo: {
-        hasNextPage: true,
-        hasPreviousPage: false,
-        startCursor: edges[0].cursor,
-        endCursor: edges[3].cursor,
-      },
-    })
-  })
+  function createConnection(nodes: number[], payload: ConnectionPayload = {}) {
+    return resolveConnection({ nodes, payload, createCursor: R.toString })
+  }
 })


### PR DESCRIPTION
@inyono This PR contains a possible improvement of `__tests__/schema/connection.ts`. I might use this commit in #88 when I test a lazy implementation of `resolveConnection()`. I do a separate PR to get feedback early (I suspect that we might want to discuss it) so that I can include it in my PR. Since I only refactored the current test, this PR can already be merged when you like it.