### PR TITLE
WIP: add setUuidState mutation

### DIFF
--- a/__tests__/schema/uuid/set-uuid-state.ts
+++ b/__tests__/schema/uuid/set-uuid-state.ts
@@ -1,0 +1,118 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { gql } from 'apollo-server'
+import { rest } from 'msw'
+
+import { article, user, user2 } from '../../../__fixtures__'
+import { Service } from '../../../src/graphql/schema/types'
+import { MutationSetUuidStateArgs } from '../../../src/types'
+import {
+  assertFailingGraphQLMutation,
+  assertSuccessfulGraphQLMutation,
+  createTestClient,
+  Client,
+} from '../../__utils__'
+
+let client: Client
+beforeEach(() => {
+  client = createTestClient({
+    service: Service.Serlo,
+    user: user.id,
+  })
+})
+
+describe('setUuidState', () => {
+  test('authenticated', async () => {
+    global.server.use(
+      rest.post(
+        `http://de.${process.env.SERLO_ORG_HOST}/api/set-uuid-state/${article.id}`,
+        (req, res, ctx) => {
+          return res(
+            ctx.json({
+              ...article,
+              trashed: false,
+            })
+          )
+        }
+      )
+    )
+    await assertSuccessfulGraphQLMutation({
+      ...createSetUuidStateMutation({
+        id: 1,
+        trashed: false,
+      }),
+      client,
+      //TODO: Add data
+    })
+  })
+
+  test('unauthenticated', async () => {
+    const client = createTestClient({
+      service: Service.SerloCloudflareWorker,
+      user: null,
+    })
+    await assertFailingGraphQLMutation(
+      {
+        ...createSetUuidStateMutation({ id: 1, trashed: false }),
+        client,
+      },
+      (errors) => {
+        expect(errors[0].extensions?.code).toEqual('UNAUTHENTICATED')
+      }
+    )
+  })
+
+  test('wrong user id', async () => {
+    global.server.use(
+      rest.post(
+        `http://de.${process.env.SERLO_ORG_HOST}/api/set-uuid-state/1`,
+        (req, res, ctx) => {
+          return res(ctx.status(403), ctx.json({}))
+        }
+      )
+    )
+    const client = createTestClient({
+      service: Service.SerloCloudflareWorker,
+      user: user2.id,
+    })
+    await assertFailingGraphQLMutation(
+      {
+        ...createSetUuidStateMutation({ id: 1, trashed: false }),
+        client,
+      },
+      (errors) => {
+        expect(errors[0].extensions?.code).toEqual('FORBIDDEN')
+      }
+    )
+  })
+
+  function createSetUuidStateMutation(variables: MutationSetUuidStateArgs) {
+    return {
+      mutation: gql`
+        mutation setUuidState($id: Int!, $trashed: Boolean!) {
+          setUuidState(id: $id, trashed: $trashed)
+        }
+      `,
+      variables,
+    }
+  }
+})

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -930,6 +930,7 @@ export type Mutation = {
     _setCache?: Maybe<Scalars['Boolean']>;
     _updateCache?: Maybe<Scalars['Boolean']>;
     setNotificationState?: Maybe<Scalars['Boolean']>;
+    setUuidState?: Maybe<AbstractUuid>;
 };
 
 // @public (undocumented)
@@ -952,6 +953,12 @@ export type Mutation_UpdateCacheArgs = {
 export type MutationSetNotificationStateArgs = {
     id: Scalars['Int'];
     unread: Scalars['Boolean'];
+};
+
+// @public (undocumented)
+export type MutationSetUuidStateArgs = {
+    id: Scalars['Int'];
+    trashed: Scalars['Boolean'];
 };
 
 // @public (undocumented)

--- a/src/graphql/data-sources/serlo.ts
+++ b/src/graphql/data-sources/serlo.ts
@@ -165,6 +165,29 @@ export class SerloDataSource extends CacheableDataSource {
     return uuid === null || isUnsupportedUuid(uuid) ? null : uuid
   }
 
+  // TODO: discuss in pair programming session:
+  // basically the same as getUuid but with different endpoint(mutation)
+  // or should we only do the mutation and then use a new call to getUuid to actually return the Payload?
+
+  public async setUuidState<T extends AbstractUuidPayload>(mutationData: {
+    id: number
+    userId: number
+    trashed: boolean
+  }): Promise<T | null> {
+    const uuid = await this.customPost<T | null>({
+      path: `/api/set-uuid-state/${mutationData.id}`,
+      body: {
+        userId: mutationData.userId,
+        trashed: mutationData.trashed,
+      },
+    })
+    await this.setCacheValue({
+      key: this.getCacheKey(`/api/uuid/${mutationData.userId}`),
+      update: () => Promise.resolve(uuid),
+    })
+    return uuid === null || isUnsupportedUuid(uuid) ? null : uuid
+  }
+
   public async getNotificationEvent<
     T extends AbstractNotificationEventPayload
   >({ id }: { id: number }): Promise<T | null> {

--- a/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
@@ -84,12 +84,11 @@ export const resolvers: AbstractUuidResolvers = {
 
       if (_user === null) throw new AuthenticationError('You are not logged in')
 
-      const uuidValue = await dataSources.serlo.setUuidState<UuidPayload>({
+      return await dataSources.serlo.setUuidState<UuidPayload>({
         id: payload.id,
         userId: _user,
         trashed: payload.trashed,
       })
-      return uuidValue
     },
   },
 }

--- a/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/resolvers.ts
@@ -19,7 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { UserInputError } from 'apollo-server'
+import { AuthenticationError, UserInputError } from 'apollo-server'
 
 import { decodePath } from '../alias'
 import { AbstractUuidResolvers, DiscriminatorType, UuidPayload } from './types'
@@ -67,6 +67,29 @@ export const resolvers: AbstractUuidResolvers = {
       } else {
         throw new UserInputError('you need to provide an id or an alias')
       }
+    },
+  },
+  Mutation: {
+    //TODO: discuss:
+    //if we want to return a useful uuid to the frontend we would actually have to query all the data we need to rebuild the current page
+    // `mutation {setUuidState(id: 22, trashed:true){ __typename, … }}`
+    // this seems a bit off, since a reload would do the same without any additional code.
+
+    async setUuidState(_parent, payload, { dataSources, user }) {
+      //debug
+      console.log('Hello setUuidState')
+      console.log(user)
+      const _user = 18981
+      //
+
+      if (_user === null) throw new AuthenticationError('You are not logged in')
+
+      const uuidValue = await dataSources.serlo.setUuidState<UuidPayload>({
+        id: payload.id,
+        userId: _user,
+        trashed: payload.trashed,
+      })
+      return uuidValue
     },
   },
 }

--- a/src/graphql/schema/uuid/abstract-uuid/types.graphql
+++ b/src/graphql/schema/uuid/abstract-uuid/types.graphql
@@ -24,3 +24,7 @@ type AbstractUuidCursor {
 type Query {
   uuid(alias: AliasInput, id: Int): AbstractUuid
 }
+
+extend type Mutation {
+  setUuidState(id: Int!, trashed: Boolean!): AbstractUuid
+}

--- a/src/graphql/schema/uuid/abstract-uuid/types.ts
+++ b/src/graphql/schema/uuid/abstract-uuid/types.ts
@@ -22,10 +22,16 @@
 import {
   AbstractUuid,
   AbstractUuidThreadsArgs,
+  MutationSetUuidStateArgs,
   QueryUuidArgs,
 } from '../../../../types'
 import { Connection } from '../../connection'
-import { QueryResolver, Resolver, TypeResolver } from '../../types'
+import {
+  MutationResolver,
+  QueryResolver,
+  Resolver,
+  TypeResolver,
+} from '../../types'
 import {
   EntityPayload,
   EntityRevisionPayload,
@@ -74,5 +80,8 @@ export interface AbstractUuidResolvers {
   }
   Query: {
     uuid: QueryResolver<QueryUuidArgs, UuidPayload | null>
+  }
+  Mutation: {
+    setUuidState: MutationResolver<MutationSetUuidStateArgs, UuidPayload | null>
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export type Mutation = {
   _setCache?: Maybe<Scalars['Boolean']>;
   _updateCache?: Maybe<Scalars['Boolean']>;
   setNotificationState?: Maybe<Scalars['Boolean']>;
+  setUuidState?: Maybe<AbstractUuid>;
 };
 
 
@@ -132,6 +133,12 @@ export type Mutation_UpdateCacheArgs = {
 export type MutationSetNotificationStateArgs = {
   id: Scalars['Int'];
   unread: Scalars['Boolean'];
+};
+
+
+export type MutationSetUuidStateArgs = {
+  id: Scalars['Int'];
+  trashed: Scalars['Boolean'];
 };
 
 export type PageInfo = {


### PR DESCRIPTION

to discuss in the next session:
```
(from serlo.ts)
// basically the same as getUuid but with different endpoint(mutation)
// or should we only do the mutation and then use a new call to getUuid to actually return the Payload?
```

```
(from resolver.ts)
//if we want to return a useful uuid to the frontend we would actually have to query all the data we need to rebuild the current page
// `mutation {setUuidState(id: 22, trashed:true){ __typename, … }}`
// this seems a bit off, since a reload would do the same without any additional code.
```

(for issue #53)