### PR TITLE
Allow up to 50 requests in parallel per instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.14.2](https://github.com/serlo/api.serlo.org/compare/v0.14.1..v0.14.2) - December 24, 2020
+
+### Changed
+
+- Increase the number of parallel requests when processing SWR updates.
+
 ## [v0.14.1](https://github.com/serlo/api.serlo.org/compare/v0.14.0..v0.14.1) - December 23, 2020
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "bugs": {
     "url": "https://github.com/serlo/api.serlo.org/issues"

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -436,6 +436,13 @@ async function exec(): Promise<void> {
       date: '2020-12-23',
       fixed: ['Remove completed jobs from SWR Queue.'],
     },
+    {
+      tagName: 'v0.14.2',
+      date: '2020-12-24',
+      changed: [
+        'Increase the number of parallel requests when processing SWR updates.',
+      ],
+    },
   ])
 
   await writeFile(path.join(__dirname, '..', 'CHANGELOG.md'), content)

--- a/src/internals/swr-queue.ts
+++ b/src/internals/swr-queue.ts
@@ -94,6 +94,7 @@ export function createSwrQueue({
   })
 
   queue.process(
+    50,
     async (job): Promise<string> => {
       const { key } = job.data
       const cacheEntry = await cache.get<unknown>({ key })


### PR DESCRIPTION
Hotfix / Workaround until we got a better solution for #171.