### PR TITLE
uuid: refactor threads into new interface

### DIFF
--- a/__tests__/schema/uuid/thread.ts
+++ b/__tests__/schema/uuid/thread.ts
@@ -245,9 +245,11 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyTitle($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                title
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  title
+                }
               }
             }
           }

--- a/__tests__/schema/uuid/thread.ts
+++ b/__tests__/schema/uuid/thread.ts
@@ -60,13 +60,15 @@ describe('uuid["threads"]', () => {
       query: gql`
         query threads($id: Int!) {
           uuid(id: $id) {
-            threads {
-              totalCount
-              nodes {
-                comments {
-                  totalCount
-                  nodes {
-                    id
+            ... on ThreadAware {
+              threads {
+                totalCount
+                nodes {
+                  comments {
+                    totalCount
+                    nodes {
+                      id
+                    }
                   }
                 }
               }
@@ -101,13 +103,15 @@ describe('uuid["threads"]', () => {
       query: gql`
         query threads($id: Int!) {
           uuid(id: $id) {
-            threads {
-              totalCount
-              nodes {
-                comments {
-                  totalCount
-                  nodes {
-                    id
+            ... on ThreadAware {
+              threads {
+                totalCount
+                nodes {
+                  comments {
+                    totalCount
+                    nodes {
+                      id
+                    }
                   }
                 }
               }
@@ -141,13 +145,15 @@ describe('uuid["threads"]', () => {
       query: gql`
         query threads($id: Int!) {
           uuid(id: $id) {
-            threads {
-              totalCount
-              nodes {
-                comments {
-                  totalCount
-                  nodes {
-                    id
+            ... on ThreadAware {
+              threads {
+                totalCount
+                nodes {
+                  comments {
+                    totalCount
+                    nodes {
+                      id
+                    }
                   }
                 }
               }
@@ -167,9 +173,11 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyCreatedAt($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                createdAt
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  createdAt
+                }
               }
             }
           }
@@ -189,9 +197,11 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyUpdatedAt($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                updatedAt
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  updatedAt
+                }
               }
             }
           }
@@ -211,9 +221,11 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyTitle($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                title
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  title
+                }
               }
             }
           }
@@ -255,9 +267,11 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyArchived($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                archived
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  archived
+                }
               }
             }
           }
@@ -277,9 +291,11 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyTrashed($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                trashed
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  trashed
+                }
               }
             }
           }
@@ -299,10 +315,12 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyObject($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                object {
-                  id
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  object {
+                    id
+                  }
                 }
               }
             }
@@ -360,11 +378,13 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyCreatedAt($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                comments {
-                  nodes {
-                    createdAt
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  comments {
+                    nodes {
+                      createdAt
+                    }
                   }
                 }
               }
@@ -402,12 +422,14 @@ describe('uuid["threads"]', () => {
       query: gql`
         query propertyCreatedAt($id: Int!) {
           uuid(id: $id) {
-            threads {
-              nodes {
-                comments {
-                  nodes {
-                    author {
-                      username
+            ... on ThreadAware {
+              threads {
+                nodes {
+                  comments {
+                    nodes {
+                      author {
+                        username
+                      }
                     }
                   }
                 }

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -85,9 +85,18 @@ export type AbstractRevision = {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
     alias?: Maybe<Scalars['String']>;
+    threads: ThreadsConnection;
     author: User;
     date: Scalars['DateTime'];
     content: Scalars['String'];
+};
+
+// @public (undocumented)
+export type AbstractRevisionThreadsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -236,7 +236,7 @@ export type Article = AbstractUuid & AbstractRepository & AbstractEntity & Abstr
 };
 
 // @public (undocumented)
-export type ArticleRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type ArticleRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'ArticleRevision';
     id: Scalars['Int'];
     author: User;
@@ -344,7 +344,7 @@ export type CommentEdge = {
 };
 
 // @public (undocumented)
-export type Course = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Course = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
     __typename?: 'Course';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -360,7 +360,7 @@ export type Course = AbstractUuid & AbstractRepository & AbstractEntity & Abstra
 };
 
 // @public (undocumented)
-export type CoursePage = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & {
+export type CoursePage = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & ThreadAware & {
     __typename?: 'CoursePage';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -375,7 +375,7 @@ export type CoursePage = AbstractUuid & AbstractRepository & AbstractEntity & In
 };
 
 // @public (undocumented)
-export type CoursePageRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type CoursePageRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'CoursePageRevision';
     id: Scalars['Int'];
     author: User;
@@ -431,7 +431,7 @@ export type CoursePageThreadsArgs = {
 };
 
 // @public (undocumented)
-export type CourseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type CourseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'CourseRevision';
     id: Scalars['Int'];
     author: User;
@@ -578,7 +578,7 @@ export type CreateThreadNotificationEvent = AbstractNotificationEvent & Instance
 };
 
 // @public (undocumented)
-type Event_2 = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+type Event_2 = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
     __typename?: 'Event';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -595,7 +595,7 @@ type Event_2 = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxo
 export { Event_2 as Event }
 
 // @public (undocumented)
-export type EventRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type EventRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'EventRevision';
     id: Scalars['Int'];
     author: User;
@@ -668,7 +668,7 @@ export type Exact<T extends {
 };
 
 // @public (undocumented)
-export type Exercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & AbstractExercise & InstanceAware & {
+export type Exercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & AbstractExercise & InstanceAware & ThreadAware & {
     __typename?: 'Exercise';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -684,7 +684,7 @@ export type Exercise = AbstractUuid & AbstractRepository & AbstractEntity & Abst
 };
 
 // @public (undocumented)
-export type ExerciseGroup = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type ExerciseGroup = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
     __typename?: 'ExerciseGroup';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -700,7 +700,7 @@ export type ExerciseGroup = AbstractUuid & AbstractRepository & AbstractEntity &
 };
 
 // @public (undocumented)
-export type ExerciseGroupRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type ExerciseGroupRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'ExerciseGroupRevision';
     id: Scalars['Int'];
     author: User;
@@ -763,7 +763,7 @@ export type ExerciseGroupThreadsArgs = {
 };
 
 // @public (undocumented)
-export type ExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & {
+export type ExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & ThreadAware & {
     __typename?: 'ExerciseRevision';
     id: Scalars['Int'];
     author: User;
@@ -826,7 +826,7 @@ export type ExerciseThreadsArgs = {
 };
 
 // @public (undocumented)
-export type GroupedExercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractExercise & InstanceAware & {
+export type GroupedExercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractExercise & InstanceAware & ThreadAware & {
     __typename?: 'GroupedExercise';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -842,7 +842,7 @@ export type GroupedExercise = AbstractUuid & AbstractRepository & AbstractEntity
 };
 
 // @public (undocumented)
-export type GroupedExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & {
+export type GroupedExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & ThreadAware & {
     __typename?: 'GroupedExerciseRevision';
     id: Scalars['Int'];
     author: User;
@@ -1068,7 +1068,7 @@ export type NotificationSetStateResponse = {
 };
 
 // @public (undocumented)
-export type Page = AbstractUuid & AbstractRepository & AbstractNavigationChild & InstanceAware & {
+export type Page = AbstractUuid & AbstractRepository & AbstractNavigationChild & InstanceAware & ThreadAware & {
     __typename?: 'Page';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -1092,7 +1092,7 @@ export type PageInfo = {
 };
 
 // @public (undocumented)
-export type PageRevision = AbstractUuid & AbstractRevision & {
+export type PageRevision = AbstractUuid & AbstractRevision & ThreadAware & {
     __typename?: 'PageRevision';
     id: Scalars['Int'];
     author: User;
@@ -1343,7 +1343,7 @@ export type SetUuidStateNotificationEvent = AbstractNotificationEvent & Instance
 };
 
 // @public (undocumented)
-export type Solution = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & {
+export type Solution = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & ThreadAware & {
     __typename?: 'Solution';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -1358,7 +1358,7 @@ export type Solution = AbstractUuid & AbstractRepository & AbstractEntity & Inst
 };
 
 // @public (undocumented)
-export type SolutionRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type SolutionRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'SolutionRevision';
     id: Scalars['Int'];
     author: User;
@@ -1651,7 +1651,7 @@ export type Video = AbstractUuid & AbstractRepository & AbstractEntity & Abstrac
 };
 
 // @public (undocumented)
-export type VideoRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type VideoRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'VideoRevision';
     id: Scalars['Int'];
     author: User;

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -66,9 +66,18 @@ export type AbstractRepository = {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
     alias?: Maybe<Scalars['String']>;
+    threads: ThreadsConnection;
     date: Scalars['DateTime'];
     instance: Instance;
     license: License;
+};
+
+// @public (undocumented)
+export type AbstractRepositoryThreadsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)
@@ -105,7 +114,6 @@ export type AbstractUuid = {
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
     alias?: Maybe<Scalars['String']>;
-    threads: ThreadsConnection;
 };
 
 // @public (undocumented)
@@ -125,21 +133,13 @@ export type AbstractUuidCursor = {
 };
 
 // @public (undocumented)
-export type AbstractUuidThreadsArgs = {
-    after?: Maybe<Scalars['String']>;
-    before?: Maybe<Scalars['String']>;
-    first?: Maybe<Scalars['Int']>;
-    last?: Maybe<Scalars['Int']>;
-};
-
-// @public (undocumented)
 export type AliasInput = {
     instance: Instance;
     path: Scalars['String'];
 };
 
 // @public (undocumented)
-export type Applet = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Applet = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
     __typename?: 'Applet';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -154,7 +154,7 @@ export type Applet = AbstractUuid & AbstractRepository & AbstractEntity & Abstra
 };
 
 // @public (undocumented)
-export type AppletRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type AppletRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
     __typename?: 'AppletRevision';
     id: Scalars['Int'];
     author: User;
@@ -221,7 +221,7 @@ export type AppletThreadsArgs = {
 };
 
 // @public (undocumented)
-export type Article = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Article = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
     __typename?: 'Article';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -325,7 +325,6 @@ export type Comment = AbstractUuid & {
     archived: Scalars['Boolean'];
     createdAt: Scalars['DateTime'];
     author: User;
-    threads: ThreadsConnection;
 };
 
 // @public (undocumented)
@@ -342,14 +341,6 @@ export type CommentEdge = {
     __typename?: 'CommentEdge';
     cursor: Scalars['String'];
     node: Comment;
-};
-
-// @public (undocumented)
-export type CommentThreadsArgs = {
-    after?: Maybe<Scalars['String']>;
-    before?: Maybe<Scalars['String']>;
-    first?: Maybe<Scalars['Int']>;
-    last?: Maybe<Scalars['Int']>;
 };
 
 // @public (undocumented)
@@ -1445,7 +1436,7 @@ export type SubscriptionCursor = {
 };
 
 // @public (undocumented)
-export type TaxonomyTerm = AbstractUuid & AbstractNavigationChild & InstanceAware & {
+export type TaxonomyTerm = AbstractUuid & AbstractNavigationChild & InstanceAware & ThreadAware & {
     __typename?: 'TaxonomyTerm';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -1532,6 +1523,19 @@ export type Thread = {
 };
 
 // @public (undocumented)
+export type ThreadAware = {
+    threads: ThreadsConnection;
+};
+
+// @public (undocumented)
+export type ThreadAwareThreadsArgs = {
+    after?: Maybe<Scalars['String']>;
+    before?: Maybe<Scalars['String']>;
+    first?: Maybe<Scalars['Int']>;
+    last?: Maybe<Scalars['Int']>;
+};
+
+// @public (undocumented)
 export type ThreadCommentsArgs = {
     after?: Maybe<Scalars['String']>;
     before?: Maybe<Scalars['String']>;
@@ -1568,7 +1572,7 @@ export type UnsupportedThread = {
 };
 
 // @public (undocumented)
-export type User = AbstractUuid & {
+export type User = AbstractUuid & ThreadAware & {
     __typename?: 'User';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -1608,6 +1612,7 @@ export type UserThreadsArgs = {
 };
 
 // @public (undocumented)
+<<<<<<< HEAD
 export type UuidMutation = {
     __typename?: 'UuidMutation';
     setState?: Maybe<UuidSetStateResponse>;
@@ -1633,6 +1638,9 @@ export type UuidSetStateResponse = {
 
 // @public (undocumented)
 export type Video = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+=======
+export type Video = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
+>>>>>>> 7c35fd2 (uuid: refactor threads into new interface)
     __typename?: 'Video';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -1711,6 +1719,45 @@ export type VideoThreadsArgs = {
     last?: Maybe<Scalars['Int']>;
 };
 
+
+// Warnings were encountered during analysis:
+//
+// src/schema/uuid/applet/resolvers.ts:31:34 - (TS2344) Type 'AppletPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'AppletPayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/applet/resolvers.ts:35:5 - (TS2344) Type 'AppletPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/article/resolvers.ts:31:34 - (TS2344) Type 'ArticlePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'ArticlePayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/article/resolvers.ts:35:5 - (TS2344) Type 'ArticlePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/course-page/resolvers.ts:34:7 - (TS2344) Type 'CoursePagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'CoursePagePayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/course-page/resolvers.ts:51:5 - (TS2344) Type 'CoursePagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/course/resolvers.ts:32:34 - (TS2344) Type 'CoursePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'CoursePayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/course/resolvers.ts:43:5 - (TS2344) Type 'CoursePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/event/resolvers.ts:31:34 - (TS2344) Type 'EventPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'EventPayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/event/resolvers.ts:34:42 - (TS2344) Type 'EventPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/exercise-group/resolvers.ts:33:7 - (TS2344) Type 'ExerciseGroupPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'ExerciseGroupPayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/exercise-group/resolvers.ts:50:5 - (TS2344) Type 'ExerciseGroupPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/exercise/resolvers.ts:32:34 - (TS2344) Type 'ExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'ExercisePayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/exercise/resolvers.ts:37:5 - (TS2344) Type 'ExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/grouped-exercise/resolvers.ts:35:7 - (TS2344) Type 'GroupedExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'GroupedExercisePayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/grouped-exercise/resolvers.ts:53:5 - (TS2344) Type 'GroupedExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/page/resolvers.ts:31:34 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'PagePayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/page/resolvers.ts:39:41 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/page/types.ts:44:29 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'PagePayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/page/types.ts:47:35 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/solution/resolvers.ts:31:34 - (TS2344) Type 'SolutionPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'SolutionPayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/solution/resolvers.ts:43:5 - (TS2344) Type 'SolutionPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+// src/schema/uuid/video/resolvers.ts:31:34 - (TS2344) Type 'VideoPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
+//   Property 'threads' is missing in type 'VideoPayload' but required in type 'AbstractRepositoryPayload'.
+// src/schema/uuid/video/resolvers.ts:34:42 - (TS2344) Type 'VideoPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
 
 // (No @packageDocumentation comment for this package)
 

--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -1612,7 +1612,6 @@ export type UserThreadsArgs = {
 };
 
 // @public (undocumented)
-<<<<<<< HEAD
 export type UuidMutation = {
     __typename?: 'UuidMutation';
     setState?: Maybe<UuidSetStateResponse>;
@@ -1637,10 +1636,7 @@ export type UuidSetStateResponse = {
 };
 
 // @public (undocumented)
-export type Video = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
-=======
 export type Video = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
->>>>>>> 7c35fd2 (uuid: refactor threads into new interface)
     __typename?: 'Video';
     id: Scalars['Int'];
     trashed: Scalars['Boolean'];
@@ -1719,45 +1715,6 @@ export type VideoThreadsArgs = {
     last?: Maybe<Scalars['Int']>;
 };
 
-
-// Warnings were encountered during analysis:
-//
-// src/schema/uuid/applet/resolvers.ts:31:34 - (TS2344) Type 'AppletPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'AppletPayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/applet/resolvers.ts:35:5 - (TS2344) Type 'AppletPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/article/resolvers.ts:31:34 - (TS2344) Type 'ArticlePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'ArticlePayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/article/resolvers.ts:35:5 - (TS2344) Type 'ArticlePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/course-page/resolvers.ts:34:7 - (TS2344) Type 'CoursePagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'CoursePagePayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/course-page/resolvers.ts:51:5 - (TS2344) Type 'CoursePagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/course/resolvers.ts:32:34 - (TS2344) Type 'CoursePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'CoursePayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/course/resolvers.ts:43:5 - (TS2344) Type 'CoursePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/event/resolvers.ts:31:34 - (TS2344) Type 'EventPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'EventPayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/event/resolvers.ts:34:42 - (TS2344) Type 'EventPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/exercise-group/resolvers.ts:33:7 - (TS2344) Type 'ExerciseGroupPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'ExerciseGroupPayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/exercise-group/resolvers.ts:50:5 - (TS2344) Type 'ExerciseGroupPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/exercise/resolvers.ts:32:34 - (TS2344) Type 'ExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'ExercisePayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/exercise/resolvers.ts:37:5 - (TS2344) Type 'ExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/grouped-exercise/resolvers.ts:35:7 - (TS2344) Type 'GroupedExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'GroupedExercisePayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/grouped-exercise/resolvers.ts:53:5 - (TS2344) Type 'GroupedExercisePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/page/resolvers.ts:31:34 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'PagePayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/page/resolvers.ts:39:41 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/page/types.ts:44:29 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'PagePayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/page/types.ts:47:35 - (TS2344) Type 'PagePayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/solution/resolvers.ts:31:34 - (TS2344) Type 'SolutionPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'SolutionPayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/solution/resolvers.ts:43:5 - (TS2344) Type 'SolutionPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-// src/schema/uuid/video/resolvers.ts:31:34 - (TS2344) Type 'VideoPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
-//   Property 'threads' is missing in type 'VideoPayload' but required in type 'AbstractRepositoryPayload'.
-// src/schema/uuid/video/resolvers.ts:34:42 - (TS2344) Type 'VideoPayload' does not satisfy the constraint 'AbstractRepositoryPayload'.
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/schema/uuid/abstract-repository/types.graphql
+++ b/src/schema/uuid/abstract-repository/types.graphql
@@ -25,6 +25,14 @@ interface AbstractRevision {
   trashed: Boolean!
   alias: String
 
+  # extends ThreadAware
+  threads(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ThreadsConnection!
+
   # Implicitly has the following field
   # repository: AbstractRepository!
   author: User!

--- a/src/schema/uuid/abstract-repository/types.graphql
+++ b/src/schema/uuid/abstract-repository/types.graphql
@@ -4,6 +4,14 @@ interface AbstractRepository {
   trashed: Boolean!
   alias: String
 
+  # extends ThreadAware
+  threads(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ThreadsConnection!
+
   date: DateTime!
   instance: Instance!
   license: License!

--- a/src/schema/uuid/abstract-repository/types.ts
+++ b/src/schema/uuid/abstract-repository/types.ts
@@ -52,7 +52,14 @@ export type RepositoryType = EntityType | DiscriminatorType.Page
 
 export type RepositoryPayload = EntityPayload | PagePayload
 export interface AbstractRepositoryPayload
-  extends Omit<AbstractRepository, 'alias' | 'currentRevision' | 'license'> {
+  extends Omit<
+    AbstractRepository,
+    // Remove everything that has its own resolver
+    keyof RepositoryResolvers<
+      AbstractRepositoryPayload,
+      AbstractRevisionPayload
+    >
+  > {
   __typename: RepositoryType
   alias: string | null
   currentRevisionId: number | null

--- a/src/schema/uuid/abstract-repository/types.ts
+++ b/src/schema/uuid/abstract-repository/types.ts
@@ -113,7 +113,8 @@ export interface RepositoryResolvers<
 export interface RevisionResolvers<
   E extends AbstractRepositoryPayload,
   R extends AbstractRevisionPayload
-> extends UuidResolvers {
+> extends UuidResolvers,
+    ThreadAwareResolvers {
   author: Resolver<R, never, Partial<UserPayload> | null>
   repository: Resolver<R, never, E | null>
 }

--- a/src/schema/uuid/abstract-repository/types.ts
+++ b/src/schema/uuid/abstract-repository/types.ts
@@ -28,6 +28,7 @@ import {
 } from '../abstract-entity'
 import { DiscriminatorType, UuidResolvers } from '../abstract-uuid'
 import { PagePayload, PageRevisionPayload } from '../page'
+import { ThreadAwareResolvers } from '../thread'
 import { UserPayload } from '../user'
 import { Resolver, TypeResolver } from '~/internals/graphql'
 import {
@@ -95,7 +96,8 @@ type AbstractRepositoryRevisionsArgs =
 export interface RepositoryResolvers<
   E extends AbstractRepositoryPayload,
   R extends AbstractRevisionPayload
-> extends UuidResolvers {
+> extends UuidResolvers,
+    ThreadAwareResolvers {
   currentRevision: Resolver<E, never, R | null>
   revisions: Resolver<E, AbstractRepositoryRevisionsArgs, Connection<R>>
   license: Resolver<E, never, Partial<License>>

--- a/src/schema/uuid/abstract-repository/types.ts
+++ b/src/schema/uuid/abstract-repository/types.ts
@@ -71,7 +71,7 @@ export type RevisionType = EntityRevisionType | DiscriminatorType.PageRevision
 
 export type RevisionPayload = EntityRevisionPayload | PageRevisionPayload
 export interface AbstractRevisionPayload
-  extends Omit<AbstractRevision, 'author' | 'repository'> {
+  extends Omit<AbstractRevision, 'author' | 'repository' | 'threads'> {
   __typename: RevisionType
   alias: null
   authorId: number

--- a/src/schema/uuid/abstract-repository/utils.ts
+++ b/src/schema/uuid/abstract-repository/utils.ts
@@ -24,6 +24,7 @@ import { array as A, pipeable } from 'fp-ts'
 import { resolveConnection } from '../../connection'
 import { isDefined } from '../../utils'
 import { createUuidResolvers } from '../abstract-uuid'
+import { createThreadResolvers } from '../thread'
 import { resolveUser } from '../user'
 import {
   AbstractRepositoryPayload,
@@ -39,6 +40,7 @@ export function createRepositoryResolvers<
 >(): RepositoryResolvers<E, R> {
   return {
     ...createUuidResolvers(),
+    ...createThreadResolvers(),
     async currentRevision(entity, _args, { dataSources }) {
       if (!entity.currentRevisionId) return null
       return (await dataSources.model.serlo.getUuid({

--- a/src/schema/uuid/abstract-repository/utils.ts
+++ b/src/schema/uuid/abstract-repository/utils.ts
@@ -90,6 +90,7 @@ export function createRevisionResolvers<
 >(): RevisionResolvers<E, R> {
   return {
     ...createUuidResolvers(),
+    ...createThreadResolvers(),
     author(entityRevision, _args, context, info) {
       return resolveUser({ id: entityRevision.authorId }, context, info)
     },

--- a/src/schema/uuid/abstract-uuid/types.graphql
+++ b/src/schema/uuid/abstract-uuid/types.graphql
@@ -2,12 +2,6 @@ interface AbstractUuid {
   id: Int!
   trashed: Boolean!
   alias: String
-  threads(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): ThreadsConnection!
 }
 
 type AbstractUuidConnection {

--- a/src/schema/uuid/abstract-uuid/types.ts
+++ b/src/schema/uuid/abstract-uuid/types.ts
@@ -19,7 +19,6 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import { Connection } from '../../connection'
 import {
   EntityPayload,
   EntityRevisionPayload,
@@ -28,7 +27,7 @@ import {
 } from '../abstract-entity'
 import { PagePayload, PageRevisionPayload } from '../page'
 import { TaxonomyTermPayload } from '../taxonomy-term'
-import { CommentPayload, ThreadData } from '../thread/types'
+import { CommentPayload } from '../thread/types'
 import { UserPayload } from '../user'
 import {
   MutationNamespace,
@@ -40,7 +39,6 @@ import {
 import {
   AbstractUuid,
   UuidMutationSetStateArgs,
-  AbstractUuidThreadsArgs,
   QueryUuidArgs,
   UuidSetStateResponse,
 } from '~/types'
@@ -71,11 +69,6 @@ export interface AbstractUuidPayload
 
 export interface UuidResolvers {
   alias: Resolver<AbstractUuidPayload, never, string | null>
-  threads: Resolver<
-    AbstractUuidPayload,
-    AbstractUuidThreadsArgs,
-    Connection<ThreadData>
-  >
 }
 
 export interface AbstractUuidResolvers {

--- a/src/schema/uuid/abstract-uuid/utils.ts
+++ b/src/schema/uuid/abstract-uuid/utils.ts
@@ -24,7 +24,6 @@ import * as R from 'ramda'
 import { EntityRevisionType, EntityType } from '../abstract-entity'
 import { AbstractUuidPayload, UuidResolvers } from '../abstract-uuid'
 import { createAliasResolvers } from '../alias'
-import { createThreadResolvers } from '../thread/utils'
 import { DiscriminatorType } from './types'
 
 const validTypes = [
@@ -38,5 +37,5 @@ export function isUnsupportedUuid(payload: AbstractUuidPayload) {
 }
 
 export function createUuidResolvers(): UuidResolvers {
-  return { ...createAliasResolvers(), ...createThreadResolvers() }
+  return { ...createAliasResolvers() }
 }

--- a/src/schema/uuid/abstract-uuid/utils.ts
+++ b/src/schema/uuid/abstract-uuid/utils.ts
@@ -37,5 +37,5 @@ export function isUnsupportedUuid(payload: AbstractUuidPayload) {
 }
 
 export function createUuidResolvers(): UuidResolvers {
-  return { ...createAliasResolvers() }
+  return createAliasResolvers()
 }

--- a/src/schema/uuid/applet/types.graphql
+++ b/src/schema/uuid/applet/types.graphql
@@ -1,4 +1,4 @@
-type Applet implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware {
+type Applet implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -27,7 +27,7 @@ type Applet implements AbstractUuid & AbstractRepository & AbstractEntity & Abst
   ): TaxonomyTermConnection!
 }
 
-type AppletRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type AppletRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/article/types.graphql
+++ b/src/schema/uuid/article/types.graphql
@@ -27,7 +27,7 @@ type Article implements AbstractUuid & AbstractRepository & AbstractEntity & Abs
   ): TaxonomyTermConnection!
 }
 
-type ArticleRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type ArticleRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/article/types.graphql
+++ b/src/schema/uuid/article/types.graphql
@@ -1,4 +1,4 @@
-type Article implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware {
+type Article implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(

--- a/src/schema/uuid/course-page/types.graphql
+++ b/src/schema/uuid/course-page/types.graphql
@@ -1,4 +1,4 @@
-type CoursePage implements AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware {
+type CoursePage implements AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -22,7 +22,7 @@ type CoursePage implements AbstractUuid & AbstractRepository & AbstractEntity & 
   course: Course!
 }
 
-type CoursePageRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type CoursePageRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/course/types.graphql
+++ b/src/schema/uuid/course/types.graphql
@@ -1,4 +1,4 @@
-type Course implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware {
+type Course implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -28,7 +28,7 @@ type Course implements AbstractUuid & AbstractRepository & AbstractEntity & Abst
   pages: [CoursePage!]!
 }
 
-type CourseRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type CourseRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/event/types.graphql
+++ b/src/schema/uuid/event/types.graphql
@@ -1,4 +1,4 @@
-type Event implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware {
+type Event implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -27,7 +27,7 @@ type Event implements AbstractUuid & AbstractRepository & AbstractEntity & Abstr
   ): TaxonomyTermConnection!
 }
 
-type EventRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type EventRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/exercise-group/types.graphql
+++ b/src/schema/uuid/exercise-group/types.graphql
@@ -1,4 +1,4 @@
-type ExerciseGroup implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware {
+type ExerciseGroup implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -28,7 +28,7 @@ type ExerciseGroup implements AbstractUuid & AbstractRepository & AbstractEntity
   exercises: [GroupedExercise!]!
 }
 
-type ExerciseGroupRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type ExerciseGroupRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/exercise/types.graphql
+++ b/src/schema/uuid/exercise/types.graphql
@@ -1,4 +1,4 @@
-type Exercise implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & AbstractExercise & InstanceAware {
+type Exercise implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & AbstractExercise & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -28,7 +28,7 @@ type Exercise implements AbstractUuid & AbstractRepository & AbstractEntity & Ab
   solution: Solution
 }
 
-type ExerciseRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision {
+type ExerciseRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/grouped-exercise/types.graphql
+++ b/src/schema/uuid/grouped-exercise/types.graphql
@@ -1,4 +1,4 @@
-type GroupedExercise implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractExercise & InstanceAware {
+type GroupedExercise implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractExercise & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -23,7 +23,7 @@ type GroupedExercise implements AbstractUuid & AbstractRepository & AbstractEnti
   exerciseGroup: ExerciseGroup!
 }
 
-type GroupedExerciseRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision {
+type GroupedExerciseRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/page/types.graphql
+++ b/src/schema/uuid/page/types.graphql
@@ -1,4 +1,4 @@
-type Page implements AbstractUuid & AbstractRepository & AbstractNavigationChild & InstanceAware {
+type Page implements AbstractUuid & AbstractRepository & AbstractNavigationChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -22,7 +22,7 @@ type Page implements AbstractUuid & AbstractRepository & AbstractNavigationChild
   navigation: Navigation
 }
 
-type PageRevision implements AbstractUuid & AbstractRevision {
+type PageRevision implements AbstractUuid & AbstractRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/solution/types.graphql
+++ b/src/schema/uuid/solution/types.graphql
@@ -1,4 +1,4 @@
-type Solution implements AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware {
+type Solution implements AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(
@@ -22,7 +22,7 @@ type Solution implements AbstractUuid & AbstractRepository & AbstractEntity & In
   exercise: AbstractExercise!
 }
 
-type SolutionRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type SolutionRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/schema/uuid/taxonomy-term/resolvers.ts
+++ b/src/schema/uuid/taxonomy-term/resolvers.ts
@@ -22,12 +22,14 @@
 import { resolveConnection } from '../../connection'
 import { isDefined } from '../../utils'
 import { createUuidResolvers } from '../abstract-uuid'
+import { createThreadResolvers } from '../thread'
 import { TaxonomyTermPayload, TaxonomyTermResolvers } from './types'
 import { Context } from '~/internals/graphql'
 
 export const resolvers: TaxonomyTermResolvers = {
   TaxonomyTerm: {
     ...createUuidResolvers(),
+    ...createThreadResolvers(),
     async parent(taxonomyTerm, _args, { dataSources }) {
       if (!taxonomyTerm.parentId) return null
       return (await dataSources.model.serlo.getUuid({

--- a/src/schema/uuid/taxonomy-term/types.graphql
+++ b/src/schema/uuid/taxonomy-term/types.graphql
@@ -12,7 +12,7 @@ enum TaxonomyTermType {
   topicFolder
 }
 
-type TaxonomyTerm implements AbstractUuid & AbstractNavigationChild & InstanceAware {
+type TaxonomyTerm implements AbstractUuid & AbstractNavigationChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(

--- a/src/schema/uuid/taxonomy-term/types.ts
+++ b/src/schema/uuid/taxonomy-term/types.ts
@@ -26,6 +26,7 @@ import {
   DiscriminatorType,
   UuidResolvers,
 } from '../abstract-uuid'
+import { ThreadAwareResolvers } from '../thread'
 import { Resolver } from '~/internals/graphql'
 import { TaxonomyTerm, TaxonomyTermChildrenArgs } from '~/types'
 
@@ -46,5 +47,6 @@ export interface TaxonomyTermResolvers {
       Connection<AbstractUuidPayload>
     >
   } & NavigationChildResolvers<TaxonomyTermPayload> &
-    UuidResolvers
+    UuidResolvers &
+    ThreadAwareResolvers
 }

--- a/src/schema/uuid/thread/index.ts
+++ b/src/schema/uuid/thread/index.ts
@@ -24,5 +24,6 @@ import typeDefs from './types.graphql'
 import { Schema } from '~/internals/graphql'
 
 export * from './types'
+export * from './utils'
 
 export const threadSchema: Schema = { resolvers, typeDefs: [typeDefs] }

--- a/src/schema/uuid/thread/resolvers.ts
+++ b/src/schema/uuid/thread/resolvers.ts
@@ -91,4 +91,9 @@ export const resolvers: ThreadResolvers = {
         : { __typename: ThreadDataType, commentPayloads: [commentPayload] }
     },
   },
+  ThreadAware: {
+    __resolveType(object) {
+      return object.__typename
+    },
+  },
 }

--- a/src/schema/uuid/thread/types.graphql
+++ b/src/schema/uuid/thread/types.graphql
@@ -22,6 +22,9 @@ type Comment implements AbstractUuid {
   archived: Boolean!
   createdAt: DateTime!
   author: User!
+}
+
+interface ThreadAware {
   threads(
     after: String
     before: String

--- a/src/schema/uuid/thread/types.ts
+++ b/src/schema/uuid/thread/types.ts
@@ -22,8 +22,13 @@
 import { Connection } from '../../connection'
 import { DiscriminatorType, UuidPayload, UuidResolvers } from '../abstract-uuid'
 import { UserPayload } from '../user'
-import { MutationResolver, Resolver } from '~/internals/graphql'
-import { MutationCreateThreadArgs, Scalars, ThreadCommentsArgs } from '~/types'
+import { MutationResolver, Resolver, TypeResolver } from '~/internals/graphql'
+import {
+  MutationCreateThreadArgs,
+  Scalars,
+  ThreadAwareThreadsArgs,
+  ThreadCommentsArgs,
+} from '~/types'
 
 export interface ThreadsPayload {
   firstCommentIds: number[]
@@ -57,6 +62,13 @@ export interface ThreadResolvers {
   Mutation: {
     createThread: MutationResolver<MutationCreateThreadArgs, ThreadData | null>
   }
+  ThreadAware: {
+    __resolveType: TypeResolver<UuidPayload>
+  }
+}
+
+export interface ThreadAwareResolvers {
+  threads: Resolver<UuidPayload, ThreadAwareThreadsArgs, Connection<ThreadData>>
 }
 
 export interface CommentPayload {

--- a/src/schema/uuid/thread/utils.ts
+++ b/src/schema/uuid/thread/utils.ts
@@ -23,10 +23,14 @@ import { ApolloError } from 'apollo-server'
 
 import { resolveConnection } from '../../connection'
 import { isDefined } from '../../utils'
-import { UuidResolvers } from '../abstract-uuid'
-import { CommentPayload, ThreadData, ThreadDataType } from './types'
+import {
+  CommentPayload,
+  ThreadAwareResolvers,
+  ThreadData,
+  ThreadDataType,
+} from './types'
 
-export function createThreadResolvers(): Pick<UuidResolvers, 'threads'> {
+export function createThreadResolvers(): ThreadAwareResolvers {
   return {
     async threads(parent, cursorPayload, { dataSources }) {
       const { firstCommentIds } = await Promise.resolve(

--- a/src/schema/uuid/user/resolvers.ts
+++ b/src/schema/uuid/user/resolvers.ts
@@ -24,6 +24,7 @@ import { either as E, pipeable } from 'fp-ts'
 import { CellValues, MajorDimension } from '../../../model'
 import { ConnectionPayload, resolveConnection } from '../../connection'
 import { createUuidResolvers } from '../abstract-uuid'
+import { createThreadResolvers } from '../thread'
 import { isUserPayload, UserPayload, UserResolvers } from './types'
 import { ErrorEvent } from '~/internals/error-event'
 import { Context } from '~/internals/graphql'
@@ -54,6 +55,7 @@ export const resolvers: UserResolvers = {
   },
   User: {
     ...createUuidResolvers(),
+    ...createThreadResolvers(),
     async activeAuthor(user, _args, { dataSources }) {
       return (await dataSources.model.serlo.getActiveAuthorIds()).includes(
         user.id

--- a/src/schema/uuid/user/types.graphql
+++ b/src/schema/uuid/user/types.graphql
@@ -1,4 +1,4 @@
-type User implements AbstractUuid {
+type User implements AbstractUuid & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(

--- a/src/schema/uuid/user/types.ts
+++ b/src/schema/uuid/user/types.ts
@@ -26,6 +26,7 @@ import {
   DiscriminatorType,
   UuidResolvers,
 } from '../abstract-uuid'
+import { ThreadAwareResolvers } from '../thread'
 import { QueryResolver, Resolver } from '~/internals/graphql'
 import {
   QueryActiveAuthorsArgs,
@@ -55,7 +56,8 @@ export interface UserResolvers {
     activeAuthor: Resolver<UserPayload, never, boolean>
     activeDonor: Resolver<UserPayload, never, boolean>
     activeReviewer: Resolver<UserPayload, never, boolean>
-  } & UuidResolvers
+  } & UuidResolvers &
+    ThreadAwareResolvers
 }
 
 export function isUserPayload(

--- a/src/schema/uuid/video/types.graphql
+++ b/src/schema/uuid/video/types.graphql
@@ -1,4 +1,4 @@
-type Video implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware {
+type Video implements AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware {
   id: Int!
   trashed: Boolean!
   threads(

--- a/src/schema/uuid/video/types.graphql
+++ b/src/schema/uuid/video/types.graphql
@@ -27,7 +27,7 @@ type Video implements AbstractUuid & AbstractRepository & AbstractEntity & Abstr
   ): TaxonomyTermConnection!
 }
 
-type VideoRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision {
+type VideoRevision implements AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware {
   id: Int!
   author: User!
   trashed: Boolean!

--- a/src/types.ts
+++ b/src/types.ts
@@ -497,9 +497,18 @@ export type AbstractRepository = {
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
   alias?: Maybe<Scalars['String']>;
+  threads: ThreadsConnection;
   date: Scalars['DateTime'];
   instance: Instance;
   license: License;
+};
+
+
+export type AbstractRepositoryThreadsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type AbstractRevision = {
@@ -547,15 +556,6 @@ export type AbstractUuid = {
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
   alias?: Maybe<Scalars['String']>;
-  threads: ThreadsConnection;
-};
-
-
-export type AbstractUuidThreadsArgs = {
-  after?: Maybe<Scalars['String']>;
-  before?: Maybe<Scalars['String']>;
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
 };
 
 export type AbstractUuidConnection = {
@@ -598,7 +598,7 @@ export type AliasInput = {
   path: Scalars['String'];
 };
 
-export type Applet = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Applet = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'Applet';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -637,7 +637,7 @@ export type AppletTaxonomyTermsArgs = {
   last?: Maybe<Scalars['Int']>;
 };
 
-export type AppletRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type AppletRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'AppletRevision';
   id: Scalars['Int'];
   author: User;
@@ -676,7 +676,7 @@ export type AppletRevisionCursor = {
   node: AppletRevision;
 };
 
-export type Article = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Article = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'Article';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1337,7 +1337,7 @@ export enum TaxonomyTermType {
   TopicFolder = 'topicFolder'
 }
 
-export type TaxonomyTerm = AbstractUuid & AbstractNavigationChild & InstanceAware & {
+export type TaxonomyTerm = AbstractUuid & AbstractNavigationChild & InstanceAware & ThreadAware & {
   __typename?: 'TaxonomyTerm';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1398,11 +1398,14 @@ export type Comment = AbstractUuid & {
   archived: Scalars['Boolean'];
   createdAt: Scalars['DateTime'];
   author: User;
+};
+
+export type ThreadAware = {
   threads: ThreadsConnection;
 };
 
 
-export type CommentThreadsArgs = {
+export type ThreadAwareThreadsArgs = {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
@@ -1447,7 +1450,7 @@ export type CommentEdge = {
   node: Comment;
 };
 
-export type User = AbstractUuid & {
+export type User = AbstractUuid & ThreadAware & {
   __typename?: 'User';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1484,7 +1487,7 @@ export type UserEdge = {
   node: User;
 };
 
-export type Video = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Video = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'Video';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];

--- a/src/types.ts
+++ b/src/types.ts
@@ -715,7 +715,7 @@ export type ArticleTaxonomyTermsArgs = {
   last?: Maybe<Scalars['Int']>;
 };
 
-export type ArticleRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type ArticleRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'ArticleRevision';
   id: Scalars['Int'];
   author: User;
@@ -753,7 +753,7 @@ export type ArticleRevisionCursor = {
   node: ArticleRevision;
 };
 
-export type CoursePage = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & {
+export type CoursePage = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & ThreadAware & {
   __typename?: 'CoursePage';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -784,7 +784,7 @@ export type CoursePageRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
-export type CoursePageRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type CoursePageRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'CoursePageRevision';
   id: Scalars['Int'];
   author: User;
@@ -820,7 +820,7 @@ export type CoursePageRevisionCursor = {
   node: CoursePageRevision;
 };
 
-export type Course = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Course = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'Course';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -860,7 +860,7 @@ export type CourseTaxonomyTermsArgs = {
   last?: Maybe<Scalars['Int']>;
 };
 
-export type CourseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type CourseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'CourseRevision';
   id: Scalars['Int'];
   author: User;
@@ -897,7 +897,7 @@ export type CourseRevisionCursor = {
   node: CourseRevision;
 };
 
-export type Event = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type Event = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'Event';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -936,7 +936,7 @@ export type EventTaxonomyTermsArgs = {
   last?: Maybe<Scalars['Int']>;
 };
 
-export type EventRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type EventRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'EventRevision';
   id: Scalars['Int'];
   author: User;
@@ -974,7 +974,7 @@ export type EventRevisionCursor = {
   node: EventRevision;
 };
 
-export type ExerciseGroup = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & {
+export type ExerciseGroup = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'ExerciseGroup';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1014,7 +1014,7 @@ export type ExerciseGroupTaxonomyTermsArgs = {
   last?: Maybe<Scalars['Int']>;
 };
 
-export type ExerciseGroupRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type ExerciseGroupRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'ExerciseGroupRevision';
   id: Scalars['Int'];
   author: User;
@@ -1049,7 +1049,7 @@ export type ExerciseGroupRevisionCursor = {
   node: ExerciseGroupRevision;
 };
 
-export type Exercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & AbstractExercise & InstanceAware & {
+export type Exercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & AbstractExercise & InstanceAware & ThreadAware & {
   __typename?: 'Exercise';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1089,7 +1089,7 @@ export type ExerciseTaxonomyTermsArgs = {
   last?: Maybe<Scalars['Int']>;
 };
 
-export type ExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & {
+export type ExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & ThreadAware & {
   __typename?: 'ExerciseRevision';
   id: Scalars['Int'];
   author: User;
@@ -1124,7 +1124,7 @@ export type ExerciseRevisionCursor = {
   node: ExerciseRevision;
 };
 
-export type GroupedExercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractExercise & InstanceAware & {
+export type GroupedExercise = AbstractUuid & AbstractRepository & AbstractEntity & AbstractExercise & InstanceAware & ThreadAware & {
   __typename?: 'GroupedExercise';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1156,7 +1156,7 @@ export type GroupedExerciseRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
-export type GroupedExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & {
+export type GroupedExerciseRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & AbstractExerciseRevision & ThreadAware & {
   __typename?: 'GroupedExerciseRevision';
   id: Scalars['Int'];
   author: User;
@@ -1191,7 +1191,7 @@ export type GroupedExerciseRevisionCursor = {
   node: GroupedExerciseRevision;
 };
 
-export type Page = AbstractUuid & AbstractRepository & AbstractNavigationChild & InstanceAware & {
+export type Page = AbstractUuid & AbstractRepository & AbstractNavigationChild & InstanceAware & ThreadAware & {
   __typename?: 'Page';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1222,7 +1222,7 @@ export type PageRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
-export type PageRevision = AbstractUuid & AbstractRevision & {
+export type PageRevision = AbstractUuid & AbstractRevision & ThreadAware & {
   __typename?: 'PageRevision';
   id: Scalars['Int'];
   author: User;
@@ -1257,7 +1257,7 @@ export type PageRevisionCursor = {
   node: PageRevision;
 };
 
-export type Solution = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & {
+export type Solution = AbstractUuid & AbstractRepository & AbstractEntity & InstanceAware & ThreadAware & {
   __typename?: 'Solution';
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
@@ -1288,7 +1288,7 @@ export type SolutionRevisionsArgs = {
   unrevised?: Maybe<Scalars['Boolean']>;
 };
 
-export type SolutionRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type SolutionRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'SolutionRevision';
   id: Scalars['Int'];
   author: User;
@@ -1526,7 +1526,7 @@ export type VideoTaxonomyTermsArgs = {
   last?: Maybe<Scalars['Int']>;
 };
 
-export type VideoRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & {
+export type VideoRevision = AbstractUuid & AbstractRevision & AbstractEntityRevision & ThreadAware & {
   __typename?: 'VideoRevision';
   id: Scalars['Int'];
   author: User;

--- a/src/types.ts
+++ b/src/types.ts
@@ -515,9 +515,18 @@ export type AbstractRevision = {
   id: Scalars['Int'];
   trashed: Scalars['Boolean'];
   alias?: Maybe<Scalars['String']>;
+  threads: ThreadsConnection;
   author: User;
   date: Scalars['DateTime'];
   content: Scalars['String'];
+};
+
+
+export type AbstractRevisionThreadsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type AbstractTaxonomyTermChild = {


### PR DESCRIPTION
Remove threads from AbstractUuid and move it into a new interface ThreadAware (#112).

There are some remaining linter warnings which I do not know how to fix.