### PR TITLE
Adds mutation "checkoutRevision"

### DIFF
--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -95,18 +95,22 @@ export async function assertFailingGraphQLMutation({
   variables,
   client,
   expectedError,
+  message,
 }: {
   mutation: DocumentNode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variables?: Record<string, any>
   client: Client
   expectedError: string
+  message?: string
 }) {
   const response = await client.mutate({
     mutation,
     variables,
   })
   expect(response?.errors?.[0]?.extensions?.code).toEqual(expectedError)
+
+  if (message) expect(response?.errors?.[0]?.message).toEqual(message)
 }
 
 /**

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -124,6 +124,12 @@ export function givenSerloEndpoint<Payload = DefaultPayloadType>(
   )
 }
 
+export function givenUuidQueryEndpoint(
+  resolver: MessageResolver<{ id: number }>
+) {
+  givenSerloEndpoint('UuidQuery', resolver)
+}
+
 export function createDatabaseLayerHandler<Payload = DefaultPayloadType>(args: {
   matchType: string
   matchPayloads?: Payload[]

--- a/__tests__/__utils__/handlers.ts
+++ b/__tests__/__utils__/handlers.ts
@@ -115,6 +115,22 @@ export function createMessageHandler(
   })
 }
 
+export function givenUuidQueryEndpoint(
+  resolver: MessageResolver<{ id: number }>
+) {
+  givenSerloEndpoint('UuidQuery', resolver)
+}
+
+export function givenEntityCheckoutRevisionEndpoint(
+  resolver: MessageResolver<{
+    revisionId: number
+    reason: string
+    userId: number
+  }>
+) {
+  givenSerloEndpoint('EntityCheckoutRevisionMutation', resolver)
+}
+
 export function givenSerloEndpoint<Payload = DefaultPayloadType>(
   matchType: string,
   resolver: MessageResolver<Payload>
@@ -122,12 +138,6 @@ export function givenSerloEndpoint<Payload = DefaultPayloadType>(
   global.server.use(
     createDatabaseLayerHandler<Payload>({ matchType, resolver })
   )
-}
-
-export function givenUuidQueryEndpoint(
-  resolver: MessageResolver<{ id: number }>
-) {
-  givenSerloEndpoint('UuidQuery', resolver)
 }
 
 export function createDatabaseLayerHandler<Payload = DefaultPayloadType>(args: {

--- a/__tests__/schema/entity/checkout-revision.ts
+++ b/__tests__/schema/entity/checkout-revision.ts
@@ -1,0 +1,64 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020-2021 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020-2021 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { gql } from 'apollo-server'
+
+import { articleRevision, user } from '../../../__fixtures__'
+import {
+  assertSuccessfulGraphQLMutation,
+  createMessageHandler,
+  createTestClient,
+} from '../../__utils__'
+
+test('when revision can be successfully checkout', async () => {
+  const client = createTestClient({ userId: user.id })
+  global.server.use(createCheckoutRevisionHandler({ success: true }))
+
+  await assertSuccessfulGraphQLMutation({
+    mutation: gql`
+      mutation ($input: CheckoutRevisionInput!) {
+        entity {
+          checkoutRevision(input: $input) {
+            success
+          }
+        }
+      }
+    `,
+    variables: {
+      input: { revisionId: articleRevision.id, reason: 'given reason' },
+    },
+    client,
+  })
+})
+
+function createCheckoutRevisionHandler(body: { success: boolean }) {
+  return createMessageHandler({
+    message: {
+      type: 'EntityCheckoutRevisionMutation',
+      payload: {
+        revisionId: articleRevision.id,
+        userId: user.id,
+        reason: 'given reason',
+      },
+    },
+    body,
+  })
+}

--- a/__tests__/schema/entity/checkout-revision.ts
+++ b/__tests__/schema/entity/checkout-revision.ts
@@ -28,11 +28,13 @@ import {
   createDatabaseLayerHandler,
   createMessageHandler,
   createTestClient,
+  createUuidHandler,
 } from '../../__utils__'
 
 test('when revision can be successfully checkout', async () => {
   const client = createTestClient({ userId: user.id })
   global.server.use(createCheckoutRevisionHandler({ success: true }))
+  global.server.use(createUuidHandler(articleRevision))
 
   await assertSuccessfulGraphQLMutation({
     ...createCheckoutRevisionMutation(),

--- a/__tests__/schema/entity/checkout-revision.ts
+++ b/__tests__/schema/entity/checkout-revision.ts
@@ -57,14 +57,9 @@ beforeEach(() => {
     createDatabaseLayerHandler<{ id: number }>({
       matchType: 'UuidQuery',
       resolver(req, res, ctx) {
-        const { id } = req.body.payload
-        const uuid = uuids[id]
+        const uuid = uuids[req.body.payload.id]
 
-        if (uuid) {
-          return res(ctx.json(uuid))
-        } else {
-          return res(ctx.json(null), ctx.status(404))
-        }
+        return uuid ? res(ctx.json(uuid)) : res(ctx.json(null), ctx.status(404))
       },
     }),
     createDatabaseLayerHandler<{

--- a/__tests__/schema/entity/checkout-revision.ts
+++ b/__tests__/schema/entity/checkout-revision.ts
@@ -35,6 +35,7 @@ test('when revision can be successfully checkout', async () => {
 
   await assertSuccessfulGraphQLMutation({
     ...createCheckoutRevisionMutation(),
+    data: { entity: { checkoutRevision: { success: true } } },
     client,
   })
 })

--- a/__tests__/schema/entity/checkout-revision.ts
+++ b/__tests__/schema/entity/checkout-revision.ts
@@ -105,7 +105,7 @@ beforeEach(() => {
   })
 })
 
-test('returns "{ success: true }" when mutation could be successfully done', async () => {
+test('returns "{ success: true }" when mutation could be successfully executed', async () => {
   await assertSuccessfulGraphQLMutation({
     ...createCheckoutRevisionMutation(),
     data: { entity: { checkoutRevision: { success: true } } },
@@ -113,7 +113,7 @@ test('returns "{ success: true }" when mutation could be successfully done', asy
   })
 })
 
-test('following queries for entity contain the current revision when entity is already in the cache', async () => {
+test('following queries for entity point to checkout revision when entity is already in the cache', async () => {
   await assertSuccessfulGraphQLQuery({
     query: gql`
       query ($id: Int!) {
@@ -174,13 +174,12 @@ test('fails when user does not have role "reviewer"', async () => {
   })
 })
 
-test('fails when database layer has an internal error', async () => {
-  givenEntityCheckoutRevisionEndpoint(hasInternalServerError())
-
+test('fails when revisionId is already checkout out', async () => {
   await assertFailingGraphQLMutation({
-    ...createCheckoutRevisionMutation(),
+    ...createCheckoutRevisionMutation({ revisionId: articleRevision.id }),
     client,
-    expectedError: 'INTERNAL_SERVER_ERROR',
+    expectedError: 'BAD_USER_INPUT',
+    message: 'revision is already checked out',
   })
 })
 
@@ -194,12 +193,13 @@ test('fails when revisionId does not belong to a revision', async () => {
   })
 })
 
-test('fails when revisionId is already checkout out', async () => {
+test('fails when database layer has an internal error', async () => {
+  givenEntityCheckoutRevisionEndpoint(hasInternalServerError())
+
   await assertFailingGraphQLMutation({
-    ...createCheckoutRevisionMutation({ revisionId: articleRevision.id }),
+    ...createCheckoutRevisionMutation(),
     client,
-    expectedError: 'BAD_USER_INPUT',
-    message: 'revision is already checked out',
+    expectedError: 'INTERNAL_SERVER_ERROR',
   })
 })
 

--- a/__tests__/schema/entity/checkout-revision.ts
+++ b/__tests__/schema/entity/checkout-revision.ts
@@ -19,6 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
+import { Instance } from '@serlo/api'
 import { gql } from 'apollo-server'
 
 import { article, articleRevision, user } from '../../../__fixtures__'
@@ -39,7 +40,8 @@ let uuids: Record<number, Model<'AbstractUuid'> | undefined>
 beforeEach(() => {
   uuids = {}
 
-  givenUuid(article)
+  givenUuid({ ...user, roles: ['de_reviewer'] })
+  givenUuid({ ...article, instance: Instance.De })
   givenUuid(articleRevision)
   givenUuid(unrevisedRevision)
 
@@ -170,6 +172,17 @@ test('fails when user is not authenticated', async () => {
     ...createCheckoutRevisionMutation(),
     client,
     expectedError: 'UNAUTHENTICATED',
+  })
+})
+
+test('fails when user does not have role "reviewer"', async () => {
+  const client = createTestClient({ userId: user.id })
+  givenUuid({ ...user, roles: ['login', 'de_moderator'] })
+
+  await assertFailingGraphQLMutation({
+    ...createCheckoutRevisionMutation(),
+    client,
+    expectedError: 'FORBIDDEN',
   })
 })
 

--- a/__tests__/schema/entity/checkout-revision.ts
+++ b/__tests__/schema/entity/checkout-revision.ts
@@ -33,6 +33,7 @@ import {
   assertSuccessfulGraphQLQuery,
   createDatabaseLayerHandler,
   createTestClient,
+  givenUuidQueryEndpoint,
   givenSerloEndpoint,
 } from '../../__utils__'
 import { Model } from '~/internals/graphql'
@@ -54,7 +55,7 @@ beforeEach(() => {
 
   givenUuids([user, article, articleRevision, unrevisedRevision])
 
-  givenSerloEndpoint<{ id: number }>('UuidQuery', (req, res, ctx) => {
+  givenUuidQueryEndpoint((req, res, ctx) => {
     const uuid = uuids[req.body.payload.id]
 
     return uuid ? res(ctx.json(uuid)) : res(ctx.json(null), ctx.status(404))

--- a/packages/authorization/src/index.ts
+++ b/packages/authorization/src/index.ts
@@ -36,6 +36,7 @@ export function instanceToScope(instance: Instance | null): Scope {
 }
 
 export enum Permission {
+  Entity_CheckoutRevision = 'entity:checkoutRevision',
   Entity_SetLicense = 'entity:setLicense',
   Entity_AddChild = 'entity:addChild',
   Entity_RemoveChild = 'entity:removeChild',
@@ -95,6 +96,7 @@ function createPermissionGuard(
 }
 
 export const Entity = {
+  checkoutRevision: createPermissionGuard(Permission.Entity_CheckoutRevision),
   setLicense: createPermissionGuard(Permission.Entity_SetLicense),
   addChild: createPermissionGuard(Permission.Entity_AddChild),
   removeChild: createPermissionGuard(Permission.Entity_RemoveChild),

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -690,10 +690,26 @@ export function createSerloModel({
     },
   })
 
+  const checkoutRevision = createMutation({
+    decoder: t.type({ success: t.boolean }),
+    async mutate(payload: {
+      revisionId: number
+      userId: number
+      reason: string
+    }) {
+      return await handleMessage({
+        message: { type: 'EntityCheckoutRevisionMutation', payload },
+        expectedStatusCodes: [200],
+      })
+    },
+    // TODO: Update Cache
+  })
+
   return {
     createThread,
     archiveThread,
     createComment,
+    checkoutRevision,
     getActiveAuthorIds,
     getActiveReviewerIds,
     getAlias,

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -711,7 +711,6 @@ export function createSerloModel({
         decoder: EntityRevisionDecoder,
       })
 
-      // TODO: Add test
       await getUuid._querySpec.removeCache({
         payload: { id: revision.repositoryId },
       })

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -33,6 +33,7 @@ import {
   NotificationDecoder,
   NavigationDecoder,
   NavigationDataDecoder,
+  EntityRevisionDecoder,
 } from './decoder'
 import {
   createMutation,
@@ -702,7 +703,19 @@ export function createSerloModel({
         expectedStatusCodes: [200],
       })
     },
-    // TODO: Update Cache
+    async updateCache({ revisionId }) {
+      // TODO: Here we need to discuss whether we want to pass entityId as well
+      // so that we do not need to fetch the revision here
+      const revision = await getUuidWithCustomDecoder({
+        id: revisionId,
+        decoder: EntityRevisionDecoder,
+      })
+
+      // TODO: Add test
+      await getUuid._querySpec.removeCache({
+        payload: { id: revision.repositoryId },
+      })
+    },
   })
 
   return {

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -692,7 +692,10 @@ export function createSerloModel({
   })
 
   const checkoutRevision = createMutation({
-    decoder: t.type({ success: t.boolean }),
+    decoder: t.union([
+      t.type({ success: t.literal(true) }),
+      t.type({ success: t.literal(false), reason: t.string }),
+    ]),
     async mutate(payload: {
       revisionId: number
       userId: number
@@ -700,7 +703,7 @@ export function createSerloModel({
     }) {
       return await handleMessage({
         message: { type: 'EntityCheckoutRevisionMutation', payload },
-        expectedStatusCodes: [200],
+        expectedStatusCodes: [200, 400],
       })
     },
     async updateCache({ revisionId }) {

--- a/packages/server/src/model/types.ts
+++ b/packages/server/src/model/types.ts
@@ -80,6 +80,7 @@ export interface Models {
   CoursePageRevision: t.TypeOf<typeof CoursePageRevisionDecoder>
   Course: t.TypeOf<typeof CourseDecoder>
   CourseRevision: t.TypeOf<typeof CourseRevisionDecoder>
+  EntityMutation: Record<string, never>
   Event: t.TypeOf<typeof EventDecoder>
   EventRevision: t.TypeOf<typeof EventRevisionDecoder>
   ExerciseGroup: t.TypeOf<typeof ExerciseGroupDecoder>

--- a/packages/server/src/schema/authorization/roles.ts
+++ b/packages/server/src/schema/authorization/roles.ts
@@ -56,6 +56,7 @@ const roleDefinitions: Record<Role, RoleDefinition> = {
   },
   [Role.Reviewer]: {
     permissions: [
+      Permission.Entity_CheckoutRevision,
       Permission.Entity_OrderChildren,
       Permission.TaxonomyTerm_OrderChildren,
       Permission.Uuid_SetState_EntityRevision,

--- a/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
@@ -72,10 +72,16 @@ export const resolvers: InterfaceResolvers<'AbstractEntity'> &
         guard: serloAuth.Entity.checkoutRevision(scope),
       })
 
-      return await dataSources.model.serlo.checkoutRevision({
+      const result = await dataSources.model.serlo.checkoutRevision({
         ...input,
         userId,
       })
+
+      if (result.success !== true) {
+        throw new UserInputError(result.reason)
+      }
+
+      return result
     },
   },
 }

--- a/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
@@ -20,10 +20,19 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 
-import { InterfaceResolvers } from '~/internals/graphql'
+import {
+  assertUserIsAuthenticated,
+  createNamespace,
+  InterfaceResolvers,
+  Mutations,
+} from '~/internals/graphql'
 
 export const resolvers: InterfaceResolvers<'AbstractEntity'> &
-  InterfaceResolvers<'AbstractEntityRevision'> = {
+  InterfaceResolvers<'AbstractEntityRevision'> &
+  Mutations<'entity'> = {
+  Mutation: {
+    entity: createNamespace(),
+  },
   AbstractEntity: {
     __resolveType(entity) {
       return entity.__typename
@@ -32,6 +41,16 @@ export const resolvers: InterfaceResolvers<'AbstractEntity'> &
   AbstractEntityRevision: {
     __resolveType(entityRevision) {
       return entityRevision.__typename
+    },
+  },
+  EntityMutation: {
+    checkoutRevision(_parent, { input }, { dataSources, userId }) {
+      // Todo: Authentication
+
+      // Todo: Add test
+      assertUserIsAuthenticated(userId)
+
+      return dataSources.model.serlo.checkoutRevision({ ...input, userId })
     },
   },
 }

--- a/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
@@ -46,8 +46,6 @@ export const resolvers: InterfaceResolvers<'AbstractEntity'> &
   EntityMutation: {
     checkoutRevision(_parent, { input }, { dataSources, userId }) {
       // Todo: Authentication
-
-      // Todo: Add test
       assertUserIsAuthenticated(userId)
 
       return dataSources.model.serlo.checkoutRevision({ ...input, userId })

--- a/packages/server/src/schema/uuid/abstract-entity/types.graphql
+++ b/packages/server/src/schema/uuid/abstract-entity/types.graphql
@@ -38,3 +38,20 @@ interface AbstractEntityRevision {
 
   changes: String!
 }
+
+extend type Mutation {
+  entity: EntityMutation!
+}
+
+type EntityMutation {
+  checkoutRevision(input: CheckoutRevisionInput!): CheckoutRevisionResponse!
+}
+
+input CheckoutRevisionInput {
+  revisionId: Int!
+  reason: String!
+}
+
+type CheckoutRevisionResponse {
+  success: Boolean!
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -492,6 +492,11 @@ export type CacheUpdateResponse = {
   query: Query;
 };
 
+export type CheckoutRevisionInput = {
+  revisionId: Scalars['Int'];
+  reason: Scalars['String'];
+};
+
 export type CheckoutRevisionNotificationEvent = AbstractNotificationEvent & InstanceAware & {
   __typename?: 'CheckoutRevisionNotificationEvent';
   id: Scalars['Int'];
@@ -502,6 +507,11 @@ export type CheckoutRevisionNotificationEvent = AbstractNotificationEvent & Inst
   repository: Applet | Article | Course | CoursePage | Event | Exercise | ExerciseGroup | GroupedExercise | Page | Solution | Video;
   revision: AppletRevision | ArticleRevision | CoursePageRevision | CourseRevision | EventRevision | ExerciseGroupRevision | ExerciseRevision | GroupedExerciseRevision | PageRevision | SolutionRevision | VideoRevision;
   reason: Scalars['String'];
+};
+
+export type CheckoutRevisionResponse = {
+  __typename?: 'CheckoutRevisionResponse';
+  success: Scalars['Boolean'];
 };
 
 export type Comment = AbstractUuid & {
@@ -819,6 +829,16 @@ export type CreateThreadNotificationEvent = AbstractNotificationEvent & Instance
   thread: UnsupportedThread;
 };
 
+
+export type EntityMutation = {
+  __typename?: 'EntityMutation';
+  checkoutRevision: CheckoutRevisionResponse;
+};
+
+
+export type EntityMutationCheckoutRevisionArgs = {
+  input: CheckoutRevisionInput;
+};
 
 export type Event = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'Event';
@@ -1248,6 +1268,7 @@ export type License = {
 export type Mutation = {
   __typename?: 'Mutation';
   _cache: _CacheMutation;
+  entity: EntityMutation;
   notification: NotificationMutation;
   subscription: SubscriptionMutation;
   thread: ThreadMutation;
@@ -2303,7 +2324,9 @@ export type ResolversTypes = {
   CacheSetResponse: ResolverTypeWrapper<ModelOf<CacheSetResponse>>;
   CacheUpdateInput: ResolverTypeWrapper<ModelOf<CacheUpdateInput>>;
   CacheUpdateResponse: ResolverTypeWrapper<ModelOf<CacheUpdateResponse>>;
+  CheckoutRevisionInput: ResolverTypeWrapper<ModelOf<CheckoutRevisionInput>>;
   CheckoutRevisionNotificationEvent: ResolverTypeWrapper<ModelOf<CheckoutRevisionNotificationEvent>>;
+  CheckoutRevisionResponse: ResolverTypeWrapper<ModelOf<CheckoutRevisionResponse>>;
   Comment: ResolverTypeWrapper<ModelOf<Comment>>;
   CommentConnection: ResolverTypeWrapper<ModelOf<CommentConnection>>;
   CommentEdge: ResolverTypeWrapper<ModelOf<CommentEdge>>;
@@ -2323,6 +2346,7 @@ export type ResolversTypes = {
   CreateTaxonomyTermNotificationEvent: ResolverTypeWrapper<ModelOf<CreateTaxonomyTermNotificationEvent>>;
   CreateThreadNotificationEvent: ResolverTypeWrapper<ModelOf<CreateThreadNotificationEvent>>;
   DateTime: ResolverTypeWrapper<ModelOf<Scalars['DateTime']>>;
+  EntityMutation: ResolverTypeWrapper<ModelOf<EntityMutation>>;
   Event: ResolverTypeWrapper<ModelOf<Event>>;
   EventRevision: ResolverTypeWrapper<ModelOf<EventRevision>>;
   EventRevisionConnection: ResolverTypeWrapper<ModelOf<EventRevisionConnection>>;
@@ -2448,7 +2472,9 @@ export type ResolversParentTypes = {
   CacheSetResponse: ModelOf<CacheSetResponse>;
   CacheUpdateInput: ModelOf<CacheUpdateInput>;
   CacheUpdateResponse: ModelOf<CacheUpdateResponse>;
+  CheckoutRevisionInput: ModelOf<CheckoutRevisionInput>;
   CheckoutRevisionNotificationEvent: ModelOf<CheckoutRevisionNotificationEvent>;
+  CheckoutRevisionResponse: ModelOf<CheckoutRevisionResponse>;
   Comment: ModelOf<Comment>;
   CommentConnection: ModelOf<CommentConnection>;
   CommentEdge: ModelOf<CommentEdge>;
@@ -2468,6 +2494,7 @@ export type ResolversParentTypes = {
   CreateTaxonomyTermNotificationEvent: ModelOf<CreateTaxonomyTermNotificationEvent>;
   CreateThreadNotificationEvent: ModelOf<CreateThreadNotificationEvent>;
   DateTime: ModelOf<Scalars['DateTime']>;
+  EntityMutation: ModelOf<EntityMutation>;
   Event: ModelOf<Event>;
   EventRevision: ModelOf<EventRevision>;
   EventRevisionConnection: ModelOf<EventRevisionConnection>;
@@ -2812,6 +2839,11 @@ export type CheckoutRevisionNotificationEventResolvers<ContextType = Context, Pa
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CheckoutRevisionResponseResolvers<ContextType = Context, ParentType extends ResolversParentTypes['CheckoutRevisionResponse'] = ResolversParentTypes['CheckoutRevisionResponse']> = {
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type CommentResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Comment'] = ResolversParentTypes['Comment']> = {
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -3008,6 +3040,11 @@ export type CreateThreadNotificationEventResolvers<ContextType = Context, Parent
 export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
   name: 'DateTime';
 }
+
+export type EntityMutationResolvers<ContextType = Context, ParentType extends ResolversParentTypes['EntityMutation'] = ResolversParentTypes['EntityMutation']> = {
+  checkoutRevision?: Resolver<ResolversTypes['CheckoutRevisionResponse'], ParentType, ContextType, RequireFields<EntityMutationCheckoutRevisionArgs, 'input'>>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
 
 export type EventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Event'] = ResolversParentTypes['Event']> = {
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -3214,6 +3251,7 @@ export type LicenseResolvers<ContextType = Context, ParentType extends Resolvers
 
 export type MutationResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   _cache?: Resolver<ResolversTypes['_cacheMutation'], ParentType, ContextType>;
+  entity?: Resolver<ResolversTypes['EntityMutation'], ParentType, ContextType>;
   notification?: Resolver<ResolversTypes['NotificationMutation'], ParentType, ContextType>;
   subscription?: Resolver<ResolversTypes['SubscriptionMutation'], ParentType, ContextType>;
   thread?: Resolver<ResolversTypes['ThreadMutation'], ParentType, ContextType>;
@@ -3740,6 +3778,7 @@ export type Resolvers<ContextType = Context> = {
   CacheSetResponse?: CacheSetResponseResolvers<ContextType>;
   CacheUpdateResponse?: CacheUpdateResponseResolvers<ContextType>;
   CheckoutRevisionNotificationEvent?: CheckoutRevisionNotificationEventResolvers<ContextType>;
+  CheckoutRevisionResponse?: CheckoutRevisionResponseResolvers<ContextType>;
   Comment?: CommentResolvers<ContextType>;
   CommentConnection?: CommentConnectionResolvers<ContextType>;
   CommentEdge?: CommentEdgeResolvers<ContextType>;
@@ -3759,6 +3798,7 @@ export type Resolvers<ContextType = Context> = {
   CreateTaxonomyTermNotificationEvent?: CreateTaxonomyTermNotificationEventResolvers<ContextType>;
   CreateThreadNotificationEvent?: CreateThreadNotificationEventResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
+  EntityMutation?: EntityMutationResolvers<ContextType>;
   Event?: EventResolvers<ContextType>;
   EventRevision?: EventRevisionResolvers<ContextType>;
   EventRevisionConnection?: EventRevisionConnectionResolvers<ContextType>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -488,6 +488,11 @@ export type CacheUpdateResponse = {
   query: Query;
 };
 
+export type CheckoutRevisionInput = {
+  revisionId: Scalars['Int'];
+  reason: Scalars['String'];
+};
+
 export type CheckoutRevisionNotificationEvent = AbstractNotificationEvent & InstanceAware & {
   __typename?: 'CheckoutRevisionNotificationEvent';
   id: Scalars['Int'];
@@ -498,6 +503,11 @@ export type CheckoutRevisionNotificationEvent = AbstractNotificationEvent & Inst
   repository: AbstractRepository;
   revision: AbstractRevision;
   reason: Scalars['String'];
+};
+
+export type CheckoutRevisionResponse = {
+  __typename?: 'CheckoutRevisionResponse';
+  success: Scalars['Boolean'];
 };
 
 export type Comment = AbstractUuid & {
@@ -815,6 +825,16 @@ export type CreateThreadNotificationEvent = AbstractNotificationEvent & Instance
   thread: UnsupportedThread;
 };
 
+
+export type EntityMutation = {
+  __typename?: 'EntityMutation';
+  checkoutRevision: CheckoutRevisionResponse;
+};
+
+
+export type EntityMutationCheckoutRevisionArgs = {
+  input: CheckoutRevisionInput;
+};
 
 export type Event = AbstractUuid & AbstractRepository & AbstractEntity & AbstractTaxonomyTermChild & InstanceAware & ThreadAware & {
   __typename?: 'Event';
@@ -1244,6 +1264,7 @@ export type License = {
 export type Mutation = {
   __typename?: 'Mutation';
   _cache: _CacheMutation;
+  entity: EntityMutation;
   notification: NotificationMutation;
   subscription: SubscriptionMutation;
   thread: ThreadMutation;


### PR DESCRIPTION
@inyono: I made a quite elaborate PR since I want to solve some problem we will have with other mutations as well in the future. In particular:

* I changed the way the tests use mock the database layer with the experience I learned in the CF worker: Instead of preemptively state which request to the database layer shall return which response, I mock the actual behavior of the database layer: I use a dictionary `uuids = Record<number, Model<"AbstractUuid">>` as a database of uuid objects and the code in the msw resolver does actually try to checkout a revision.  The advantage https://github.com/serlo/api.serlo.org/blob/78ac0b84a70e02c484e13777b74584b330bed5ad/__tests__/schema/entity/checkout-revision.ts#L68-L105 is a pseudo code for what needs to be implemented in the database layer. With this setup I can actually easily test whether the cache is changed properly (which would be harder with the old approach).
* I try to handle all possible errors in the tests which can happen.

When you give positive feedback I will implement the mutation "rejectRevision" in the same way. I also will move helper functions like `givenUuid` to appropriate places. Feel free to change this branch directly when I didn't implement the behavior of the database layer correctly.