### PR TITLE
internals(error-event): improve context

### DIFF
--- a/src/model/google-spreadsheet-api.ts
+++ b/src/model/google-spreadsheet-api.ts
@@ -70,8 +70,8 @@ export function createGoogleSpreadsheetApiModel({
           `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${range}`
         )
         url.searchParams.append('majorDimension', majorDimension)
-        const apiSectret = process.env.GOOGLE_SPREADSHEET_API_SECRET
-        url.searchParams.append('key', apiSectret)
+        const apiSecret = process.env.GOOGLE_SPREADSHEET_API_SECRET
+        url.searchParams.append('key', apiSecret)
 
         const specifyErrorLocation = E.mapLeft(
           addContext({

--- a/src/schema/uuid/user/resolvers.ts
+++ b/src/schema/uuid/user/resolvers.ts
@@ -94,7 +94,7 @@ async function resolveUserConnectionFromIds({
   )
   return resolveConnection<UserPayload>({
     nodes: assertAll({
-      assertation: isUserPayload,
+      assertion: isUserPayload,
       error: new Error('ids do not belong to a user'),
     })(uuids),
     payload,
@@ -129,7 +129,7 @@ function extractIDsFromFirstColumn(
     E.map((rows) => rows.slice(1).map(R.trim)),
     E.map(
       assertAll({
-        assertation: (entry) => /^\d+$/.test(entry),
+        assertion: (entry) => /^\d+$/.test(entry),
         error: new Error('invalid entry in activeDonorSpreadsheet'),
       })
     ),


### PR DESCRIPTION
Serializes objects when passing context, so that we get something more useful than
```
{alias: [Object]}
```