### PR TITLE
v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [v0.11.3](https://github.com/serlo/api.serlo.org/compare/v0.11.2..v0.11.3) - November 24, 2020
 
+### Fixed
+
+- Tweak `max-age`s of stale-while-revalidate caching.
+
 ### Internal
 
 - **alias**. Remove `source` and `timestamp` from `AliasPayload`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.11.0](https://github.com/serlo/api.serlo.org/compare/v0.10.1..v0.11.0) - November 18, 2020
+## [v0.11.3](https://github.com/serlo/api.serlo.org/compare/v0.11.2..v0.11.3) - November 24, 2020
+
+### Internal
+
+- **alias**. Remove `source` and `timestamp` from `AliasPayload`.
+
+## [v0.11.2](https://github.com/serlo/api.serlo.org/compare/v0.11.1..v0.11.2) - November 18, 2020
 
 ### Added
 
 - We now have a stale-while-revalidate caching approach in place. This should lead to more correct behavior even when our listeners fail.
 - **notification**. Add `objectId` to `AbstractNotificationEvent` which reports the ID of the object that triggered the event (and can be used to unsubscribe).
 - **uuid**. Add `threads`.
+
+## [v0.11.1](https://github.com/serlo/api.serlo.org/compare/v0.11.0..v0.11.1) - November 18, 2020 \[YANKED]
+
+## [v0.11.0](https://github.com/serlo/api.serlo.org/compare/v0.10.1..v0.11.0) - November 18, 2020 \[YANKED]
 
 ## [v0.10.1](https://github.com/serlo/api.serlo.org/compare/v0.10.0..v0.10.1) - October 14, 2020
 

--- a/__fixtures__/uuid/grouped-exercise.ts
+++ b/__fixtures__/uuid/grouped-exercise.ts
@@ -36,8 +36,6 @@ export const groupedExerciseAlias: AliasPayload = {
   id: 2219,
   instance: Instance.De,
   path: '/2219/2219',
-  source: '/entity/view/2219',
-  timestamp: '2014-05-25T10:25:44Z',
 }
 
 export const groupedExercise: GroupedExercisePayload = {

--- a/__fixtures__/uuid/solution.ts
+++ b/__fixtures__/uuid/solution.ts
@@ -36,8 +36,6 @@ export const solutionAlias: AliasPayload = {
   id: 29648,
   instance: Instance.De,
   path: '/29648/29648',
-  source: '/entity/view/29648',
-  timestamp: '2014-05-25T10:25:44Z',
 }
 
 export const solution: SolutionPayload = {

--- a/__tests-pacts__/serlo.org/alias.ts
+++ b/__tests-pacts__/serlo.org/alias.ts
@@ -32,8 +32,6 @@ test('Alias', async () => {
     id: 19767,
     instance: Instance.De,
     path: '/mathe',
-    source: '/page/view/19767',
-    timestamp: '2014-05-25T10:25:44+02:00',
   }
   await addJsonInteraction({
     name: 'fetch data of alias /mathe',
@@ -43,8 +41,6 @@ test('Alias', async () => {
       id: alias.id,
       instance: Matchers.string(alias.instance),
       path: Matchers.string(alias.path),
-      source: Matchers.string(alias.source),
-      timestamp: Matchers.iso8601DateTime(alias.timestamp),
     },
   })
   await fetch(`http://de.${process.env.SERLO_ORG_HOST}/api/alias/mathe`)

--- a/__tests__/schema/uuid/abstract-repository.ts
+++ b/__tests__/schema/uuid/abstract-repository.ts
@@ -189,8 +189,6 @@ describe('Repository', () => {
           id: repository.id,
           instance: repository.instance,
           path: '/ü',
-          source: `/source`,
-          timestamp: 'timestamp',
         })
       )
       await assertSuccessfulGraphQLQuery({
@@ -230,8 +228,6 @@ describe('Repository', () => {
           id: repository.id,
           instance: repository.instance,
           path: '/path',
-          source: `/source`,
-          timestamp: 'timestamp',
         })
       )
       await assertSuccessfulGraphQLQuery({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "bugs": {
     "url": "https://github.com/serlo/api.serlo.org/issues"

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -378,6 +378,7 @@ async function exec(): Promise<void> {
     {
       tagName: 'v0.11.3',
       date: '2020-11-24',
+      fixed: ['Tweak `max-age`s of stale-while-revalidate caching.'],
       internal: [
         ['alias', 'Remove `source` and `timestamp` from `AliasPayload`.'],
       ],

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -356,6 +356,16 @@ async function exec(): Promise<void> {
     {
       tagName: 'v0.11.0',
       date: '2020-11-18',
+      yanked: true,
+    },
+    {
+      tagName: 'v0.11.1',
+      date: '2020-11-18',
+      yanked: true,
+    },
+    {
+      tagName: 'v0.11.2',
+      date: '2020-11-18',
       added: [
         'We now have a stale-while-revalidate caching approach in place. This should lead to more correct behavior even when our listeners fail.',
         [
@@ -363,6 +373,13 @@ async function exec(): Promise<void> {
           'Add `objectId` to `AbstractNotificationEvent` which reports the ID of the object that triggered the event (and can be used to unsubscribe).',
         ],
         ['uuid', 'Add `threads`.'],
+      ],
+    },
+    {
+      tagName: 'v0.11.3',
+      date: '2020-11-24',
+      internal: [
+        ['alias', 'Remove `source` and `timestamp` from `AliasPayload`.'],
       ],
     },
   ])

--- a/src/graphql/data-sources/cacheable-data-source.ts
+++ b/src/graphql/data-sources/cacheable-data-source.ts
@@ -25,7 +25,8 @@ import * as R from 'ramda'
 
 import { Environment } from '../environment'
 
-export const HOUR = 60 * 60
+export const MINUTE = 60
+export const HOUR = 60 * MINUTE
 export const DAY = 24 * HOUR
 
 export abstract class CacheableDataSource extends RESTDataSource {

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -40,7 +40,7 @@ import {
 } from '../schema'
 import { SubscriptionsPayload } from '../schema/subscription'
 import { Service } from '../schema/types'
-import { CacheableDataSource, DAY, HOUR } from './cacheable-data-source'
+import { CacheableDataSource, DAY, HOUR, MINUTE } from './cacheable-data-source'
 
 export class SerloDataSource extends CacheableDataSource {
   public async getActiveAuthorIds(): Promise<number[]> {
@@ -68,7 +68,7 @@ export class SerloDataSource extends CacheableDataSource {
     return this.cacheAwareGet<AliasPayload>({
       path: `/api/alias${cleanPath}`,
       instance,
-      maxAge: 1 * HOUR,
+      maxAge: 5 * MINUTE,
     })
   }
 
@@ -160,7 +160,7 @@ export class SerloDataSource extends CacheableDataSource {
   }): Promise<T | null> {
     const uuid = await this.cacheAwareGet<T | null>({
       path: `/api/uuid/${id}`,
-      maxAge: 1 * DAY,
+      maxAge: 5 * MINUTE,
     })
     return uuid === null || isUnsupportedUuid(uuid) ? null : uuid
   }
@@ -245,7 +245,10 @@ export class SerloDataSource extends CacheableDataSource {
   }
 
   public async getThreadIds({ id }: { id: number }): Promise<ThreadsPayload> {
-    return this.cacheAwareGet({ path: `/api/threads/${id}` })
+    return this.cacheAwareGet({
+      path: `/api/threads/${id}`,
+      maxAge: 5 * MINUTE,
+    })
   }
 
   private async cacheAwareGet<T>({

--- a/src/graphql/schema/uuid/alias/types.ts
+++ b/src/graphql/schema/uuid/alias/types.ts
@@ -19,15 +19,13 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { Instance, Scalars } from '../../../../types'
+import { Instance } from '../../../../types'
 import { Resolver } from '../../types'
 
 export interface AliasPayload {
   id: number
   instance: Instance
   path: string
-  source: string
-  timestamp: Scalars['DateTime']
 }
 
 export interface AliasResolvers<T extends { alias: string | null }> {


### PR DESCRIPTION
## [v0.11.3](https://github.com/serlo/api.serlo.org/compare/v0.11.2..v0.11.3) - November 24, 2020

### Fixed

- Tweak `max-age`s of stale-while-revalidate caching.

### Internal

- **alias**. Remove `source` and `timestamp` from `AliasPayload`. (For https://github.com/serlo/serlo.org/pull/540)