### PR TITLE
fix: Cache mutations should return "true"

### DIFF
--- a/__tests__/schema/cache.ts
+++ b/__tests__/schema/cache.ts
@@ -69,6 +69,7 @@ test('_setCache (authenticated)', async () => {
   await assertSuccessfulGraphQLMutation({
     ...createSetCacheMutation(testVars[0]),
     client,
+    data: { _setCache: true },
   })
 
   const cachedValue = await global.cache.get({ key: testVars[0].key })
@@ -111,6 +112,7 @@ test('_removeCache (authenticated via Serlo Service)', async () => {
   await assertSuccessfulGraphQLMutation({
     ...createRemoveCacheMutation(testVars[0]),
     client,
+    data: { _removeCache: true },
   })
 
   const cachedValue = await global.cache.get({ key: testVars[0].key })
@@ -126,6 +128,7 @@ test('_removeCache (authenticated as CarolinJaser)', async () => {
   await assertSuccessfulGraphQLMutation({
     ...createRemoveCacheMutation(testVars[0]),
     client,
+    data: { _removeCache: true },
   })
 
   const cachedValue = await global.cache.get({ key: testVars[0].key })

--- a/packages/server/src/schema/cache/resolvers.ts
+++ b/packages/server/src/schema/cache/resolvers.ts
@@ -36,7 +36,7 @@ export const resolvers: Resolvers = {
         key,
         value,
       })
-      return null
+      return true
     },
     async _removeCache(_parent, { key }, { dataSources, service, userId }) {
       const allowedUserIds = [
@@ -56,7 +56,7 @@ export const resolvers: Resolvers = {
         )
       }
       await dataSources.model.serlo.removeCacheValue({ key })
-      return null
+      return true
     },
     async _updateCache(_parent, { keys }, { dataSources, service }) {
       if (service !== Service.Serlo) {
@@ -69,7 +69,7 @@ export const resolvers: Resolvers = {
           await dataSources.model.updateCacheValue({ key })
         })
       )
-      return null
+      return true
     },
   },
 }


### PR DESCRIPTION
The type of all cache mutations is "Boolean" and thus it is better to return `true` instead of `null` after a successful operation