### PR TITLE
Add setNotificationsState rebase

### DIFF
--- a/__tests-pacts__/serlo.org/set-notification-state.ts
+++ b/__tests-pacts__/serlo.org/set-notification-state.ts
@@ -30,7 +30,7 @@ import {
 } from '../__utils__'
 import { Service } from '~/internals/auth'
 
-test('setNotificationState', async () => {
+test('setNotificationsState', async () => {
   global.client = createTestClient({
     service: Service.SerloCloudflareWorker,
     user: user.id,
@@ -66,12 +66,12 @@ test('setNotificationState', async () => {
   })
   await assertSuccessfulGraphQLMutation({
     mutation: gql`
-      mutation setNotificationState($id: Int!, $unread: Boolean!) {
-        setNotificationState(id: $id, unread: $unread)
+      mutation setNotificationsState($ids: [Int!]!, $unread: Boolean!) {
+        setNotificationsState(ids: $ids, unread: $unread)
       }
     `,
     variables: {
-      id: 9,
+      ids: [9],
       unread: true,
     },
   })

--- a/__tests-pacts__/serlo.org/set-notifications-state.ts
+++ b/__tests-pacts__/serlo.org/set-notifications-state.ts
@@ -25,11 +25,11 @@ import { gql } from 'apollo-server'
 import { checkoutRevisionNotificationEvent } from '../../__fixtures__'
 import { user } from '../../__fixtures__/uuid'
 import { createTestClient } from '../../__tests__/__utils__'
-import { Service } from '../../src/graphql/schema/types'
 import {
   assertSuccessfulGraphQLQuery,
   assertSuccessfulGraphQLMutation,
 } from '../__utils__'
+import { Service } from '~/../dist/graphql/schema/types'
 
 test('setNotificationsState', async () => {
   global.client = createTestClient({

--- a/__tests-pacts__/serlo.org/set-notifications-state.ts
+++ b/__tests-pacts__/serlo.org/set-notifications-state.ts
@@ -22,15 +22,16 @@
 import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
 
-import { checkoutRevisionNotificationEvent, user } from '../../__fixtures__'
+import { checkoutRevisionNotificationEvent } from '../../__fixtures__'
+import { user } from '../../__fixtures__/uuid'
 import { createTestClient } from '../../__tests__/__utils__'
+import { Service } from '../../src/graphql/schema/types'
 import {
-  assertSuccessfulGraphQLMutation,
   assertSuccessfulGraphQLQuery,
+  assertSuccessfulGraphQLMutation,
 } from '../__utils__'
-import { Service } from '~/internals/auth'
 
-test('setNotificationState', async () => {
+test('setNotificationsState', async () => {
   global.client = createTestClient({
     service: Service.SerloCloudflareWorker,
     user: user.id,
@@ -66,12 +67,12 @@ test('setNotificationState', async () => {
   })
   await assertSuccessfulGraphQLMutation({
     mutation: gql`
-      mutation setNotificationState($id: Int!, $unread: Boolean!) {
-        setNotificationState(id: $id, unread: $unread)
+      mutation setNotificationsState($ids: [Int!]!, $unread: Boolean!) {
+        setNotificationsState(ids: $ids, unread: $unread)
       }
     `,
     variables: {
-      id: 9,
+      ids: [9],
       unread: true,
     },
   })

--- a/__tests-pacts__/serlo.org/set-notifications-state.ts
+++ b/__tests-pacts__/serlo.org/set-notifications-state.ts
@@ -29,7 +29,7 @@ import {
   assertSuccessfulGraphQLQuery,
   assertSuccessfulGraphQLMutation,
 } from '../__utils__'
-import { Service } from '~/../dist/graphql/schema/types'
+import { Service } from '~/internals/auth'
 
 test('setNotificationsState', async () => {
   global.client = createTestClient({

--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -72,17 +72,20 @@ export async function assertSuccessfulGraphQLMutation({
   mutation,
   variables,
   client,
+  data,
 }: {
   mutation: DocumentNode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variables?: Record<string, any>
   client: Client
+  data?: GraphQLResponse['data']
 }) {
   const response = await client.mutate({
     mutation,
     variables,
   })
   expect(response.errors).toBeUndefined()
+  if (data) expect(response.data).toEqual(data)
 }
 
 export async function assertFailingGraphQLMutation(

--- a/__tests__/schema/notification.ts
+++ b/__tests__/schema/notification.ts
@@ -83,7 +83,7 @@ import {
   createUuidHandler,
 } from '../__utils__'
 import { Service } from '~/internals/auth'
-import { Instance, MutationSetNotificationStateArgs } from '~/types'
+import { Instance, MutationSetNotificationsStateArgs } from '~/types'
 
 describe('notifications', () => {
   let client: Client
@@ -2198,14 +2198,14 @@ describe('notificationEvent', () => {
   })
 })
 
-describe('setNotificationState', () => {
-  function createSetNotificationStateMutation(
-    variables: MutationSetNotificationStateArgs
+describe('setNotificationsState', () => {
+  function createSetNotificationsStateMutation(
+    variables: MutationSetNotificationsStateArgs
   ) {
     return {
       mutation: gql`
-        mutation setNotificationState($id: Int!, $unread: Boolean!) {
-          setNotificationState(id: $id, unread: $unread)
+        mutation setNotificationsState($ids: [Int!]!, $unread: Boolean!) {
+          setNotificationsState(ids: $ids, unread: $unread)
         }
       `,
       variables,
@@ -2219,7 +2219,10 @@ describe('setNotificationState', () => {
     })
     await assertFailingGraphQLMutation(
       {
-        ...createSetNotificationStateMutation({ id: 1, unread: false }),
+        ...createSetNotificationsStateMutation({
+          ids: [1, 2, 6],
+          unread: false,
+        }),
         client,
       },
       (errors) => {
@@ -2243,7 +2246,7 @@ describe('setNotificationState', () => {
     })
     await assertFailingGraphQLMutation(
       {
-        ...createSetNotificationStateMutation({ id: 1, unread: false }),
+        ...createSetNotificationsStateMutation({ ids: [1], unread: false }),
         client,
       },
       (errors) => {
@@ -2296,8 +2299,8 @@ describe('setNotificationState', () => {
       user: user.id,
     })
     await assertSuccessfulGraphQLMutation({
-      ...createSetNotificationStateMutation({
-        id: 1,
+      ...createSetNotificationsStateMutation({
+        ids: [1],
         unread: false,
       }),
       client,

--- a/__tests__/schema/notification.ts
+++ b/__tests__/schema/notification.ts
@@ -83,11 +83,7 @@ import {
   createUuidHandler,
 } from '../__utils__'
 import { Service } from '~/internals/auth'
-import {
-  Instance,
-  MutationSetNotificationsStateArgs,
-  MutationSetNotificationStateArgs,
-} from '~/types'
+import { Instance } from '~/types'
 
 describe('notifications', () => {
   let client: Client
@@ -2201,6 +2197,12 @@ describe('notificationEvent', () => {
 })
 
 describe('setNotificationState', () => {
+  const mutation = gql`
+    mutation setNotificationState($id: Int!, $unread: Boolean!) {
+      setNotificationState(id: $id, unread: $unread)
+    }
+  `
+
   test('authenticated', async () => {
     global.server.use(
       rest.post(
@@ -2226,25 +2228,26 @@ describe('setNotificationState', () => {
       user: user.id,
     })
     await assertSuccessfulGraphQLMutation({
-      ...createSetNotificationStateMutation({
+      mutation,
+      variables: {
         id: 1,
         unread: false,
-      }),
+      },
       client,
-      data: { setNotificationState: null },
+      data: { setNotificationState: true },
     })
   })
   test('unauthenticated', async () => {
     const client = createTestClient({
-      service: Service.SerloCloudflareWorker,
       user: null,
     })
     await assertFailingGraphQLMutation(
       {
-        ...createSetNotificationStateMutation({
+        mutation,
+        variables: {
           id: 1,
           unread: false,
-        }),
+        },
         client,
       },
       (errors) => {
@@ -2268,7 +2271,8 @@ describe('setNotificationState', () => {
     })
     await assertFailingGraphQLMutation(
       {
-        ...createSetNotificationStateMutation({ id: 1, unread: false }),
+        mutation,
+        variables: { id: 1, unread: false },
         client,
       },
       (errors) => {
@@ -2276,22 +2280,15 @@ describe('setNotificationState', () => {
       }
     )
   })
-
-  function createSetNotificationStateMutation(
-    variables: MutationSetNotificationStateArgs
-  ) {
-    return {
-      mutation: gql`
-        mutation setNotificationState($id: Int!, $unread: Boolean!) {
-          setNotificationState(id: $id, unread: $unread)
-        }
-      `,
-      variables,
-    }
-  }
 })
 
 describe('setNotificationsState', () => {
+  const mutation = gql`
+    mutation setNotificationsState($ids: [Int!]!, $unread: Boolean!) {
+      setNotificationsState(ids: $ids, unread: $unread)
+    }
+  `
+
   test('authenticated', async () => {
     global.server.use(
       rest.post(
@@ -2317,26 +2314,27 @@ describe('setNotificationsState', () => {
       user: user.id,
     })
     await assertSuccessfulGraphQLMutation({
-      ...createSetNotificationsStateMutation({
+      mutation,
+      variables: {
         ids: [1],
         unread: false,
-      }),
+      },
       client,
-      data: { setNotificationsState: null },
+      data: { setNotificationsState: true },
     })
   })
 
   test('unauthenticated', async () => {
     const client = createTestClient({
-      service: Service.SerloCloudflareWorker,
       user: null,
     })
     await assertFailingGraphQLMutation(
       {
-        ...createSetNotificationsStateMutation({
+        mutation,
+        variables: {
           ids: [1, 2, 6],
           unread: false,
-        }),
+        },
         client,
       },
       (errors) => {
@@ -2360,7 +2358,8 @@ describe('setNotificationsState', () => {
     })
     await assertFailingGraphQLMutation(
       {
-        ...createSetNotificationsStateMutation({ ids: [1], unread: false }),
+        mutation,
+        variables: { ids: [1], unread: false },
         client,
       },
       (errors) => {
@@ -2368,17 +2367,4 @@ describe('setNotificationsState', () => {
       }
     )
   })
-
-  function createSetNotificationsStateMutation(
-    variables: MutationSetNotificationsStateArgs
-  ) {
-    return {
-      mutation: gql`
-        mutation setNotificationsState($ids: [Int!]!, $unread: Boolean!) {
-          setNotificationsState(ids: $ids, unread: $unread)
-        }
-      `,
-      variables,
-    }
-  }
 })

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -942,7 +942,7 @@ export type Mutation = {
     _removeCache?: Maybe<Scalars['Boolean']>;
     _setCache?: Maybe<Scalars['Boolean']>;
     _updateCache?: Maybe<Scalars['Boolean']>;
-    setNotificationState?: Maybe<Scalars['Boolean']>;
+    setNotificationsState?: Maybe<Scalars['Boolean']>;
 };
 
 // @public (undocumented)
@@ -962,8 +962,8 @@ export type Mutation_UpdateCacheArgs = {
 };
 
 // @public (undocumented)
-export type MutationSetNotificationStateArgs = {
-    id: Scalars['Int'];
+export type MutationSetNotificationsStateArgs = {
+    ids: Array<Scalars['Int']>;
     unread: Scalars['Boolean'];
 };
 

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -942,6 +942,7 @@ export type Mutation = {
     _removeCache?: Maybe<Scalars['Boolean']>;
     _setCache?: Maybe<Scalars['Boolean']>;
     _updateCache?: Maybe<Scalars['Boolean']>;
+    setNotificationState?: Maybe<Scalars['Boolean']>;
     setNotificationsState?: Maybe<Scalars['Boolean']>;
 };
 
@@ -964,6 +965,12 @@ export type Mutation_UpdateCacheArgs = {
 // @public (undocumented)
 export type MutationSetNotificationsStateArgs = {
     ids: Array<Scalars['Int']>;
+    unread: Scalars['Boolean'];
+};
+
+// @public (undocumented)
+export type MutationSetNotificationStateArgs = {
+    id: Scalars['Int'];
     unread: Scalars['Boolean'];
 };
 

--- a/src/model/serlo.ts
+++ b/src/model/serlo.ts
@@ -355,37 +355,33 @@ export function createSerloModel({
     environment
   )
 
-  const setNotificationsState = createMutation<{
-    ids: number[]
-    userId: number
-    unread: boolean
-  }>({
-    mutate: async (notificationState: {
+  const setNotificationsState = createMutation<
+    {
       ids: number[]
       userId: number
       unread: boolean
-    }) => {
+    },
+    boolean
+  >({
+    mutate: async ({ ids, userId, unread }) => {
       //
       const values: NotificationsPayload[] = await Promise.all(
         //TODO: rewrite legacy endpoint so that it accepts an array directly
-        notificationState.ids.map(
+        ids.map(
           async (notificationId): Promise<NotificationsPayload> => {
             const value = await post<NotificationsPayload>({
               path: `/api/set-notification-state/${notificationId}`,
-              body: {
-                userId: notificationState.userId,
-                unread: notificationState.unread,
-              },
+              body: { userId, unread },
             })
             await environment.cache.set({
-              key: `de.serlo.org/api/notifications/${notificationState.userId}`,
+              key: `de.serlo.org/api/notifications/${userId}`,
               value,
             })
             return value
           }
         )
       )
-      values.every(Boolean)
+      return values.every(Boolean)
     },
   })
 

--- a/src/schema/notification/resolvers.ts
+++ b/src/schema/notification/resolvers.ts
@@ -71,6 +71,15 @@ export const resolvers: NotificationResolvers = {
     },
   },
   Mutation: {
+    async setNotificationState(_parent, payload, { dataSources, user }) {
+      if (user === null) throw new AuthenticationError('You are not logged in')
+      const result = await dataSources.serlo.setNotificationsState({
+        ids: [payload.id],
+        userId: user,
+        unread: payload.unread,
+      })
+      return result
+    },
     async setNotificationsState(_parent, payload, { dataSources, user }) {
       if (user === null) throw new AuthenticationError('You are not logged in')
       return await dataSources.model.serlo.setNotificationsState({

--- a/src/schema/notification/resolvers.ts
+++ b/src/schema/notification/resolvers.ts
@@ -20,12 +20,12 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { resolveConnection } from '../connection'
-import { checkUserIsAuthenticated } from '../utils'
 import {
   NotificationEventPayload,
   NotificationPayload,
   NotificationResolvers,
 } from './types'
+import { checkUserIsAuthenticated } from '~/schema/utils'
 
 export const resolvers: NotificationResolvers = {
   AbstractNotificationEvent: {

--- a/src/schema/notification/resolvers.ts
+++ b/src/schema/notification/resolvers.ts
@@ -25,7 +25,7 @@ import {
   NotificationPayload,
   NotificationResolvers,
 } from './types'
-import { checkUserIsAuthenticated } from '~/schema/utils'
+import { assertUserIsAuthenticated } from '~/schema/utils'
 
 export const resolvers: NotificationResolvers = {
   AbstractNotificationEvent: {
@@ -46,9 +46,9 @@ export const resolvers: NotificationResolvers = {
       { unread, ...cursorPayload },
       { dataSources, user }
     ) {
-      checkUserIsAuthenticated(user)
+      assertUserIsAuthenticated(user)
       const { notifications } = await dataSources.model.serlo.getNotifications({
-        id: user as number,
+        id: user,
       })
       return resolveConnection<NotificationPayload>({
         nodes: notifications.filter((notification) => {
@@ -71,18 +71,18 @@ export const resolvers: NotificationResolvers = {
   },
   Mutation: {
     async setNotificationState(_parent, payload, { dataSources, user }) {
-      checkUserIsAuthenticated(user)
+      assertUserIsAuthenticated(user)
       return await dataSources.model.serlo.setNotificationsState({
         ids: [payload.id],
-        userId: user as number,
+        userId: user,
         unread: payload.unread,
       })
     },
     async setNotificationsState(_parent, payload, { dataSources, user }) {
-      checkUserIsAuthenticated(user)
+      assertUserIsAuthenticated(user)
       return await dataSources.model.serlo.setNotificationsState({
         ids: payload.ids,
-        userId: user as number,
+        userId: user,
         unread: payload.unread,
       })
     },

--- a/src/schema/notification/resolvers.ts
+++ b/src/schema/notification/resolvers.ts
@@ -71,14 +71,13 @@ export const resolvers: NotificationResolvers = {
     },
   },
   Mutation: {
-    async setNotificationState(_parent, payload, { dataSources, user }) {
+    async setNotificationsState(_parent, payload, { dataSources, user }) {
       if (user === null) throw new AuthenticationError('You are not logged in')
-      await dataSources.model.serlo.setNotificationState({
-        id: payload.id,
+      return await dataSources.model.serlo.setNotificationsState({
+        ids: payload.ids,
         userId: user,
         unread: payload.unread,
       })
-      return null
     },
   },
 }

--- a/src/schema/notification/resolvers.ts
+++ b/src/schema/notification/resolvers.ts
@@ -19,9 +19,8 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { AuthenticationError } from 'apollo-server'
-
 import { resolveConnection } from '../connection'
+import { checkUserIsAuthenticated } from '../utils'
 import {
   NotificationEventPayload,
   NotificationPayload,
@@ -47,9 +46,9 @@ export const resolvers: NotificationResolvers = {
       { unread, ...cursorPayload },
       { dataSources, user }
     ) {
-      if (user === null) throw new AuthenticationError('You are not logged in')
+      checkUserIsAuthenticated(user)
       const { notifications } = await dataSources.model.serlo.getNotifications({
-        id: user,
+        id: user as number,
       })
       return resolveConnection<NotificationPayload>({
         nodes: notifications.filter((notification) => {
@@ -72,19 +71,18 @@ export const resolvers: NotificationResolvers = {
   },
   Mutation: {
     async setNotificationState(_parent, payload, { dataSources, user }) {
-      if (user === null) throw new AuthenticationError('You are not logged in')
-      const result = await dataSources.serlo.setNotificationsState({
+      checkUserIsAuthenticated(user)
+      return await dataSources.model.serlo.setNotificationsState({
         ids: [payload.id],
-        userId: user,
+        userId: user as number,
         unread: payload.unread,
       })
-      return result
     },
     async setNotificationsState(_parent, payload, { dataSources, user }) {
-      if (user === null) throw new AuthenticationError('You are not logged in')
+      checkUserIsAuthenticated(user)
       return await dataSources.model.serlo.setNotificationsState({
         ids: payload.ids,
-        userId: user,
+        userId: user as number,
         unread: payload.unread,
       })
     },

--- a/src/schema/notification/types.graphql
+++ b/src/schema/notification/types.graphql
@@ -24,7 +24,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  setNotificationState(id: Int!, unread: Boolean!): Boolean
+  setNotificationsState(ids: [Int!]!, unread: Boolean!): Boolean
 }
 
 type NotificationConnection {

--- a/src/schema/notification/types.graphql
+++ b/src/schema/notification/types.graphql
@@ -24,6 +24,7 @@ extend type Query {
 }
 
 extend type Mutation {
+  setNotificationState(id: Int!, unread: Boolean!): Boolean
   setNotificationsState(ids: [Int!]!, unread: Boolean!): Boolean
 }
 

--- a/src/schema/notification/types.ts
+++ b/src/schema/notification/types.ts
@@ -46,6 +46,7 @@ import {
 import {
   AbstractNotificationEvent,
   MutationSetNotificationsStateArgs,
+  MutationSetNotificationStateArgs,
   Notification,
   QueryNotificationEventArgs,
   QueryNotificationsArgs,
@@ -124,11 +125,11 @@ export interface NotificationResolvers {
   Mutation: {
     setNotificationState: MutationResolver<
       MutationSetNotificationStateArgs,
-      boolean
+      void
     >
     setNotificationsState: MutationResolver<
       MutationSetNotificationsStateArgs,
-      boolean
+      void
     >
   }
 }

--- a/src/schema/notification/types.ts
+++ b/src/schema/notification/types.ts
@@ -125,11 +125,11 @@ export interface NotificationResolvers {
   Mutation: {
     setNotificationState: MutationResolver<
       MutationSetNotificationStateArgs,
-      void
+      boolean
     >
     setNotificationsState: MutationResolver<
       MutationSetNotificationsStateArgs,
-      void
+      boolean
     >
   }
 }

--- a/src/schema/notification/types.ts
+++ b/src/schema/notification/types.ts
@@ -122,6 +122,10 @@ export interface NotificationResolvers {
     >
   }
   Mutation: {
+    setNotificationState: MutationResolver<
+      MutationSetNotificationStateArgs,
+      boolean
+    >
     setNotificationsState: MutationResolver<
       MutationSetNotificationsStateArgs,
       boolean

--- a/src/schema/notification/types.ts
+++ b/src/schema/notification/types.ts
@@ -45,7 +45,7 @@ import {
 } from '~/internals/graphql'
 import {
   AbstractNotificationEvent,
-  MutationSetNotificationStateArgs,
+  MutationSetNotificationsStateArgs,
   Notification,
   QueryNotificationEventArgs,
   QueryNotificationsArgs,
@@ -122,7 +122,10 @@ export interface NotificationResolvers {
     >
   }
   Mutation: {
-    setNotificationState: MutationResolver<MutationSetNotificationStateArgs>
+    setNotificationsState: MutationResolver<
+      MutationSetNotificationsStateArgs,
+      boolean
+    >
   }
 }
 

--- a/src/schema/subscription/resolvers.ts
+++ b/src/schema/subscription/resolvers.ts
@@ -22,14 +22,14 @@
 import { resolveConnection } from '../connection'
 import { AbstractUuidPayload } from '../uuid'
 import { SubscriptionResolvers } from './types'
-import { checkUserIsAuthenticated } from '~/schema/utils'
+import { assertUserIsAuthenticated } from '~/schema/utils'
 
 export const resolvers: SubscriptionResolvers = {
   Query: {
     async subscriptions(parent, cursorPayload, { dataSources, user }) {
-      checkUserIsAuthenticated(user)
+      assertUserIsAuthenticated(user)
       const subscriptions = await dataSources.model.serlo.getSubscriptions({
-        id: user as number,
+        id: user,
       })
       const result = await Promise.all(
         subscriptions.subscriptions.map((id) => {

--- a/src/schema/subscription/resolvers.ts
+++ b/src/schema/subscription/resolvers.ts
@@ -19,18 +19,17 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { AuthenticationError } from 'apollo-server'
-
 import { resolveConnection } from '../connection'
+import { checkUserIsAuthenticated } from '../utils'
 import { AbstractUuidPayload } from '../uuid'
 import { SubscriptionResolvers } from './types'
 
 export const resolvers: SubscriptionResolvers = {
   Query: {
     async subscriptions(parent, cursorPayload, { dataSources, user }) {
-      if (user === null) throw new AuthenticationError('You are not logged in')
+      checkUserIsAuthenticated(user)
       const subscriptions = await dataSources.model.serlo.getSubscriptions({
-        id: user,
+        id: user as number,
       })
       const result = await Promise.all(
         subscriptions.subscriptions.map((id) => {

--- a/src/schema/subscription/resolvers.ts
+++ b/src/schema/subscription/resolvers.ts
@@ -20,9 +20,9 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { resolveConnection } from '../connection'
-import { checkUserIsAuthenticated } from '../utils'
 import { AbstractUuidPayload } from '../uuid'
 import { SubscriptionResolvers } from './types'
+import { checkUserIsAuthenticated } from '~/schema/utils'
 
 export const resolvers: SubscriptionResolvers = {
   Query: {

--- a/src/schema/utils.ts
+++ b/src/schema/utils.ts
@@ -19,6 +19,15 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
+
+import { AuthenticationError } from 'apollo-server'
+
+import { Context } from '~/internals/graphql'
+
 export function isDefined<A>(value?: A | null): value is A {
   return value !== null && value !== undefined
+}
+
+export function checkUserIsAuthenticated(user: Context['user']) {
+  if (user === null) throw new AuthenticationError('You are not logged in')
 }

--- a/src/schema/utils.ts
+++ b/src/schema/utils.ts
@@ -28,6 +28,8 @@ export function isDefined<A>(value?: A | null): value is A {
   return value !== null && value !== undefined
 }
 
-export function checkUserIsAuthenticated(user: Context['user']) {
+export function assertUserIsAuthenticated(
+  user: Context['user']
+): asserts user is number {
   if (user === null) throw new AuthenticationError('You are not logged in')
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export type Mutation = {
   _removeCache?: Maybe<Scalars['Boolean']>;
   _setCache?: Maybe<Scalars['Boolean']>;
   _updateCache?: Maybe<Scalars['Boolean']>;
+  setNotificationState?: Maybe<Scalars['Boolean']>;
   setNotificationsState?: Maybe<Scalars['Boolean']>;
 };
 
@@ -128,6 +129,12 @@ export type Mutation_SetCacheArgs = {
 
 export type Mutation_UpdateCacheArgs = {
   keys: Array<Scalars['String']>;
+};
+
+
+export type MutationSetNotificationStateArgs = {
+  id: Scalars['Int'];
+  unread: Scalars['Boolean'];
 };
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,7 +111,7 @@ export type Mutation = {
   _removeCache?: Maybe<Scalars['Boolean']>;
   _setCache?: Maybe<Scalars['Boolean']>;
   _updateCache?: Maybe<Scalars['Boolean']>;
-  setNotificationState?: Maybe<Scalars['Boolean']>;
+  setNotificationsState?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -131,8 +131,8 @@ export type Mutation_UpdateCacheArgs = {
 };
 
 
-export type MutationSetNotificationStateArgs = {
-  id: Scalars['Int'];
+export type MutationSetNotificationsStateArgs = {
+  ids: Array<Scalars['Int']>;
   unread: Scalars['Boolean'];
 };
 


### PR DESCRIPTION
(rebase of https://github.com/serlo/api.serlo.org/pull/152)

Improvement: 
We should probably accept arrays in the legacy endpoint directly. 
(currently we just loop through the ids)

(closes #150, #146)

