### PR TITLE
mutation.createThread: Remove authorId parameter

### DIFF
--- a/api/api.serlo.org.api.md
+++ b/api/api.serlo.org.api.md
@@ -983,7 +983,6 @@ export type MutationCreateThreadArgs = {
     title: Scalars['String'];
     content: Scalars['String'];
     objectId: Scalars['Int'];
-    authorId: Scalars['Int'];
 };
 
 // @public (undocumented)

--- a/src/schema/uuid/thread/types.graphql
+++ b/src/schema/uuid/thread/types.graphql
@@ -63,10 +63,5 @@ type CommentEdge {
 }
 
 extend type Mutation {
-  createThread(
-    title: String!
-    content: String!
-    objectId: Int!
-    authorId: Int!
-  ): Thread
+  createThread(title: String!, content: String!, objectId: Int!): Thread
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,6 @@ export type MutationCreateThreadArgs = {
   title: Scalars['String'];
   content: Scalars['String'];
   objectId: Scalars['Int'];
-  authorId: Scalars['Int'];
 };
 
 export type PageInfo = {


### PR DESCRIPTION
This parameter is not necessary since the userId is already given by the
userId of the current session.