### PR TITLE
refactor: Collect all cache functions in ModelDataSource

### DIFF
--- a/packages/server/src/internals/data-source.ts
+++ b/packages/server/src/internals/data-source.ts
@@ -39,6 +39,14 @@ export class ModelDataSource extends RESTDataSource {
     this.googleSpreadsheetApi = createGoogleSpreadsheetApiModel(args)
   }
 
+  public async removeCacheValue({ key }: { key: string }) {
+    await this.environment.cache.remove({ key })
+  }
+
+  public async setCacheValue(args: { key: string; value: unknown }) {
+    await this.environment.cache.set(args)
+  }
+
   public async updateCacheValue({ key }: { key: string }) {
     await this.environment.swrQueue.queue({ key })
   }

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -671,18 +671,6 @@ export function createSerloModel({
     },
   })
 
-  const setCacheValue = createMutation<{ key: string; value: unknown }>({
-    legacyMutate: async ({ key, value }) => {
-      await environment.cache.set({ key, value })
-    },
-  })
-
-  const removeCacheValue = createMutation<{ key: string }>({
-    legacyMutate: async ({ key }) => {
-      await environment.cache.remove({ key })
-    },
-  })
-
   return {
     createThread,
     archiveThread,
@@ -701,8 +689,6 @@ export function createSerloModel({
     getUuid,
     getUuidWithCustomDecoder,
     setUuidState,
-    removeCacheValue,
-    setCacheValue,
     setNotificationState,
   }
 }

--- a/packages/server/src/schema/cache/resolvers.ts
+++ b/packages/server/src/schema/cache/resolvers.ts
@@ -32,7 +32,7 @@ export const resolvers: Resolvers = {
           'You do not have the permissions to set the cache'
         )
       }
-      await dataSources.model.serlo.setCacheValue({
+      await dataSources.model.setCacheValue({
         key,
         value,
       })
@@ -55,7 +55,7 @@ export const resolvers: Resolvers = {
           'You do not have the permissions to remove the cache'
         )
       }
-      await dataSources.model.serlo.removeCacheValue({ key })
+      await dataSources.model.removeCacheValue({ key })
       return null
     },
     async _updateCache(_parent, { keys }, { dataSources, service }) {


### PR DESCRIPTION
Cache related functions should not be handled in the serlo data source since (1) there are no requests to the database layer and (2) those function are not serlo specific (cache entries of the google spreadsheet data source can also be handled by those functions)