### PR TITLE
RFC: Allow logged in users to pruge cache

### DIFF
--- a/__tests__/schema/cache.ts
+++ b/__tests__/schema/cache.ts
@@ -26,6 +26,7 @@ import {
   createRemoveCacheMutation,
   createSetCacheMutation,
   createUpdateCacheMutation,
+  user,
 } from '../../__fixtures__'
 import {
   assertFailingGraphQLMutation,
@@ -89,10 +90,25 @@ test('_removeCache (forbidden)', async () => {
   })
 })
 
-test('_removeCache (authenticated)', async () => {
+test('_removeCache (authenticated via Serlo Service)', async () => {
   const client = createTestClient({
     service: Service.Serlo,
     userId: null,
+  })
+
+  await assertSuccessfulGraphQLMutation({
+    ...createRemoveCacheMutation(testVars[0]),
+    client,
+  })
+
+  const cachedValue = await global.cache.get({ key: testVars[0].key })
+  expect(option.isNone(cachedValue)).toBe(true)
+})
+
+test('_removeCache (authenticated as User)', async () => {
+  const client = createTestClient({
+    service: Service.SerloCloudflareWorker,
+    userId: user.id,
   })
 
   await assertSuccessfulGraphQLMutation({

--- a/__tests__/schema/cache.ts
+++ b/__tests__/schema/cache.ts
@@ -78,10 +78,22 @@ test('_setCache (authenticated)', async () => {
   })
 })
 
-test('_removeCache (forbidden)', async () => {
+test('_removeCache (forbidden with not logged in user)', async () => {
   const client = createTestClient({
     service: Service.SerloCloudflareWorker,
     userId: null,
+  })
+  await assertFailingGraphQLMutation({
+    ...createRemoveCacheMutation(testVars[0]),
+    client,
+    expectedError: 'FORBIDDEN',
+  })
+})
+
+test('_removeCache (forbidden with wrong user)', async () => {
+  const client = createTestClient({
+    service: Service.SerloCloudflareWorker,
+    userId: user.id,
   })
   await assertFailingGraphQLMutation({
     ...createRemoveCacheMutation(testVars[0]),
@@ -105,10 +117,10 @@ test('_removeCache (authenticated via Serlo Service)', async () => {
   expect(option.isNone(cachedValue)).toBe(true)
 })
 
-test('_removeCache (authenticated as User)', async () => {
+test('_removeCache (authenticated as CarolinJaser)', async () => {
   const client = createTestClient({
     service: Service.SerloCloudflareWorker,
-    userId: user.id,
+    userId: 178145,
   })
 
   await assertSuccessfulGraphQLMutation({

--- a/src/schema/cache/resolvers.ts
+++ b/src/schema/cache/resolvers.ts
@@ -39,7 +39,18 @@ export const resolvers: CacheResolvers = {
       return null
     },
     async _removeCache(_parent, { key }, { dataSources, service, userId }) {
-      if (service !== Service.Serlo && userId === null) {
+      const allowedUserIds = [
+        26217, // kulla
+        15473, // inyono
+        131536, // dal
+        32543, // botho
+        178145, // CarolinJaser
+      ]
+
+      if (
+        service !== Service.Serlo &&
+        (userId === null || !allowedUserIds.includes(userId))
+      ) {
         throw new ForbiddenError(
           'You do not have the permissions to remove the cache'
         )

--- a/src/schema/cache/resolvers.ts
+++ b/src/schema/cache/resolvers.ts
@@ -38,8 +38,8 @@ export const resolvers: CacheResolvers = {
       })
       return null
     },
-    async _removeCache(_parent, { key }, { dataSources, service }) {
-      if (service !== Service.Serlo) {
+    async _removeCache(_parent, { key }, { dataSources, service, userId }) {
+      if (service !== Service.Serlo && userId === null) {
         throw new ForbiddenError(
           'You do not have the permissions to remove the cache'
         )


### PR DESCRIPTION
This PR allows logged in users to purge the cache for an entry. During the time we have problems with invalid cache values this would help us to refresh them via the api console (for this we can also use `[/* whitespace list of user ids */].include(userId)` as a check). Also a button `Refresh cache` or `Purge cache` can be included for logged in user. However for this we might want to include a new mutation like `uuid.purge(id: Int)` since the frontend shouldn't compute the cache key for an uuid.