### PR TITLE
Several improvements for sentry

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,6 +105,7 @@ module.exports = {
           'scripts/**/*',
           'jest.config.js',
           'jest.config-pacts-*.js',
+          '__config__/*.ts',
         ],
         optionalDependencies: false,
       },

--- a/__config__/jest.d.ts
+++ b/__config__/jest.d.ts
@@ -19,9 +19,12 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-/* eslint-disable @typescript-eslint/no-namespace */
+import { Event } from '@sentry/node'
+
 import { MockTimer } from './setup'
 import { Cache } from '~/internals/cache'
+
+export {}
 
 declare global {
   namespace NodeJS {
@@ -29,6 +32,7 @@ declare global {
       cache: Cache
       server: ReturnType<typeof import('msw/node').setupServer>
       timer: MockTimer
+      sentryEvents: Event[]
     }
   }
 }

--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -110,31 +110,37 @@ export async function assertFailingGraphQLMutation({
 }
 
 /**
- * Assertation that a certain error event occured. Since we use Sentry this
+ * Assertion that a certain error event occured. Since we use Sentry this
  * function checks that a Sentry event was thrown.
  *
- * TODO: This function has not a good error message in case the asseration
- * fails. I reccomend you to investigate `global.sentryEvents` with
+ * TODO: This function has not a good error message in case the assertion
+ * fails. I recommend you to investigate `global.sentryEvents` with
  * `console.log()` or something similar when your tests fail.
  *
  * @example
- * // assertation that at least one error occured
+ * ```ts
+ * // assertion that at least one error occurred
  * assertErrorEvent()
+ * ```
  *
  * @example
+ * ```ts
  * assertErrorEvent({
- *   // additional assertation that error message is 'Error XYZ'
+ *   // additional assertion that error message is 'Error XYZ'
  *   message: 'Error XYZ'
  * })
+ * ```
  *
  * @example
+ * ```ts
  * assertErrorEvent({
- *   // additional assertation that the context "error" contains
+ *   // additional assertion that the context "error" contains
  *   // `{ invalidValue: 23 }`. This means that `contexts.error.invalidValue === 23`.
  *   // See https://docs.sentry.io/platforms/javascript/enriching-events/context/
  *   // for an introduction about contexts in Sentry
  *   errorContext: { invalidValue: 23 },
  * })
+ * ```
  */
 export async function assertErrorEvent(args?: {
   message?: string

--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -151,15 +151,8 @@ export async function assertErrorEvent(args?: {
         const contextValue = event.contexts?.error?.[contextName]
         const targetValue = args.errorContext[contextName]
 
-        if (typeof contextValue === 'string') {
-          if (typeof targetValue === 'string') {
-            if (contextValue !== targetValue) return false
-          } else {
-            if (!R.equals(JSON.parse(contextValue), targetValue)) return false
-          }
-        } else {
-          if (!R.equals(contextValue, targetValue)) return false
-        }
+        if (!R.equals(destringifyProperties(contextValue), targetValue))
+          return false
       }
     }
 
@@ -171,4 +164,15 @@ export async function assertErrorEvent(args?: {
 
   await waitForAllSentryEvents
   expect(global.sentryEvents.some(eventPredicate)).toBe(true)
+}
+
+function destringifyProperties(value: unknown) {
+  const destringify = (value: unknown) =>
+    typeof value === 'string' ? (JSON.parse(value) as unknown) : value
+
+  return Array.isArray(value)
+    ? value.map(destringify)
+    : typeof value === 'object' && value !== null
+    ? R.mapObjIndexed(destringify, value)
+    : value
 }

--- a/__tests__/internals/index.ts
+++ b/__tests__/internals/index.ts
@@ -1,0 +1,58 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020-2021 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020-2021 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { gql } from 'apollo-server'
+
+import {
+  assertErrorEvent,
+  assertFailingGraphQLQuery,
+  createMessageHandler,
+  createTestClient,
+} from '../__utils__'
+
+test('invalid values are reported to sentry', async () => {
+  const client = createTestClient()
+  const invalidValue = { __typename: 'Article', invalid: 'this in invalid' }
+
+  global.server.use(
+    createMessageHandler({
+      message: { type: 'UuidQuery', payload: { id: 42 } },
+      body: invalidValue,
+    })
+  )
+
+  await assertFailingGraphQLQuery({
+    query: gql`
+      query($id: Int!) {
+        uuid(id: $id) {
+          __typename
+        }
+      }
+    `,
+    variables: { id: 42 },
+    client,
+  })
+
+  await assertErrorEvent({
+    message: 'Invalid value received from a data source.',
+    errorContext: { invalidValue },
+  })
+})

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -428,18 +428,21 @@ describe('endpoint activeDonors', () => {
         givenSpreadheetApi(returnsJson({}))
 
         await expectUserIds({ endpoint: 'activeDonors', ids: [] })
+        await assertErrorEvent()
       })
 
       test('when spreadsheet api responds with malformed json', async () => {
         givenSpreadheetApi(returnsMalformedJson())
 
         await expectUserIds({ endpoint: 'activeDonors', ids: [] })
+        await assertErrorEvent()
       })
 
       test('when spreadsheet api has an internal server error', async () => {
         givenSpreadheetApi(hasInternalServerError())
 
         await expectUserIds({ endpoint: 'activeDonors', ids: [] })
+        await assertErrorEvent()
       })
     })
   })

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -402,8 +402,7 @@ describe('endpoint activeDonors', () => {
       givenActiveDonorsSpreadsheet([['Header', '23', 'foo', '-1', '', '1.5']])
 
       await expectUserIds({ endpoint: 'activeDonors', ids: [23] })
-
-      assertErrorEvent({
+      await assertErrorEvent({
         message: 'invalid entry in activeDonorSpreadsheet',
         errorContext: { invalidElements: ['foo', '-1', '', '1.5'] },
       })

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -29,6 +29,7 @@ import {
   user2,
 } from '../../../__fixtures__'
 import {
+  assertErrorEvent,
   assertSuccessfulGraphQLQuery,
   Client,
   createMessageHandler,
@@ -401,6 +402,11 @@ describe('endpoint activeDonors', () => {
       givenActiveDonorsSpreadsheet([['Header', '23', 'foo', '-1', '', '1.5']])
 
       await expectUserIds({ endpoint: 'activeDonors', ids: [23] })
+
+      assertErrorEvent({
+        message: 'invalid entry in activeDonorSpreadsheet',
+        errorContext: { invalidElements: ['foo', '-1', '', '1.5'] },
+      })
     })
 
     test('cell entries are trimmed of leading and trailing whitespaces', async () => {

--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -359,6 +359,7 @@ describe('endpoint activeAuthors', () => {
     )
 
     await expectUserIds({ endpoint: 'activeAuthors', ids: [user.id] })
+    await assertErrorEvent({ errorContext: { invalidElements: [article] } })
   })
 })
 
@@ -379,6 +380,7 @@ describe('endpoint activeReviewers', () => {
     )
 
     await expectUserIds({ endpoint: 'activeReviewers', ids: [user.id] })
+    await assertErrorEvent({ errorContext: { invalidElements: [article] } })
   })
 })
 
@@ -395,6 +397,7 @@ describe('endpoint activeDonors', () => {
     global.server.use(createUuidHandler(article))
 
     await expectUserIds({ endpoint: 'activeDonors', ids: [user.id] })
+    await assertErrorEvent({ errorContext: { invalidElements: [article] } })
   })
 
   describe('parser', () => {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@inyono/copyright-headers": "^0.1.0",
     "@pact-foundation/pact": "^9.0.0",
     "@pact-foundation/pact-node": "^10.0.0",
+    "@sentry/node": "^6.0.0",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "^4.16.0",

--- a/packages/server/src/internals/error-event.ts
+++ b/packages/server/src/internals/error-event.ts
@@ -23,6 +23,7 @@ import * as Sentry from '@sentry/node'
 import { array as A } from 'fp-ts'
 import * as F from 'fp-ts/lib/function'
 import R from 'ramda'
+
 import { stringifyContext } from './sentry'
 
 export interface ErrorEvent extends ErrorContext {

--- a/packages/server/src/internals/error-event.ts
+++ b/packages/server/src/internals/error-event.ts
@@ -23,6 +23,7 @@ import * as Sentry from '@sentry/node'
 import { array as A } from 'fp-ts'
 import * as F from 'fp-ts/lib/function'
 import R from 'ramda'
+import { stringifyContext } from './sentry'
 
 export interface ErrorEvent extends ErrorContext {
   error: Error
@@ -80,23 +81,17 @@ function captureErrorEvent(event: ErrorEvent) {
     }
 
     if (event.locationContext) {
-      scope.setContext('location', serializeRecord(event.locationContext))
+      scope.setContext('location', stringifyContext(event.locationContext))
     }
 
     if (event.errorContext) {
-      scope.setContext('error', serializeRecord(event.errorContext))
+      scope.setContext('error', stringifyContext(event.errorContext))
     }
 
     scope.setLevel(Sentry.Severity.Error)
 
     return scope
   })
-
-  function serializeRecord(record: Record<string, unknown>) {
-    return R.mapObjIndexed((value) => {
-      return typeof value === 'object' ? JSON.stringify(value, null, 2) : value
-    }, record)
-  }
 }
 
 export interface ErrorContext {

--- a/packages/server/src/internals/sentry.ts
+++ b/packages/server/src/internals/sentry.ts
@@ -54,15 +54,13 @@ export function createSentryPlugin(): ApolloServerPlugin {
 
             Sentry.captureException(error, (scope) => {
               scope.setTag('kind', ctx.operationName)
+
+              const { query, variables } = ctx.request
               scope.setContext(
                 'graphql',
                 stringifyContext({
-                  query: ctx.request.query,
-                  ...(ctx.request.variables === undefined
-                    ? {}
-                    : {
-                        variables: ctx.request.variables,
-                      }),
+                  query,
+                  ...(variables === undefined ? {} : { variables }),
                 })
               )
 

--- a/packages/server/src/internals/sentry.ts
+++ b/packages/server/src/internals/sentry.ts
@@ -79,7 +79,7 @@ export function createSentryPlugin(): ApolloServerPlugin {
                     JSON.stringify(error.originalError.invalidValue),
                   ])
 
-                  scope.setContext('decoder', {
+                  scope.setContext('error', {
                     invalidValue: stringifyObjectProperties(
                       error.originalError.invalidValue
                     ),

--- a/packages/server/src/schema/uuid/user/resolvers.ts
+++ b/packages/server/src/schema/uuid/user/resolvers.ts
@@ -30,7 +30,6 @@ import {
   ErrorEvent,
 } from '~/internals/error-event'
 import { Context, Model, Queries, TypeResolvers } from '~/internals/graphql'
-import { Payload } from '~/internals/model/types'
 import { DiscriminatorType } from '~/model/decoder'
 import { CellValues, MajorDimension } from '~/model/google-spreadsheet-api'
 import { resolveScopedRoles } from '~/schema/authorization/utils'


### PR DESCRIPTION
This PR includes:

* The possibility to test that certain sentry events are thrown (see https://github.com/serlo/api.serlo.org/blob/sentry-improvements/__tests__/__utils__/assertions.ts#L139 )
* Added unit tests concering sentry (especially the missing unit test for https://github.com/serlo/api.serlo.org/pull/323 )
* The helper function `stringifyContext()` to stringify context information