### PR TITLE
Sentry improvement

### DIFF
--- a/src/internals/error-event.ts
+++ b/src/internals/error-event.ts
@@ -23,6 +23,8 @@ import * as Sentry from '@sentry/node'
 import { function as F, array as A } from 'fp-ts'
 import R from 'ramda'
 
+import { serializeRecord } from '~/utils'
+
 export interface ErrorEvent extends Context {
   error: Error
 }
@@ -90,12 +92,6 @@ function captureErrorEvent(event: ErrorEvent) {
 
     return scope
   })
-
-  function serializeRecord(record: Record<string, unknown>) {
-    return R.mapObjIndexed((value) => {
-      return typeof value === 'object' ? JSON.stringify(value, null, 2) : value
-    }, record)
-  }
 }
 
 interface Context {

--- a/src/internals/error-event.ts
+++ b/src/internals/error-event.ts
@@ -23,8 +23,6 @@ import * as Sentry from '@sentry/node'
 import { function as F, array as A } from 'fp-ts'
 import R from 'ramda'
 
-import { serializeRecord } from '~/utils'
-
 export interface ErrorEvent extends Context {
   error: Error
 }
@@ -81,11 +79,11 @@ function captureErrorEvent(event: ErrorEvent) {
     }
 
     if (event.locationContext) {
-      scope.setContext('location', serializeRecord(event.locationContext))
+      scope.setContext('location', event.locationContext)
     }
 
     if (event.errorContext) {
-      scope.setContext('error', serializeRecord(event.errorContext))
+      scope.setContext('error', event.errorContext)
     }
 
     scope.setLevel(Sentry.Severity.Error)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,15 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
+import R from 'ramda'
+
 export type AsyncOrSync<T> = Promise<T> | T
+
+export function serializeRecord(record: Record<string, unknown>) {
+  return R.mapObjIndexed((value) => {
+    return typeof value === 'object' ? JSON.stringify(value, null, 2) : value
+  }, record)
+}
 
 export function isDefined<A>(value?: A | null): value is A {
   return value !== null && value !== undefined

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,15 +19,8 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import R from 'ramda'
 
 export type AsyncOrSync<T> = Promise<T> | T
-
-export function serializeRecord(record: Record<string, unknown>) {
-  return R.mapObjIndexed((value) => {
-    return typeof value === 'object' ? JSON.stringify(value, null, 2) : value
-  }, record)
-}
 
 export function isDefined<A>(value?: A | null): value is A {
   return value !== null && value !== undefined


### PR DESCRIPTION
Follow up of https://github.com/serlo/api.serlo.org/pull/251#event-4340807069: Use `beforeSend()` to serialize context variables.