### PR TITLE
sentry: Add event processor to apply stringifyContexts()

### DIFF
--- a/__config__/setup.ts
+++ b/__config__/setup.ts
@@ -29,6 +29,7 @@ import {
   givenSpreadheetApi,
 } from '../__tests__/__utils__'
 import { createCache } from '~/internals/cache'
+import { initializeSentry } from '~/internals/sentry'
 import { Time, timeToMilliseconds } from '~/internals/swr-queue'
 import { Timer } from '~/internals/timer'
 
@@ -51,9 +52,10 @@ export class MockTimer implements Timer {
 }
 
 export function setup() {
-  Sentry.init({
+  initializeSentry({
     dsn: 'https://public@127.0.0.1/0',
     environment: 'testing',
+    context: 'testing',
   })
 
   const timer = new MockTimer()

--- a/packages/server/src/internals/error-event.ts
+++ b/packages/server/src/internals/error-event.ts
@@ -24,8 +24,6 @@ import { array as A } from 'fp-ts'
 import * as F from 'fp-ts/lib/function'
 import R from 'ramda'
 
-import { stringifyContext } from './sentry'
-
 export interface ErrorEvent extends ErrorContext {
   error: Error
 }
@@ -82,11 +80,11 @@ function captureErrorEvent(event: ErrorEvent) {
     }
 
     if (event.locationContext) {
-      scope.setContext('location', stringifyContext(event.locationContext))
+      scope.setContext('location', event.locationContext)
     }
 
     if (event.errorContext) {
-      scope.setContext('error', stringifyContext(event.errorContext))
+      scope.setContext('error', event.errorContext)
     }
 
     scope.setLevel(Sentry.Severity.Error)

--- a/packages/server/src/internals/server/index.ts
+++ b/packages/server/src/internals/server/index.ts
@@ -37,7 +37,7 @@ export function start() {
   dotenv.config({
     path: path.join(__dirname, '..', '..', '..', '.env'),
   })
-  initializeSentry('server')
+  initializeSentry({ context: 'server' })
   const timer = createTimer()
   const cache = createCache({ timer })
   const swrQueue = createSwrQueue({ cache, timer })

--- a/packages/server/src/internals/swr-queue-worker.ts
+++ b/packages/server/src/internals/swr-queue-worker.ts
@@ -32,7 +32,7 @@ export async function start() {
   dotenv.config({
     path: path.join(__dirname, '..', '..', '..', '.env'),
   })
-  initializeSentry('swr-queue-worker')
+  initializeSentry({ context: 'swr-queue-worker' })
   const timer = createTimer()
   const cache = createCache({ timer })
   const swrQueueWorker = createSwrQueueWorker({
@@ -43,7 +43,7 @@ export async function start() {
   await swrQueueWorker.ready()
 
   const app = createApp()
-  app.get('/.well-known/health', (req, res) => {
+  app.get('/.well-known/health', (_req, res) => {
     swrQueueWorker
       .healthy()
       .then(() => {


### PR DESCRIPTION
Fixes the changes made in https://github.com/serlo/api.serlo.org/pull/264 (`beforeSend()` cannot be used since at this stage the context variables are already trimmed to a smaller size)

The new changes helped me to fix the problems in https://github.com/serlo/api.serlo.org/pull/264 since now I can test locally what sentry is doing :tada: