### PR TITLE
add setUuidState mutation

### DIFF
--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -72,17 +72,20 @@ export async function assertSuccessfulGraphQLMutation({
   mutation,
   variables,
   client,
+  data,
 }: {
   mutation: DocumentNode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variables?: Record<string, any>
   client: Client
+  data?: GraphQLResponse['data']
 }) {
   const response = await client.mutate({
     mutation,
     variables,
   })
   expect(response.errors).toBeUndefined()
+  if (data) expect(response.data).toEqual(data)
 }
 
 export async function assertFailingGraphQLMutation(

--- a/__tests__/schema/uuid/set-uuid-state.ts
+++ b/__tests__/schema/uuid/set-uuid-state.ts
@@ -1,0 +1,118 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { gql } from 'apollo-server'
+import { rest } from 'msw'
+
+import { article, user, user2 } from '../../../__fixtures__'
+import { Service } from '../../../src/graphql/schema/types'
+import { MutationSetUuidStateArgs } from '../../../src/types'
+import {
+  assertFailingGraphQLMutation,
+  assertSuccessfulGraphQLMutation,
+  createTestClient,
+  Client,
+} from '../../__utils__'
+
+let client: Client
+beforeEach(() => {
+  client = createTestClient({
+    service: Service.Serlo,
+    user: user.id,
+  })
+})
+
+describe('setUuidState', () => {
+  test('authenticated', async () => {
+    global.server.use(
+      rest.post(
+        `http://de.${process.env.SERLO_ORG_HOST}/api/set-uuid-state/${article.id}`,
+        (req, res, ctx) => {
+          return res(
+            ctx.json({
+              ...article,
+              trashed: false,
+            })
+          )
+        }
+      )
+    )
+    await assertSuccessfulGraphQLMutation({
+      ...createSetUuidStateMutation({
+        id: 1,
+        trashed: false,
+      }),
+      client,
+      //TODO: Add data
+    })
+  })
+
+  test('unauthenticated', async () => {
+    const client = createTestClient({
+      service: Service.SerloCloudflareWorker,
+      user: null,
+    })
+    await assertFailingGraphQLMutation(
+      {
+        ...createSetUuidStateMutation({ id: 1, trashed: false }),
+        client,
+      },
+      (errors) => {
+        expect(errors[0].extensions?.code).toEqual('UNAUTHENTICATED')
+      }
+    )
+  })
+
+  test('wrong user id', async () => {
+    global.server.use(
+      rest.post(
+        `http://de.${process.env.SERLO_ORG_HOST}/api/set-uuid-state/1`,
+        (req, res, ctx) => {
+          return res(ctx.status(403), ctx.json({}))
+        }
+      )
+    )
+    const client = createTestClient({
+      service: Service.SerloCloudflareWorker,
+      user: user2.id,
+    })
+    await assertFailingGraphQLMutation(
+      {
+        ...createSetUuidStateMutation({ id: 1, trashed: false }),
+        client,
+      },
+      (errors) => {
+        expect(errors[0].extensions?.code).toEqual('FORBIDDEN')
+      }
+    )
+  })
+
+  function createSetUuidStateMutation(variables: MutationSetUuidStateArgs) {
+    return {
+      mutation: gql`
+        mutation setUuidState($id: Int!, $trashed: Boolean!) {
+          setUuidState(id: $id, trashed: $trashed)
+        }
+      `,
+      variables,
+    }
+  }
+})

--- a/__tests__/schema/uuid/set-uuid-state.ts
+++ b/__tests__/schema/uuid/set-uuid-state.ts
@@ -28,20 +28,15 @@ import {
   assertFailingGraphQLMutation,
   assertSuccessfulGraphQLMutation,
   createTestClient,
-  Client,
 } from '../../__utils__'
 import { Service } from '~/internals/auth'
 
-let client: Client
-beforeEach(() => {
-  client = createTestClient({
-    service: Service.Serlo,
-    user: user.id,
-  })
-})
-
 describe('setUuidState', () => {
   test('authenticated', async () => {
+    const client = createTestClient({
+      service: Service.Serlo,
+      user: user.id,
+    })
     global.server.use(
       rest.post(
         `http://de.${process.env.SERLO_ORG_HOST}/api/set-uuid-state/${article.id}`,
@@ -57,11 +52,11 @@ describe('setUuidState', () => {
     )
     await assertSuccessfulGraphQLMutation({
       ...createSetUuidStateMutation({
-        id: 1,
+        id: article.id,
         trashed: false,
       }),
       client,
-      //TODO: Add data
+      data: null, //TODO: decide on the correct return value
     })
   })
 
@@ -109,7 +104,9 @@ describe('setUuidState', () => {
     return {
       mutation: gql`
         mutation setUuidState($id: Int!, $trashed: Boolean!) {
-          setUuidState(id: $id, trashed: $trashed)
+          setUuidState(id: $id, trashed: $trashed) {
+            id
+          }
         }
       `,
       variables,

--- a/__tests__/schema/uuid/set-uuid-state.ts
+++ b/__tests__/schema/uuid/set-uuid-state.ts
@@ -23,7 +23,6 @@ import { gql } from 'apollo-server'
 import { rest } from 'msw'
 
 import { article, user, user2 } from '../../../__fixtures__'
-import { Service } from '../../../src/graphql/schema/types'
 import { MutationSetUuidStateArgs } from '../../../src/types'
 import {
   assertFailingGraphQLMutation,
@@ -31,6 +30,7 @@ import {
   createTestClient,
   Client,
 } from '../../__utils__'
+import { Service } from '~/internals/auth'
 
 let client: Client
 beforeEach(() => {

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -943,6 +943,7 @@ export type Mutation = {
     _setCache?: Maybe<Scalars['Boolean']>;
     _updateCache?: Maybe<Scalars['Boolean']>;
     setNotificationState?: Maybe<Scalars['Boolean']>;
+    setUuidState?: Maybe<AbstractUuid>;
 };
 
 // @public (undocumented)
@@ -965,6 +966,12 @@ export type Mutation_UpdateCacheArgs = {
 export type MutationSetNotificationStateArgs = {
     id: Scalars['Int'];
     unread: Scalars['Boolean'];
+};
+
+// @public (undocumented)
+export type MutationSetUuidStateArgs = {
+    id: Scalars['Int'];
+    trashed: Scalars['Boolean'];
 };
 
 // @public (undocumented)

--- a/src/model/serlo.ts
+++ b/src/model/serlo.ts
@@ -126,6 +126,34 @@ export function createSerloModel({
     environment
   )
 
+  const setUuidState = createMutation<
+    {
+      id: number
+      userId: number
+      trashed: boolean
+    },
+    AbstractUuidPayload | null
+  >({
+    mutate: async (mutationData: {
+      id: number
+      userId: number
+      trashed: boolean
+    }) => {
+      const value = await post<AbstractUuidPayload | null>({
+        path: `/api/set-uuid-state/${mutationData.id}`,
+        body: {
+          userId: mutationData.userId,
+          trashed: mutationData.trashed,
+        },
+      })
+      await environment.cache.set({
+        key: `de.serlo.org/api/uuid/${mutationData.id}`,
+        value,
+      })
+      return value
+    },
+  })
+
   const getActiveAuthorIds = createQuery<undefined, number[]>(
     {
       getCurrentValue: async () => {
@@ -464,6 +492,7 @@ export function createSerloModel({
     getSubscriptions,
     getThreadIds,
     getUuid,
+    setUuidState,
     removeCacheValue,
     setCacheValue,
     setNotificationState,

--- a/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -98,7 +98,7 @@ export const resolvers: AbstractUuidResolvers = {
 
       if (_user === null) throw new AuthenticationError('You are not logged in')
 
-      return await dataSources.serlo.setUuidState<UuidPayload>({
+      return await dataSources.model.serlo.setUuidState({
         id: payload.id,
         userId: _user,
         trashed: payload.trashed,

--- a/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -98,12 +98,11 @@ export const resolvers: AbstractUuidResolvers = {
 
       if (_user === null) throw new AuthenticationError('You are not logged in')
 
-      const uuidValue = await dataSources.serlo.setUuidState<UuidPayload>({
+      return await dataSources.serlo.setUuidState<UuidPayload>({
         id: payload.id,
         userId: _user,
         trashed: payload.trashed,
       })
-      return uuidValue
     },
   },
 }

--- a/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -19,7 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { UserInputError } from 'apollo-server'
+import { AuthenticationError, UserInputError } from 'apollo-server'
 
 import { decodePath } from '../alias'
 import { AbstractUuidResolvers, DiscriminatorType, UuidPayload } from './types'
@@ -81,6 +81,29 @@ export const resolvers: AbstractUuidResolvers = {
       } else {
         throw new UserInputError('you need to provide an id or an alias')
       }
+    },
+  },
+  Mutation: {
+    //TODO: discuss:
+    //if we want to return a useful uuid to the frontend we would actually have to query all the data we need to rebuild the current page
+    // `mutation {setUuidState(id: 22, trashed:true){ __typename, … }}`
+    // this seems a bit off, since a reload would do the same without any additional code.
+
+    async setUuidState(_parent, payload, { dataSources, user }) {
+      //debug
+      console.log('Hello setUuidState')
+      console.log(user)
+      const _user = 18981
+      //
+
+      if (_user === null) throw new AuthenticationError('You are not logged in')
+
+      const uuidValue = await dataSources.serlo.setUuidState<UuidPayload>({
+        id: payload.id,
+        userId: _user,
+        trashed: payload.trashed,
+      })
+      return uuidValue
     },
   },
 }

--- a/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -91,16 +91,16 @@ export const resolvers: AbstractUuidResolvers = {
 
     async setUuidState(_parent, payload, { dataSources, user }) {
       //debug
-      console.log('Hello setUuidState')
-      console.log(user)
-      const _user = 18981
+      // console.log('Hello setUuidState')
+      // console.log(user)
+      // const _user = 18981
       //
 
-      if (_user === null) throw new AuthenticationError('You are not logged in')
+      if (user === null) throw new AuthenticationError('You are not logged in')
 
       return await dataSources.model.serlo.setUuidState({
         id: payload.id,
-        userId: _user,
+        userId: user,
         trashed: payload.trashed,
       })
     },

--- a/src/schema/uuid/abstract-uuid/types.graphql
+++ b/src/schema/uuid/abstract-uuid/types.graphql
@@ -24,3 +24,7 @@ type AbstractUuidCursor {
 type Query {
   uuid(alias: AliasInput, id: Int): AbstractUuid
 }
+
+extend type Mutation {
+  setUuidState(id: Int!, trashed: Boolean!): AbstractUuid
+}

--- a/src/schema/uuid/abstract-uuid/types.ts
+++ b/src/schema/uuid/abstract-uuid/types.ts
@@ -30,8 +30,18 @@ import { PagePayload, PageRevisionPayload } from '../page'
 import { TaxonomyTermPayload } from '../taxonomy-term'
 import { CommentPayload, ThreadData } from '../thread/types'
 import { UserPayload } from '../user'
-import { QueryResolver, Resolver, TypeResolver } from '~/internals/graphql'
-import { AbstractUuid, AbstractUuidThreadsArgs, QueryUuidArgs } from '~/types'
+import {
+  MutationResolver,
+  QueryResolver,
+  Resolver,
+  TypeResolver,
+} from '~/internals/graphql'
+import {
+  AbstractUuid,
+  AbstractUuidThreadsArgs,
+  MutationSetUuidStateArgs,
+  QueryUuidArgs,
+} from '~/types'
 
 export enum DiscriminatorType {
   Page = 'Page',
@@ -70,5 +80,8 @@ export interface AbstractUuidResolvers {
   }
   Query: {
     uuid: QueryResolver<QueryUuidArgs, UuidPayload | null>
+  }
+  Mutation: {
+    setUuidState: MutationResolver<MutationSetUuidStateArgs, UuidPayload | null>
   }
 }

--- a/src/schema/uuid/abstract-uuid/types.ts
+++ b/src/schema/uuid/abstract-uuid/types.ts
@@ -82,6 +82,9 @@ export interface AbstractUuidResolvers {
     uuid: QueryResolver<QueryUuidArgs, UuidPayload | null>
   }
   Mutation: {
-    setUuidState: MutationResolver<MutationSetUuidStateArgs, UuidPayload | null>
+    setUuidState: MutationResolver<
+      MutationSetUuidStateArgs,
+      AbstractUuidPayload | null
+    >
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,7 @@ export type Mutation = {
   _setCache?: Maybe<Scalars['Boolean']>;
   _updateCache?: Maybe<Scalars['Boolean']>;
   setNotificationState?: Maybe<Scalars['Boolean']>;
+  setUuidState?: Maybe<AbstractUuid>;
 };
 
 
@@ -134,6 +135,12 @@ export type Mutation_UpdateCacheArgs = {
 export type MutationSetNotificationStateArgs = {
   id: Scalars['Int'];
   unread: Scalars['Boolean'];
+};
+
+
+export type MutationSetUuidStateArgs = {
+  id: Scalars['Int'];
+  trashed: Scalars['Boolean'];
 };
 
 export type PageInfo = {


### PR DESCRIPTION
(rebase, follow up of https://github.com/serlo/api.serlo.org/pull/149) (for issue #53)

### Return type of this mutation?
If we want to return a useful uuid to the frontend we would actually have to query all the data we need to rebuild the current page inside of the mutation:

``` gql
mutation {setUuidState(id: 22, trashed:true){ __typename, …, …, … }}
```

this seems a bit much compared to `setUuidState(id: 22, trashed:true)`
Especially since a "reload" would do the same without any additional code and the cache is not rewritten when the mutation runs, the delay should be very small.
Personally I'd go with void / boolean as return type. 
What do you think @kulla and @inyono?

### State of PR
- added basic tests, review welcome
- depends on changes to the legacy handler (new `/api/set-uuid-state/` endpoint)
- add/check pacts tests