### PR TITLE
Feedback-PR: Events

### DIFF
--- a/__tests-pacts__/serlo.org/current-event.ts
+++ b/__tests-pacts__/serlo.org/current-event.ts
@@ -19,37 +19,19 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-/* eslint-disable import/no-unassigned-import */
-describe('GET /api/alias/:alias', () => {
-  require('./alias')
-})
-describe('GET /api/cache-keys', () => {
-  require('./cache-keys')
-})
-describe('GET /api/current-event-id', () => {
-  require('./current-event')
-})
-describe('GET /api/event/:id', () => {
-  require('./event')
-})
-describe('GET /api/license/:id', () => {
-  require('./license')
-})
-describe('GET /api/navigation', () => {
-  require('./navigation')
-})
-describe('GET /api/notifications/:id', () => {
-  require('./notifications')
-})
-describe('POST /api/set-notification-state/:id', () => {
-  require('./set-notification-state')
-})
-describe('GET /api/subscriptions', () => {
-  require('./subscriptions')
-})
-describe('GET /api/user/*', () => {
-  require('./user')
-})
-describe('GET /api/uuid/:id', () => {
-  require('./uuid')
+import { Matchers } from '@pact-foundation/pact'
+import fetch from 'node-fetch'
+
+import { addJsonInteraction } from '../__utils__'
+
+test('/api/current-event-id', async () => {
+  await addJsonInteraction({
+    name: 'fetch current event id',
+    given: 'current event id is 100',
+    path: '/api/current-event-id',
+    body: {
+      currentEventId: Matchers.integer(100),
+    },
+  })
+  await fetch(`http://de.${process.env.SERLO_ORG_HOST}/api/current-event-id`)
 })

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -1,0 +1,110 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { gql } from 'apollo-server'
+import * as R from 'ramda'
+
+import {
+  checkoutRevisionNotificationEvent,
+  rejectRevisionNotificationEvent,
+  createCommentNotificationEvent,
+  createEntityNotificationEvent,
+  createEntityLinkNotificationEvent,
+  removeEntityLinkNotificationEvent,
+  setLicenseNotificationEvent,
+  setUuidStateNotificationEvent,
+  createThreadNotificationEvent,
+  createTaxonomyLinkNotificationEvent,
+  createEntityRevisionNotificationEvent,
+  removeTaxonomyLinkNotificationEvent,
+  createTaxonomyTermNotificationEvent,
+  setTaxonomyTermNotificationEvent,
+  setThreadStateNotificationEvent,
+  user,
+} from '../../__fixtures__'
+import {
+  NotificationEventType,
+  NotificationEventPayload,
+} from '../../src/graphql/schema'
+import { Service } from '../../src/graphql/schema/types'
+import {
+  Client,
+  createTestClient,
+  createEventLogHandlers,
+  assertSuccessfulGraphQLQuery,
+} from '../__utils__'
+
+let client: Client
+
+beforeEach(() => {
+  client = createTestClient({
+    service: Service.SerloCloudflareWorker,
+    user: user.id,
+  }).client
+})
+
+const eventRepository: Record<
+  NotificationEventType,
+  NotificationEventPayload
+> = {
+  [NotificationEventType.CheckoutRevision]: checkoutRevisionNotificationEvent,
+  [NotificationEventType.RejectRevision]: rejectRevisionNotificationEvent,
+  [NotificationEventType.CreateComment]: createCommentNotificationEvent,
+  [NotificationEventType.SetLicense]: setLicenseNotificationEvent,
+  [NotificationEventType.CreateEntity]: createEntityNotificationEvent,
+  [NotificationEventType.CreateTaxonomyLink]: createTaxonomyLinkNotificationEvent,
+  [NotificationEventType.RemoveTaxonomyLink]: removeTaxonomyLinkNotificationEvent,
+  [NotificationEventType.CreateThread]: createThreadNotificationEvent,
+  [NotificationEventType.SetUuidState]: setUuidStateNotificationEvent,
+  [NotificationEventType.CreateEntityLink]: createEntityLinkNotificationEvent,
+  [NotificationEventType.RemoveEntityLink]: removeEntityLinkNotificationEvent,
+  [NotificationEventType.CreateEntityRevision]: createEntityRevisionNotificationEvent,
+  [NotificationEventType.CreateTaxonomyTerm]: createTaxonomyTermNotificationEvent,
+  [NotificationEventType.SetTaxonomyTerm]: setTaxonomyTermNotificationEvent,
+  [NotificationEventType.SetTaxonomyParent]: setTaxonomyTermNotificationEvent,
+  [NotificationEventType.SetThreadState]: setThreadStateNotificationEvent,
+}
+const events = R.values(eventRepository).map((event, id) => {
+  return { ...event, id }
+})
+
+test('without filter', async () => {
+  global.server.use(...createEventLogHandlers(events))
+
+  await assertSuccessfulGraphQLQuery({
+    query: gql`
+      query events {
+        events {
+          nodes {
+            __typename
+            id
+          }
+        }
+      }
+    `,
+    client,
+    data: { events: { nodes: events.map(getIdAndTypename) } },
+  })
+})
+
+function getIdAndTypename(event: NotificationEventPayload) {
+  return R.pick(['__typename', 'id'], event)
+}

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -58,6 +58,22 @@ export type AbstractNotificationEvent = {
 };
 
 // @public (undocumented)
+export type AbstractNotificationEventConnection = {
+    __typename?: 'AbstractNotificationEventConnection';
+    edges: Array<AbstractNotificationEventEdge>;
+    nodes: Array<AbstractNotificationEvent>;
+    totalCount: Scalars['Int'];
+    pageInfo: PageInfo;
+};
+
+// @public (undocumented)
+export type AbstractNotificationEventEdge = {
+    __typename?: 'AbstractNotificationEventEdge';
+    cursor: Scalars['String'];
+    node: AbstractNotificationEvent;
+};
+
+// @public (undocumented)
 export type AbstractRepository = {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -882,6 +898,7 @@ export type Query = {
     activeAuthors: UserConnection;
     activeDonors: UserConnection;
     activeReviewers: UserConnection;
+    events: AbstractNotificationEventConnection;
     license?: Maybe<License>;
     notificationEvent?: Maybe<AbstractNotificationEvent>;
     notifications: NotificationConnection;
@@ -915,6 +932,14 @@ export type QueryActiveDonorsArgs = {
 
 // @public (undocumented)
 export type QueryActiveReviewersArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
+export type QueryEventsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
     first?: Maybe<Scalars['Int']>;

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -162,6 +162,10 @@ export class SerloDataSource extends CacheableDataSource {
     return uuid === null || isUnsupportedUuid(uuid) ? null : uuid
   }
 
+  public async getCurrentEventId(): Promise<{ currentEventId: number }> {
+    return this.cacheAwareGet({ path: `/api/current-event-id`, ttl: 30 })
+  }
+
   public async getNotificationEvent<
     T extends AbstractNotificationEventPayload
   >({ id }: { id: number }): Promise<T | null> {

--- a/src/graphql/schema/connection/utils.ts
+++ b/src/graphql/schema/connection/utils.ts
@@ -98,3 +98,19 @@ export function resolveConnection<T>({
     return false
   }
 }
+
+export async function mapConnection<A, B>(
+  fetcher: (node: A) => Promise<B>,
+  connection: Connection<A>
+): Promise<Connection<B>> {
+  const newNodes = await Promise.all(connection.nodes.map(fetcher))
+  console.log(newNodes.findIndex(node => node === null))
+
+  return {
+    ...connection,
+    edges: newNodes.map((node, i) => {
+      return { node, cursor: connection.edges[i].cursor }
+    }),
+    nodes: newNodes,
+  }
+}

--- a/src/graphql/schema/notification/types.graphql
+++ b/src/graphql/schema/notification/types.graphql
@@ -12,6 +12,12 @@ interface AbstractNotificationEvent {
 }
 
 extend type Query {
+  events(
+    after: String
+	before: String
+	first: Int
+	last: Int
+  ): AbstractNotificationEventConnection!
   notifications(
     after: String
     before: String
@@ -36,4 +42,16 @@ type NotificationConnection {
 type NotificationEdge {
   cursor: String!
   node: Notification!
+}
+
+type AbstractNotificationEventConnection {
+  edges: [AbstractNotificationEventEdge!]!
+  nodes: [AbstractNotificationEvent!]!
+  totalCount: Int!
+  pageInfo: PageInfo!
+}
+
+type AbstractNotificationEventEdge {
+  cursor: String!
+  node: AbstractNotificationEvent!
 }

--- a/src/graphql/schema/notification/types.ts
+++ b/src/graphql/schema/notification/types.ts
@@ -25,6 +25,7 @@ import {
   Notification,
   QueryNotificationEventArgs,
   QueryNotificationsArgs,
+  QueryEventsArgs,
 } from '../../../types'
 import { Connection } from '../connection'
 import {
@@ -111,6 +112,10 @@ export interface NotificationResolvers {
     event: Resolver<NotificationPayload, never, NotificationEventPayload | null>
   }
   Query: {
+    events: QueryResolver<
+      QueryEventsArgs,
+      Connection<AbstractNotificationEventPayload>
+    >
     notifications: QueryResolver<
       QueryNotificationsArgs,
       Connection<NotificationPayload>

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type Query = {
   activeAuthors: UserConnection;
   activeDonors: UserConnection;
   activeReviewers: UserConnection;
+  events: AbstractNotificationEventConnection;
   license?: Maybe<License>;
   notificationEvent?: Maybe<AbstractNotificationEvent>;
   notifications: NotificationConnection;
@@ -51,6 +52,14 @@ export type QueryActiveDonorsArgs = {
 
 
 export type QueryActiveReviewersArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryEventsArgs = {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
@@ -351,6 +360,20 @@ export type NotificationEdge = {
   __typename?: 'NotificationEdge';
   cursor: Scalars['String'];
   node: Notification;
+};
+
+export type AbstractNotificationEventConnection = {
+  __typename?: 'AbstractNotificationEventConnection';
+  edges: Array<AbstractNotificationEventEdge>;
+  nodes: Array<AbstractNotificationEvent>;
+  totalCount: Scalars['Int'];
+  pageInfo: PageInfo;
+};
+
+export type AbstractNotificationEventEdge = {
+  __typename?: 'AbstractNotificationEventEdge';
+  cursor: Scalars['String'];
+  node: AbstractNotificationEvent;
 };
 
 export type QuerySubscriptionResult = {


### PR DESCRIPTION
@inyono This PR is just for getting feedback (tests, pacts and clean code is missing and in case of good feedback I will implement it).

I have the following idea how to fetch the events which seems to be promising for me: There is an endpoint `/api/event-ids` which returns a chunk of event-ids. It has the payload `{ eventIds: number[], hasNext: boolean }`. `hasNext === true` iff there are more event ids to fetch. With the parameter `after` we are able to fetch event ids after a certain id. The endpoint returns a predefined maximum amount of event-ids so that the response is not to big (like 50.000).

The code for retrieving all event ids is https://github.com/serlo/api.serlo.org/blob/6514ab1b503ed2c55590983a742be60feb5a4d14/src/graphql/data-sources/serlo.ts#L165-L195

The idea is:

1. There is a cache for all retrieved event ids with a certain filter (e.g. under the key `serlo.org/api/event-ids?user=1`)
2. This list is updated with the above endpoint as long as `hasNext === true` (the call to the above endpoint is cached with a certain `ttl` so that sccuessive calls are completely cached)

Afterwards the list of ids is passed to `resolveConnection` and a map-function is used to fetch the event data but only those we are interested in: https://github.com/serlo/api.serlo.org/blob/6514ab1b503ed2c55590983a742be60feb5a4d14/src/graphql/schema/notification/resolvers.ts#L49-L68 map-function: https://github.com/serlo/api.serlo.org/blob/6514ab1b503ed2c55590983a742be60feb5a4d14/src/graphql/schema/connection/utils.ts#L102-L116

Do you think this is in general a good idea? Then I would implement it. At the following you find a prototype implementation of the endpoint: https://github.com/serlo/serlo.org/blob/0c186e6f14e87a55d0bd4bd5d84c6868f25a3983/packages/public/server/src/module/Api/src/ApiManager.php#L356-L401

### What I have learned so far

Yesterday I implemented a dump solution which is https://github.com/serlo/api.serlo.org/blob/98df7fba1aa31e0ed5fb5b1357285adcbdd7b1c1/src/graphql/schema/notification/resolvers.ts#L49-L64

With this solution I ran into a heap overflow error -> I guess due to to many request calls in parallel. When I tried to fill the cache with querys to `{ notificationEvent(id: ...) { __typename } }` I noticed that subsequent 100 calls take 50s. Thus I would like to do the filtering of the events at serlo.org which lead me to the above solution. 