### PR TITLE
cache: Remove "ttl" option

### DIFF
--- a/__tests__/data-sources/cacheable-data-source.ts
+++ b/__tests__/data-sources/cacheable-data-source.ts
@@ -30,7 +30,7 @@ const now = jest.fn<number, never>()
 beforeEach(() => {
   now.mockReturnValue(Date.now())
 
-  cache = createInMemoryCache({ now })
+  cache = createInMemoryCache()
   dataSource = new ExampleDataSource({ cache, timer: { now } })
 })
 
@@ -132,80 +132,13 @@ describe('getFromCache()', () => {
   })
 })
 
-describe('setCache()', () => {
-  test('updates cached value', async () => {
-    await dataSource.setCache({
-      key: 'content',
-      update: () => Promise.resolve('Updated version'),
-    })
-
-    expect(await dataSource.getContent()).toBe('Updated version')
+test('setCache() updates cached value', async () => {
+  await dataSource.setCache({
+    key: 'content',
+    update: () => Promise.resolve('Updated version'),
   })
 
-  describe('when ttl is passed', () => {
-    test('returns cached value when passed time < ttl', async () => {
-      await dataSource.setCache({
-        key: 'content',
-        update: () => Promise.resolve('Updated version'),
-        ttl: 10,
-      })
-      waitFor(5)
-
-      expect(await dataSource.getContent()).toBe('Updated version')
-    })
-
-    test('returns current value when ttl < passed time', async () => {
-      dataSource.setContent('First version')
-      await dataSource.setCache({
-        key: 'content',
-        update: () => Promise.resolve('Updated version'),
-        ttl: 10,
-      })
-      waitFor(15)
-
-      expect(await dataSource.getContent()).toBe('First version')
-    })
-
-    test('does not use predefined ttl in cache', async () => {
-      await cache.set('content', 'Old version', { ttl: 10 })
-
-      await dataSource.setCache({
-        key: 'content',
-        update: () => Promise.resolve('Updated version'),
-        ttl: 20,
-      })
-      waitFor(15)
-
-      expect(await dataSource.getContent()).toBe('Updated version')
-    })
-  })
-
-  describe('when ttl is already stored in cache', () => {
-    test('returns cached value when passed time < ttl', async () => {
-      await cache.set('content', 'Old version', { ttl: 10 })
-
-      await dataSource.setCache({
-        key: 'content',
-        update: () => Promise.resolve('Updated version'),
-      })
-      waitFor(5)
-
-      expect(await dataSource.getContent()).toBe('Updated version')
-    })
-
-    test('returns current value when ttl < passed time', async () => {
-      await cache.set('content', 'Old version', { ttl: 10 })
-      dataSource.setContent('First version')
-
-      await dataSource.setCache({
-        key: 'content',
-        update: () => Promise.resolve('Updated version'),
-      })
-      waitFor(15)
-
-      expect(await dataSource.getContent()).toBe('First version')
-    })
-  })
+  expect(await dataSource.getContent()).toBe('Updated version')
 })
 
 function waitFor(seconds: number) {

--- a/src/cache/in-memory-cache.ts
+++ b/src/cache/in-memory-cache.ts
@@ -19,37 +19,21 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { option as O, pipeable } from 'fp-ts'
+import { option as O } from 'fp-ts'
 
-import { Cache, createTimer } from '../graphql/environment'
+import { Cache } from '../graphql/environment'
 
-interface Entry {
-  value: unknown
-  lastModified: number
-  ttl?: number
-}
-
-export function createInMemoryCache(timer = createTimer()): Cache {
-  let cache: Record<string, Entry> = {}
+export function createInMemoryCache(): Cache {
+  let cache: Record<string, unknown> = {}
 
   return {
     // eslint-disable-next-line @typescript-eslint/require-await
-    get: async <T>(key: string) => {
-      const isAlive = (x: Entry) => {
-        if (x.ttl === undefined) return true
-
-        return timer.now() - x.lastModified < x.ttl * 1000
-      }
-
-      return pipeable.pipe(
-        O.fromNullable(cache[key]),
-        O.chain(O.fromPredicate(isAlive)),
-        O.map((x) => x.value as T)
-      )
+    async get<T>(key: string) {
+      return O.fromNullable(cache[key] as T)
     },
     // eslint-disable-next-line @typescript-eslint/require-await
-    async set(key, value, options) {
-      cache[key] = { value, ttl: options?.ttl, lastModified: Date.now() }
+    async set(key, value) {
+      cache[key] = value
     },
     // eslint-disable-next-line @typescript-eslint/require-await
     async remove(key: string) {
@@ -58,14 +42,6 @@ export function createInMemoryCache(timer = createTimer()): Cache {
     // eslint-disable-next-line @typescript-eslint/require-await
     async flush() {
       cache = {}
-    },
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async getTtl(key: string): Promise<O.Option<number>> {
-      const value = cache[key]
-      return pipeable.pipe(
-        O.fromNullable(value),
-        O.chain((x) => O.fromNullable(x.ttl))
-      )
     },
   }
 }

--- a/src/graphql/data-sources/cacheable-data-source.ts
+++ b/src/graphql/data-sources/cacheable-data-source.ts
@@ -33,16 +33,11 @@ export abstract class CacheableDataSource extends RESTDataSource {
   public async setCache<Value>({
     key,
     update,
-    ttl,
   }: {
     key: string
     update: UpdateFunction<Value>
-    ttl?: number
   }): Promise<Value> {
-    ttl = ttl ?? O.toUndefined(await this.environment.cache.getTtl(key))
-    const newEntry = await this.setValue({ key, value: await update(), ttl })
-
-    return newEntry.value
+    return (await this.setValue({ key, value: await update() })).value
   }
 
   protected async getFromCache<Value>({
@@ -81,15 +76,13 @@ export abstract class CacheableDataSource extends RESTDataSource {
   private async setValue<Value>({
     key,
     value,
-    ttl,
   }: {
     key: string
     value: Value
-    ttl?: number
   }): Promise<Entry<Value>> {
     const newEntry = { value, lastModified: this.environment.timer.now() }
 
-    await this.environment.cache.set(key, newEntry, { ttl })
+    await this.environment.cache.set(key, newEntry)
 
     return newEntry
   }

--- a/src/graphql/environment.ts
+++ b/src/graphql/environment.ts
@@ -28,10 +28,9 @@ export interface Environment {
 
 export interface Cache {
   get<T>(key: string): Promise<O.Option<T>>
-  set(key: string, value: unknown, options?: { ttl?: number }): Promise<void>
+  set(key: string, value: unknown): Promise<void>
   remove(key: string): Promise<void>
   flush(): Promise<void>
-  getTtl(key: string): Promise<O.Option<number>>
 }
 
 export interface Timer {


### PR DESCRIPTION
This removes the `ttl` option from the cache since we do not need it anymore with the swr feature.