### PR TITLE
Cache mutation namespace

### DIFF
--- a/__fixtures__/cache.ts
+++ b/__fixtures__/cache.ts
@@ -27,13 +27,19 @@ export function createSetCacheMutation(variables: {
 }) {
   return {
     mutation: gql`
-      mutation setCache($key: String!, $value: JSON!) {
-        _setCache(key: $key, value: $value)
+      mutation($input: CacheSetInput!) {
+        cache {
+          _set(input: $input) {
+            success
+          }
+        }
       }
     `,
     variables: {
-      key: variables.key,
-      value: variables.value,
+      input: {
+        key: variables.key,
+        value: variables.value,
+      },
     },
   }
 }
@@ -41,21 +47,37 @@ export function createSetCacheMutation(variables: {
 export function createRemoveCacheMutation(variables: { key: string }) {
   return {
     mutation: gql`
-      mutation removeCache($key: String!) {
-        _removeCache(key: $key)
+      mutation($input: CacheRemoveInput!) {
+        cache {
+          _remove(input: $input) {
+            success
+          }
+        }
       }
     `,
-    variables,
+    variables: {
+      input: {
+        key: variables.key,
+      },
+    },
   }
 }
 
 export function createUpdateCacheMutation(keys: string[]) {
   return {
     mutation: gql`
-      mutation _updateCache($keys: [String!]!) {
-        _updateCache(keys: $keys)
+      mutation($input: CacheUpdateInput!) {
+        cache {
+          _update(input: $input) {
+            success
+          }
+        }
       }
     `,
-    variables: { keys },
+    variables: {
+      input: {
+        keys: keys,
+      },
+    },
   }
 }

--- a/__tests__/schema/cache.ts
+++ b/__tests__/schema/cache.ts
@@ -46,7 +46,7 @@ const testVars = [
   },
 ]
 
-test('_setCache (forbidden)', async () => {
+test('_set (forbidden)', async () => {
   const client = createTestClient({
     service: Service.SerloCloudflareWorker,
     userId: null,
@@ -59,7 +59,7 @@ test('_setCache (forbidden)', async () => {
   })
 })
 
-test('_setCache (authenticated)', async () => {
+test('_set (authenticated)', async () => {
   const client = createTestClient({
     service: Service.Serlo,
     userId: null,
@@ -78,7 +78,7 @@ test('_setCache (authenticated)', async () => {
   })
 })
 
-test('_removeCache (forbidden with not logged in user)', async () => {
+test('_remove (forbidden with not logged in user)', async () => {
   const client = createTestClient({
     service: Service.SerloCloudflareWorker,
     userId: null,
@@ -90,7 +90,7 @@ test('_removeCache (forbidden with not logged in user)', async () => {
   })
 })
 
-test('_removeCache (forbidden with wrong user)', async () => {
+test('_remove (forbidden with wrong user)', async () => {
   const client = createTestClient({
     service: Service.SerloCloudflareWorker,
     userId: user.id,
@@ -102,7 +102,7 @@ test('_removeCache (forbidden with wrong user)', async () => {
   })
 })
 
-test('_removeCache (authenticated via Serlo Service)', async () => {
+test('_remove (authenticated via Serlo Service)', async () => {
   const client = createTestClient({
     service: Service.Serlo,
     userId: null,
@@ -117,7 +117,7 @@ test('_removeCache (authenticated via Serlo Service)', async () => {
   expect(option.isNone(cachedValue)).toBe(true)
 })
 
-test('_removeCache (authenticated as CarolinJaser)', async () => {
+test('_remove (authenticated as CarolinJaser)', async () => {
   const client = createTestClient({
     service: Service.SerloCloudflareWorker,
     userId: 178145,
@@ -132,7 +132,7 @@ test('_removeCache (authenticated as CarolinJaser)', async () => {
   expect(option.isNone(cachedValue)).toBe(true)
 })
 
-test('_updateCache (forbidden)', async () => {
+test('_update (forbidden)', async () => {
   const client = createTestClient({
     service: Service.SerloCloudflareWorker,
     userId: null,

--- a/__tests__/schema/uuid/abstract-navigation-child.ts
+++ b/__tests__/schema/uuid/abstract-navigation-child.ts
@@ -43,13 +43,19 @@ function createSetNavigationMutation(
 ) {
   return {
     mutation: gql`
-      mutation _setCache($key: String!, $value: JSON!) {
-        _setCache(key: $key, value: $value)
+      mutation($input: CacheSetInput!) {
+        cache {
+          _set(input: $input) {
+            success
+          }
+        }
       }
     `,
     variables: {
-      key: `${navigation.instance}.serlo.org/api/navigation`,
-      value: navigation,
+      input: {
+        key: `${navigation.instance}.serlo.org/api/navigation`,
+        value: navigation,
+      },
     },
   }
 }
@@ -57,13 +63,19 @@ function createSetNavigationMutation(
 function createSetPageMutation(page: Model<'Page'>) {
   return {
     mutation: gql`
-      mutation _setCache($key: String!, $value: JSON!) {
-        _setCache(key: $key, value: $value)
+      mutation($input: CacheSetInput!) {
+        cache {
+          _set(input: $input) {
+            success
+          }
+        }
       }
     `,
     variables: {
-      key: `de.serlo.org/api/uuid/${page.id}`,
-      value: page,
+      input: {
+        key: `de.serlo.org/api/uuid/${page.id}`,
+        value: page,
+      },
     },
   }
 }
@@ -71,13 +83,19 @@ function createSetPageMutation(page: Model<'Page'>) {
 function createSetTaxonomyTermMutation(taxonomyTerm: Model<'TaxonomyTerm'>) {
   return {
     mutation: gql`
-      mutation _setCache($key: String!, $value: JSON!) {
-        _setCache(key: $key, value: $value)
+      mutation($input: CacheSetInput!) {
+        cache {
+          _set(input: $input) {
+            success
+          }
+        }
       }
     `,
     variables: {
-      key: `de.serlo.org/api/uuid/${taxonomyTerm.id}`,
-      value: taxonomyTerm,
+      input: {
+        key: `de.serlo.org/api/uuid/${taxonomyTerm.id}`,
+        value: taxonomyTerm,
+      },
     },
   }
 }

--- a/packages/server/src/schema/cache/resolvers.ts
+++ b/packages/server/src/schema/cache/resolvers.ts
@@ -22,11 +22,15 @@
 import { ForbiddenError } from 'apollo-server'
 
 import { Service } from '~/internals/authentication'
-import { Resolvers } from '~/types'
+import { createMutationNamespace, Mutations } from '~/internals/graphql'
 
-export const resolvers: Resolvers = {
+export const resolvers: Mutations<'cache'> = {
   Mutation: {
-    async _setCache(_parent, { key, value }, { dataSources, service }) {
+    cache: createMutationNamespace(),
+  },
+  CacheMutation: {
+    async _set(_parent, payload, { dataSources, service }) {
+      const { key, value } = payload.input
       if (service !== Service.Serlo) {
         throw new ForbiddenError(
           'You do not have the permissions to set the cache'
@@ -38,7 +42,8 @@ export const resolvers: Resolvers = {
       })
       return null
     },
-    async _removeCache(_parent, { key }, { dataSources, service, userId }) {
+    async _remove(_parent, payload, { dataSources, service, userId }) {
+      const { key } = payload.input
       const allowedUserIds = [
         26217, // kulla
         15473, // inyono
@@ -58,7 +63,8 @@ export const resolvers: Resolvers = {
       await dataSources.model.serlo.removeCacheValue({ key })
       return null
     },
-    async _updateCache(_parent, { keys }, { dataSources, service }) {
+    async _update(_parent, payload, { dataSources, service }) {
+      const { keys } = payload.input
       if (service !== Service.Serlo) {
         throw new ForbiddenError(
           'You do not have the permissions to update the cache'

--- a/packages/server/src/schema/cache/types.graphql
+++ b/packages/server/src/schema/cache/types.graphql
@@ -1,5 +1,37 @@
-type Mutation {
-  _setCache(key: String!, value: JSON!): Boolean
-  _removeCache(key: String!): Boolean
-  _updateCache(keys: [String!]!): Boolean
+extend type Mutation {
+  cache: CacheMutation!
+}
+
+type CacheMutation {
+  _set(input: CacheSetInput!): CacheSetResponse
+  _remove(input: CacheRemoveInput!): CacheRemoveResponse
+  _update(input: CacheUpdateInput!): CacheUpdateResponse
+}
+
+input CacheSetInput {
+  key: String!
+  value: JSON!
+}
+
+type CacheSetResponse {
+  success: Boolean!
+  query: Query!
+}
+
+input CacheRemoveInput {
+  key: String!
+}
+
+type CacheRemoveResponse {
+  success: Boolean!
+  query: Query!
+}
+
+input CacheUpdateInput {
+  keys: [String!]!
+}
+
+type CacheUpdateResponse {
+  success: Boolean!
+  query: Query!
 }

--- a/packages/server/src/schema/cache/types.graphql
+++ b/packages/server/src/schema/cache/types.graphql
@@ -1,4 +1,4 @@
-extend type Mutation {
+type Mutation {
   cache: CacheMutation!
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -315,6 +315,59 @@ export type ArticleRevisionCursor = {
   node: ArticleRevision;
 };
 
+export type CacheMutation = {
+  __typename?: 'CacheMutation';
+  _set?: Maybe<CacheSetResponse>;
+  _remove?: Maybe<CacheRemoveResponse>;
+  _update?: Maybe<CacheUpdateResponse>;
+};
+
+
+export type CacheMutation_SetArgs = {
+  input: CacheSetInput;
+};
+
+
+export type CacheMutation_RemoveArgs = {
+  input: CacheRemoveInput;
+};
+
+
+export type CacheMutation_UpdateArgs = {
+  input: CacheUpdateInput;
+};
+
+export type CacheRemoveInput = {
+  key: Scalars['String'];
+};
+
+export type CacheRemoveResponse = {
+  __typename?: 'CacheRemoveResponse';
+  success: Scalars['Boolean'];
+  query: Query;
+};
+
+export type CacheSetInput = {
+  key: Scalars['String'];
+  value: Scalars['JSON'];
+};
+
+export type CacheSetResponse = {
+  __typename?: 'CacheSetResponse';
+  success: Scalars['Boolean'];
+  query: Query;
+};
+
+export type CacheUpdateInput = {
+  keys: Array<Scalars['String']>;
+};
+
+export type CacheUpdateResponse = {
+  __typename?: 'CacheUpdateResponse';
+  success: Scalars['Boolean'];
+  query: Query;
+};
+
 export type CheckoutRevisionNotificationEvent = AbstractNotificationEvent & InstanceAware & {
   __typename?: 'CheckoutRevisionNotificationEvent';
   id: Scalars['Int'];
@@ -926,29 +979,11 @@ export type License = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  _removeCache?: Maybe<Scalars['Boolean']>;
-  _setCache?: Maybe<Scalars['Boolean']>;
-  _updateCache?: Maybe<Scalars['Boolean']>;
+  cache: CacheMutation;
   notification: NotificationMutation;
   subscription: SubscriptionMutation;
   thread: ThreadMutation;
   uuid: UuidMutation;
-};
-
-
-export type Mutation_RemoveCacheArgs = {
-  key: Scalars['String'];
-};
-
-
-export type Mutation_SetCacheArgs = {
-  key: Scalars['String'];
-  value: Scalars['JSON'];
-};
-
-
-export type Mutation_UpdateCacheArgs = {
-  keys: Array<Scalars['String']>;
 };
 
 export type Navigation = {
@@ -1852,6 +1887,13 @@ export type ResolversTypes = {
   ArticleRevision: ResolverTypeWrapper<ModelOf<ArticleRevision>>;
   ArticleRevisionConnection: ResolverTypeWrapper<ModelOf<ArticleRevisionConnection>>;
   ArticleRevisionCursor: ResolverTypeWrapper<ModelOf<ArticleRevisionCursor>>;
+  CacheMutation: ResolverTypeWrapper<ModelOf<CacheMutation>>;
+  CacheRemoveInput: ResolverTypeWrapper<ModelOf<CacheRemoveInput>>;
+  CacheRemoveResponse: ResolverTypeWrapper<ModelOf<CacheRemoveResponse>>;
+  CacheSetInput: ResolverTypeWrapper<ModelOf<CacheSetInput>>;
+  CacheSetResponse: ResolverTypeWrapper<ModelOf<CacheSetResponse>>;
+  CacheUpdateInput: ResolverTypeWrapper<ModelOf<CacheUpdateInput>>;
+  CacheUpdateResponse: ResolverTypeWrapper<ModelOf<CacheUpdateResponse>>;
   CheckoutRevisionNotificationEvent: ResolverTypeWrapper<ModelOf<CheckoutRevisionNotificationEvent>>;
   Comment: ResolverTypeWrapper<ModelOf<Comment>>;
   CommentConnection: ResolverTypeWrapper<ModelOf<CommentConnection>>;
@@ -1988,6 +2030,13 @@ export type ResolversParentTypes = {
   ArticleRevision: ModelOf<ArticleRevision>;
   ArticleRevisionConnection: ModelOf<ArticleRevisionConnection>;
   ArticleRevisionCursor: ModelOf<ArticleRevisionCursor>;
+  CacheMutation: ModelOf<CacheMutation>;
+  CacheRemoveInput: ModelOf<CacheRemoveInput>;
+  CacheRemoveResponse: ModelOf<CacheRemoveResponse>;
+  CacheSetInput: ModelOf<CacheSetInput>;
+  CacheSetResponse: ModelOf<CacheSetResponse>;
+  CacheUpdateInput: ModelOf<CacheUpdateInput>;
+  CacheUpdateResponse: ModelOf<CacheUpdateResponse>;
   CheckoutRevisionNotificationEvent: ModelOf<CheckoutRevisionNotificationEvent>;
   Comment: ModelOf<Comment>;
   CommentConnection: ModelOf<CommentConnection>;
@@ -2292,6 +2341,31 @@ export type ArticleRevisionConnectionResolvers<ContextType = Context, ParentType
 export type ArticleRevisionCursorResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ArticleRevisionCursor'] = ResolversParentTypes['ArticleRevisionCursor']> = {
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   node?: Resolver<ResolversTypes['ArticleRevision'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CacheMutationResolvers<ContextType = Context, ParentType extends ResolversParentTypes['CacheMutation'] = ResolversParentTypes['CacheMutation']> = {
+  _set?: Resolver<Maybe<ResolversTypes['CacheSetResponse']>, ParentType, ContextType, RequireFields<CacheMutation_SetArgs, 'input'>>;
+  _remove?: Resolver<Maybe<ResolversTypes['CacheRemoveResponse']>, ParentType, ContextType, RequireFields<CacheMutation_RemoveArgs, 'input'>>;
+  _update?: Resolver<Maybe<ResolversTypes['CacheUpdateResponse']>, ParentType, ContextType, RequireFields<CacheMutation_UpdateArgs, 'input'>>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CacheRemoveResponseResolvers<ContextType = Context, ParentType extends ResolversParentTypes['CacheRemoveResponse'] = ResolversParentTypes['CacheRemoveResponse']> = {
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  query?: Resolver<ResolversTypes['Query'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CacheSetResponseResolvers<ContextType = Context, ParentType extends ResolversParentTypes['CacheSetResponse'] = ResolversParentTypes['CacheSetResponse']> = {
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  query?: Resolver<ResolversTypes['Query'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CacheUpdateResponseResolvers<ContextType = Context, ParentType extends ResolversParentTypes['CacheUpdateResponse'] = ResolversParentTypes['CacheUpdateResponse']> = {
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  query?: Resolver<ResolversTypes['Query'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2694,9 +2768,7 @@ export type LicenseResolvers<ContextType = Context, ParentType extends Resolvers
 };
 
 export type MutationResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  _removeCache?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<Mutation_RemoveCacheArgs, 'key'>>;
-  _setCache?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<Mutation_SetCacheArgs, 'key' | 'value'>>;
-  _updateCache?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<Mutation_UpdateCacheArgs, 'keys'>>;
+  cache?: Resolver<ResolversTypes['CacheMutation'], ParentType, ContextType>;
   notification?: Resolver<ResolversTypes['NotificationMutation'], ParentType, ContextType>;
   subscription?: Resolver<ResolversTypes['SubscriptionMutation'], ParentType, ContextType>;
   thread?: Resolver<ResolversTypes['ThreadMutation'], ParentType, ContextType>;
@@ -3198,6 +3270,10 @@ export type Resolvers<ContextType = Context> = {
   ArticleRevision?: ArticleRevisionResolvers<ContextType>;
   ArticleRevisionConnection?: ArticleRevisionConnectionResolvers<ContextType>;
   ArticleRevisionCursor?: ArticleRevisionCursorResolvers<ContextType>;
+  CacheMutation?: CacheMutationResolvers<ContextType>;
+  CacheRemoveResponse?: CacheRemoveResponseResolvers<ContextType>;
+  CacheSetResponse?: CacheSetResponseResolvers<ContextType>;
+  CacheUpdateResponse?: CacheUpdateResponseResolvers<ContextType>;
   CheckoutRevisionNotificationEvent?: CheckoutRevisionNotificationEventResolvers<ContextType>;
   Comment?: CommentResolvers<ContextType>;
   CommentConnection?: CommentConnectionResolvers<ContextType>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -311,6 +311,59 @@ export type ArticleRevisionCursor = {
   node: ArticleRevision;
 };
 
+export type CacheMutation = {
+  __typename?: 'CacheMutation';
+  _set?: Maybe<CacheSetResponse>;
+  _remove?: Maybe<CacheRemoveResponse>;
+  _update?: Maybe<CacheUpdateResponse>;
+};
+
+
+export type CacheMutation_SetArgs = {
+  input: CacheSetInput;
+};
+
+
+export type CacheMutation_RemoveArgs = {
+  input: CacheRemoveInput;
+};
+
+
+export type CacheMutation_UpdateArgs = {
+  input: CacheUpdateInput;
+};
+
+export type CacheRemoveInput = {
+  key: Scalars['String'];
+};
+
+export type CacheRemoveResponse = {
+  __typename?: 'CacheRemoveResponse';
+  success: Scalars['Boolean'];
+  query: Query;
+};
+
+export type CacheSetInput = {
+  key: Scalars['String'];
+  value: Scalars['JSON'];
+};
+
+export type CacheSetResponse = {
+  __typename?: 'CacheSetResponse';
+  success: Scalars['Boolean'];
+  query: Query;
+};
+
+export type CacheUpdateInput = {
+  keys: Array<Scalars['String']>;
+};
+
+export type CacheUpdateResponse = {
+  __typename?: 'CacheUpdateResponse';
+  success: Scalars['Boolean'];
+  query: Query;
+};
+
 export type CheckoutRevisionNotificationEvent = AbstractNotificationEvent & InstanceAware & {
   __typename?: 'CheckoutRevisionNotificationEvent';
   id: Scalars['Int'];
@@ -922,29 +975,11 @@ export type License = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  _removeCache?: Maybe<Scalars['Boolean']>;
-  _setCache?: Maybe<Scalars['Boolean']>;
-  _updateCache?: Maybe<Scalars['Boolean']>;
+  cache: CacheMutation;
   notification: NotificationMutation;
   subscription: SubscriptionMutation;
   thread: ThreadMutation;
   uuid: UuidMutation;
-};
-
-
-export type Mutation_RemoveCacheArgs = {
-  key: Scalars['String'];
-};
-
-
-export type Mutation_SetCacheArgs = {
-  key: Scalars['String'];
-  value: Scalars['JSON'];
-};
-
-
-export type Mutation_UpdateCacheArgs = {
-  keys: Array<Scalars['String']>;
 };
 
 export type Navigation = {


### PR DESCRIPTION
Adds new convention for mutation namespaces to cache. Contains breaking change, so this PR should stay open until the breaking change is dealt with.