### PR TITLE
Removed helper functions from tests for course

### DIFF
--- a/__fixtures__/uuid/course-page.ts
+++ b/__fixtures__/uuid/course-page.ts
@@ -19,8 +19,6 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import * as R from 'ramda'
-
 import { license } from '../license'
 import { course } from './course'
 import { Model } from '~/internals/graphql'
@@ -51,19 +49,4 @@ export const coursePageRevision: Model<'CoursePageRevision'> = {
   title: 'title',
   content: 'content',
   changes: 'changes',
-}
-
-export function getCoursePageDataWithoutSubResolvers(
-  coursePage: Model<'CoursePage'>
-) {
-  return R.omit(
-    ['currentRevisionId', 'revisionIds', 'licenseId', 'parentId', 'alias'],
-    coursePage
-  )
-}
-
-export function getCoursePageRevisionDataWithoutSubResolvers(
-  coursePageRevision: Model<'CoursePageRevision'>
-) {
-  return R.omit(['authorId', 'repositoryId', 'alias'], coursePageRevision)
 }

--- a/__fixtures__/uuid/course.ts
+++ b/__fixtures__/uuid/course.ts
@@ -19,8 +19,6 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-import * as R from 'ramda'
-
 import { license } from '../license'
 import { Model } from '~/internals/graphql'
 import { EntityRevisionType, EntityType } from '~/model/decoder'
@@ -52,24 +50,4 @@ export const courseRevision: Model<'CourseRevision'> = {
   content: 'content',
   changes: 'changes',
   metaDescription: 'metaDescription',
-}
-
-export function getCourseDataWithoutSubResolvers(course: Model<'Course'>) {
-  return R.omit(
-    [
-      'currentRevisionId',
-      'revisionIds',
-      'licenseId',
-      'taxonomyTermIds',
-      'pageIds',
-      'alias',
-    ],
-    course
-  )
-}
-
-export function getCourseRevisionDataWithoutSubResolvers(
-  courseRevision: Model<'CourseRevision'>
-) {
-  return R.omit(['authorId', 'repositoryId', 'alias'], courseRevision)
 }

--- a/__tests-pacts__/serlo.org-database-layer/uuid/course-page.ts
+++ b/__tests-pacts__/serlo.org-database-layer/uuid/course-page.ts
@@ -21,13 +21,9 @@
  */
 import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
+import R from 'ramda'
 
-import {
-  coursePage,
-  coursePageRevision,
-  getCoursePageDataWithoutSubResolvers,
-  getCoursePageRevisionDataWithoutSubResolvers,
-} from '../../../__fixtures__'
+import { coursePage, coursePageRevision } from '../../../__fixtures__'
 import {
   addUuidInteraction,
   assertSuccessfulGraphQLQuery,
@@ -64,7 +60,10 @@ test('CoursePage', async () => {
         }
       `,
     data: {
-      uuid: getCoursePageDataWithoutSubResolvers(coursePage),
+      uuid: R.pick(
+        ['__typename', 'id', 'trashed', 'instance', 'date'],
+        coursePage
+      ),
     },
   })
 })
@@ -99,7 +98,10 @@ test('CoursePageRevision', async () => {
         }
       `,
     data: {
-      uuid: getCoursePageRevisionDataWithoutSubResolvers(coursePageRevision),
+      uuid: R.pick(
+        ['__typename', 'id', 'trashed', 'date', 'title', 'content', 'changes'],
+        coursePageRevision
+      ),
     },
   })
 })

--- a/__tests-pacts__/serlo.org-database-layer/uuid/course.ts
+++ b/__tests-pacts__/serlo.org-database-layer/uuid/course.ts
@@ -21,13 +21,9 @@
  */
 import { Matchers } from '@pact-foundation/pact'
 import { gql } from 'apollo-server'
+import R from 'ramda'
 
-import {
-  course,
-  courseRevision,
-  getCourseDataWithoutSubResolvers,
-  getCourseRevisionDataWithoutSubResolvers,
-} from '../../../__fixtures__'
+import { course, courseRevision } from '../../../__fixtures__'
 import {
   addUuidInteraction,
   assertSuccessfulGraphQLQuery,
@@ -71,7 +67,7 @@ test('Course', async () => {
         }
       `,
     data: {
-      uuid: getCourseDataWithoutSubResolvers(course),
+      uuid: R.pick(['__typename', 'id', 'trashed', 'instance', 'date'], course),
     },
   })
 })
@@ -108,7 +104,19 @@ test('CourseRevision', async () => {
         }
       `,
     data: {
-      uuid: getCourseRevisionDataWithoutSubResolvers(courseRevision),
+      uuid: R.pick(
+        [
+          '__typename',
+          'id',
+          'trashed',
+          'date',
+          'title',
+          'content',
+          'changes',
+          'metaDescription',
+        ],
+        courseRevision
+      ),
     },
   })
 })

--- a/__tests__/schema/uuid/course-page.ts
+++ b/__tests__/schema/uuid/course-page.ts
@@ -20,20 +20,15 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { gql } from 'apollo-server'
+import R from 'ramda'
 
-import {
-  course,
-  coursePage,
-  coursePageRevision,
-  getCourseDataWithoutSubResolvers,
-  getCoursePageDataWithoutSubResolvers,
-  getCoursePageRevisionDataWithoutSubResolvers,
-} from '../../../__fixtures__'
+import { course, coursePage, coursePageRevision } from '../../../__fixtures__'
 import {
   assertSuccessfulGraphQLQuery,
   Client,
   createTestClient,
   createUuidHandler,
+  getTypenameAndId,
 } from '../../__utils__'
 
 let client: Client
@@ -64,7 +59,10 @@ describe('CoursePage', () => {
       `,
       variables: coursePage,
       data: {
-        uuid: getCoursePageDataWithoutSubResolvers(coursePage),
+        uuid: R.pick(
+          ['__typename', 'id', 'trashed', 'instance', 'date'],
+          coursePage
+        ),
       },
       client,
     })
@@ -80,9 +78,6 @@ describe('CoursePage', () => {
               course {
                 __typename
                 id
-                trashed
-                instance
-                date
               }
             }
           }
@@ -91,7 +86,7 @@ describe('CoursePage', () => {
       variables: coursePage,
       data: {
         uuid: {
-          course: getCourseDataWithoutSubResolvers(course),
+          course: getTypenameAndId(course),
         },
       },
       client,
@@ -119,7 +114,10 @@ test('CoursePageRevision', async () => {
     `,
     variables: coursePageRevision,
     data: {
-      uuid: getCoursePageRevisionDataWithoutSubResolvers(coursePageRevision),
+      uuid: R.pick(
+        ['__typename', 'id', 'trashed', 'date', 'title', 'content', 'changes'],
+        coursePageRevision
+      ),
     },
     client,
   })

--- a/__tests__/schema/uuid/course.ts
+++ b/__tests__/schema/uuid/course.ts
@@ -20,20 +20,15 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import { gql } from 'apollo-server'
+import R from 'ramda'
 
-import {
-  course,
-  coursePage,
-  courseRevision,
-  getCourseDataWithoutSubResolvers,
-  getCoursePageDataWithoutSubResolvers,
-  getCourseRevisionDataWithoutSubResolvers,
-} from '../../../__fixtures__'
+import { course, coursePage, courseRevision } from '../../../__fixtures__'
 import {
   assertSuccessfulGraphQLQuery,
   Client,
   createTestClient,
   createUuidHandler,
+  getTypenameAndId,
 } from '../../__utils__'
 
 let client: Client
@@ -64,7 +59,10 @@ describe('Course', () => {
       `,
       variables: course,
       data: {
-        uuid: getCourseDataWithoutSubResolvers(course),
+        uuid: R.pick(
+          ['__typename', 'id', 'trashed', 'instance', 'date'],
+          course
+        ),
       },
       client,
     })
@@ -80,9 +78,6 @@ describe('Course', () => {
               pages {
                 __typename
                 id
-                trashed
-                instance
-                date
               }
             }
           }
@@ -91,7 +86,7 @@ describe('Course', () => {
       variables: course,
       data: {
         uuid: {
-          pages: [getCoursePageDataWithoutSubResolvers(coursePage)],
+          pages: [getTypenameAndId(coursePage)],
         },
       },
       client,
@@ -258,7 +253,19 @@ test('CourseRevision', async () => {
     `,
     variables: courseRevision,
     data: {
-      uuid: getCourseRevisionDataWithoutSubResolvers(courseRevision),
+      uuid: R.pick(
+        [
+          '__typename',
+          'id',
+          'trashed',
+          'date',
+          'title',
+          'content',
+          'changes',
+          'metaDescription',
+        ],
+        courseRevision
+      ),
     },
     client,
   })


### PR DESCRIPTION
Related to #347 

Question: Does it suffice to check for `['id', '__typename', 'instance', 'date']` in either unit or pacts tests of one type, e.g. Course, and use `getTypenameandId(`) in all other tests? Or should each of unit and pacts tests check once for these basic properties?