### PR TITLE
fix: Resolve id from alias when it contains the alias

### DIFF
--- a/__tests__/schema/uuid/abstract-uuid.ts
+++ b/__tests__/schema/uuid/abstract-uuid.ts
@@ -165,6 +165,35 @@ describe('uuid', () => {
     })
   })
 
+  test('returns uuid when alias is /:subject/:id/:alias (as hotfix for the current bug in the database layer)', async () => {
+    global.server.use(createUuidHandler(article))
+    await assertSuccessfulGraphQLQuery({
+      query: gql`
+        query uuid($alias: AliasInput!) {
+          uuid(alias: $alias) {
+            __typename
+            ... on Article {
+              id
+              trashed
+              instance
+              date
+            }
+          }
+        }
+      `,
+      variables: {
+        alias: {
+          instance: Instance.De,
+          path: `/mathe/${article.id}/das-viereck`,
+        },
+      },
+      data: {
+        uuid: getArticleDataWithoutSubResolvers(article),
+      },
+      client,
+    })
+  })
+
   test('returns revision when alias is /entity/repository/compare/:entityId/:revisionId', async () => {
     global.server.use(createUuidHandler(articleRevision))
     await assertSuccessfulGraphQLQuery({

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -167,6 +167,7 @@ async function resolveIdFromAlias(
   for (const regex of [
     /^\/(\d+)$/,
     /^\/entity\/view\/(\d+)$/,
+    /^\/[^/]+\/(\d+)\/[^/]*$/,
     /^\/entity\/repository\/compare\/\d+\/(\d+)$/,
     /^\/user\/profile\/(\d+)$/,
   ]) {

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -165,15 +165,15 @@ async function resolveIdFromAlias(
   }
 
   for (const regex of [
-    /^\/(\d+)$/,
-    /^\/entity\/view\/(\d+)$/,
-    /^\/[^/]+\/(\d+)\/[^/]*$/,
-    /^\/entity\/repository\/compare\/\d+\/(\d+)$/,
-    /^\/user\/profile\/(\d+)$/,
+    /^\/(?<id>\d+)$/,
+    /^\/entity\/view\/(?<id>\d+)$/,
+    /^\/(?<subject>[^/]+\/)?(?<id>\d+)\/(?<title>[^/]*)$/,
+    /^\/entity\/repository\/compare\/\d+\/(?<id>\d+)$/,
+    /^\/user\/profile\/(?<id>\d+)$/,
   ]) {
     const match = regex.exec(cleanPath)
 
-    if (match) return parseInt(match[1])
+    if (match && match.groups !== undefined) return parseInt(match.groups.id)
   }
 
   const customId = resolveCustomId({


### PR DESCRIPTION
Currently there is a bug in the database layer which sometimes returns
invalid responses in the alias request. This is a hotfix for the time we
fix this issue