### PR TITLE
Add eslint rule "no-console"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     // eslint
     'no-duplicate-imports': 'error',
     'no-unused-vars': 'off',
+    'no-console': 'error',
 
     // @typescript-eslint/eslint-plugin
     '@typescript-eslint/ban-ts-comment': 'warn',

--- a/packages/server/src/internals/server/index.ts
+++ b/packages/server/src/internals/server/index.ts
@@ -58,9 +58,11 @@ function initializeGraphQLServer({
   const port = 3000
   const host = `http://localhost:${port}`
   app.listen({ port }, () => {
+    /* eslint-disable no-console */
     console.log('🚀 Server ready')
     console.log(`Playground:          ${host}/___graphql`)
     console.log(`GraphQL endpoint:    ${host}${graphqlPath}`)
     console.log(`SWR Queue Dashboard: ${host}${dashboardPath}`)
+    /* eslint-enable no-console */
   })
 }

--- a/packages/server/src/internals/swr-queue-worker.ts
+++ b/packages/server/src/internals/swr-queue-worker.ts
@@ -54,6 +54,7 @@ export async function start() {
       })
   })
   app.listen({ port: 3000 }, () => {
+    // eslint-disable-next-line no-console
     console.log('🚀 SWR Queue Worker ready')
   })
 }

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -31,6 +31,7 @@ exec()
     process.exit(0)
   })
   .catch((error) => {
+    // eslint-disable-next-line no-console
     console.error(error)
     process.exit(1)
   })

--- a/scripts/publish-pacts.ts
+++ b/scripts/publish-pacts.ts
@@ -42,5 +42,6 @@ void pact
     consumerVersion,
   })
   .then(function () {
+    // eslint-disable-next-line no-console
     console.log('success')
   })


### PR DESCRIPTION
Closes https://github.com/serlo/api.serlo.org/issues/340 See also https://eslint.org/docs/rules/no-console (so we can detect leftover console.log() statements before merging into master)