### PR TITLE
add timeout and retries to swr jobs

### DIFF
--- a/packages/server/src/internals/swr-queue.ts
+++ b/packages/server/src/internals/swr-queue.ts
@@ -108,7 +108,13 @@ export function createSwrQueue({
 
       // By setting the job's ID, we make sure that there will be only one update job for the same key
       // See also https://github.com/bee-queue/bee-queue#jobsetidid
-      const job = await queue.createJob(updateJob).setId(updateJob.key).save()
+      const job = await queue
+        .createJob(updateJob)
+        .setId(updateJob.key)
+        .timeout(60000)
+        .retries(5)
+        .backoff('exponential', 10000)
+        .save()
 
       job.on('failed', (err) => {
         log.error(`Job ${job.id} failed with error ${err.message}`)


### PR DESCRIPTION
suggestion for #344.
Adding timeout of 1 min. If a job takes longer it should:
- report (hopefully helps us to understand why it happens)
- retry up to 5 times (might solve the problem?)