### PR TITLE
RFC: add cache key stack

### DIFF
--- a/packages/server/src/internals/server/graphql-middleware.ts
+++ b/packages/server/src/internals/server/graphql-middleware.ts
@@ -82,7 +82,27 @@ export function getGraphQLOptions(
     introspection: true,
     // We add the playground via express middleware in src/index.ts
     playground: false,
-    plugins: [createSentryPlugin()],
+    plugins: [
+      createSentryPlugin(),
+      {
+        requestDidStart() {
+          return {
+            executionDidStart() {
+              return {
+                willResolveField({ source, args, context, info }) {
+                  return (error) => {
+                    if (error) {
+                      const cacheKeyStack = source?.['_cacheKeyStack'] ?? []
+                      console.log(`It failed with ${error}`, cacheKeyStack)
+                    }
+                  }
+                },
+              }
+            },
+          }
+        },
+      },
+    ],
     dataSources() {
       return {
         model: new ModelDataSource(environment),

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -65,6 +65,18 @@ export const resolvers: InterfaceResolvers<'AbstractUuid'> &
       const uuid = await dataSources.model.serlo.getUuid({
         id: decodedUuid.right,
       })
+
+      if (uuid) {
+        // @ts-expect-error
+        uuid['_cacheKeyStack'] = uuid['_cacheKeyStack'] ?? []
+        // @ts-expect-error
+        uuid['_cacheKeyStack'].push(
+          dataSources.model.serlo.getUuid._querySpec.getKey({
+            id: decodedUuid.right,
+          })
+        )
+      }
+
       return checkUuid(payload, uuid)
     },
   },

--- a/packages/server/src/schema/uuid/user/resolvers.ts
+++ b/packages/server/src/schema/uuid/user/resolvers.ts
@@ -77,6 +77,7 @@ export const resolvers: Queries<
       })
     },
     async activeAuthor(user, _args, { dataSources }) {
+      throw new Error('simulate error here')
       return (await dataSources.model.serlo.getActiveAuthorIds()).includes(
         user.id
       )


### PR DESCRIPTION
This is an RFC to reject cache values of parent values when unrecoverable errors arise.