### PR TITLE
Extend AbstractRevision and AbstractEntityRevision

### DIFF
--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -20,6 +20,8 @@ export type AbstractEntityRevision = {
     trashed: Scalars['Boolean'];
     author: User;
     date: Scalars['DateTime'];
+    content: Scalars['String'];
+    changes: Scalars['String'];
 };
 
 // @public (undocumented)
@@ -74,6 +76,7 @@ export type AbstractRevision = {
     trashed: Scalars['Boolean'];
     author: User;
     date: Scalars['DateTime'];
+    content: Scalars['String'];
 };
 
 // @public (undocumented)

--- a/src/schema/uuid/abstract-entity/types.graphql
+++ b/src/schema/uuid/abstract-entity/types.graphql
@@ -9,9 +9,14 @@ interface AbstractEntity {
 }
 
 interface AbstractEntityRevision {
-  # extends AbstractRevision
+  # extends AbstractUuid
   id: Int!
   trashed: Boolean!
+
+  # extends AbstractRevision
   author: User!
   date: DateTime!
+  content: String!
+
+  changes: String!
 }

--- a/src/schema/uuid/abstract-repository/types.graphql
+++ b/src/schema/uuid/abstract-repository/types.graphql
@@ -20,4 +20,5 @@ interface AbstractRevision {
   # repository: AbstractRepository!
   author: User!
   date: DateTime!
+  content: String!
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,6 +400,8 @@ export type AbstractEntityRevision = {
   trashed: Scalars['Boolean'];
   author: User;
   date: Scalars['DateTime'];
+  content: Scalars['String'];
+  changes: Scalars['String'];
 };
 
 export type AbstractExercise = {
@@ -475,6 +477,7 @@ export type AbstractRevision = {
   trashed: Scalars['Boolean'];
   author: User;
   date: Scalars['DateTime'];
+  content: Scalars['String'];
 };
 
 export type AbstractTaxonomyTermChild = {


### PR DESCRIPTION
Add field "content" to AbstractRevision and "changes" to
AbstractEntityRevision since they are implemented in all types using
these interfaces.