### PR TITLE
user: Change alias type to "String" instead of "String!"

### DIFF
--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -1514,7 +1514,7 @@ export type User = AbstractUuid & {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
     threads: ThreadsConnection;
-    alias: Scalars['String'];
+    alias?: Maybe<Scalars['String']>;
     username: Scalars['String'];
     date: Scalars['DateTime'];
     lastLogin?: Maybe<Scalars['DateTime']>;

--- a/src/graphql/schema/uuid/user/types.graphql
+++ b/src/graphql/schema/uuid/user/types.graphql
@@ -7,7 +7,7 @@ type User implements AbstractUuid {
     first: Int
     last: Int
   ): ThreadsConnection!
-  alias: String!
+  alias: String
   username: String!
   date: DateTime!
   lastLogin: DateTime

--- a/src/types.ts
+++ b/src/types.ts
@@ -1384,7 +1384,7 @@ export type User = AbstractUuid & {
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
   threads: ThreadsConnection;
-  alias: Scalars['String'];
+  alias?: Maybe<Scalars['String']>;
   username: Scalars['String'];
   date: Scalars['DateTime'];
   lastLogin?: Maybe<Scalars['DateTime']>;


### PR DESCRIPTION
Fixes https://github.com/serlo/serlo.org-cloudflare-worker/issues/83

The new query at the cf worker throws an error since the type of "alias" in "User" does not match the one in the other types: Thus there is no redirect and no redirect to the new frontend (since the typename couldn't be fetched).

![2020-11-30-121531_1282x760_scrot](https://user-images.githubusercontent.com/1327215/100603740-d406ca80-3305-11eb-9d62-7296ebd24ff9.png)