### PR TITLE
sentry: Fix fingerprint for SWR error of invalid value

### DIFF
--- a/packages/server/src/internals/error-event.ts
+++ b/packages/server/src/internals/error-event.ts
@@ -32,7 +32,11 @@ export interface ErrorEvent extends ErrorContext {
 export function addContext(
   context: ErrorContext
 ): (error: ErrorEvent) => ErrorEvent {
-  return R.mergeDeepWith(R.concat, context)
+  return R.mergeDeepWith(
+    (a: unknown, b: unknown) =>
+      Array.isArray(a) && Array.isArray(b) ? R.concat(a, b) : a,
+    context
+  )
 }
 
 export function consumeErrorEvent<A>(defaultValue: A) {

--- a/packages/server/src/internals/error-event.ts
+++ b/packages/server/src/internals/error-event.ts
@@ -32,7 +32,7 @@ export interface ErrorEvent extends ErrorContext {
 export function addContext(
   context: ErrorContext
 ): (error: ErrorEvent) => ErrorEvent {
-  return R.mergeDeepRight(context)
+  return R.mergeDeepWith(R.concat, context)
 }
 
 export function consumeErrorEvent<A>(defaultValue: A) {
@@ -88,6 +88,10 @@ export function captureErrorEvent(event: ErrorEvent) {
       scope.setContext('error', event.errorContext)
     }
 
+    if (event.fingerprint) {
+      scope.setFingerprint(event.fingerprint)
+    }
+
     scope.setLevel(Sentry.Severity.Error)
 
     return scope
@@ -96,6 +100,7 @@ export function captureErrorEvent(event: ErrorEvent) {
 
 export interface ErrorContext {
   location?: string
+  fingerprint?: string[]
   locationContext?: Record<string, unknown>
   errorContext?: Record<string, unknown>
 }

--- a/packages/server/src/internals/swr-queue.ts
+++ b/packages/server/src/internals/swr-queue.ts
@@ -215,6 +215,7 @@ export function createSwrQueueWorker({
             captureErrorEvent({
               error: new Error(INVALID_VALUE_RECEIVED),
               location: 'SWR worker',
+              fingerprint: ['invalid-value', 'swr', JSON.stringify(value)],
               errorContext: {
                 key,
                 invalidValue: value,


### PR DESCRIPTION
So that events in https://sentry.io/organizations/serlo/issues/2403485201/?project=5385534&query=is%3Aunresolved are not in one group of errors