### PR TITLE
auth: throw errors when provided token is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.26.0](https://github.com/serlo/api.serlo.org/compare/v0.25.0..v0.26.0) - June 30, 2021
+
+### Breaking Changes
+
+- **authorization**. Throw `INVALID_TOKEN` error when user token is invalid (e.g. expired, malformed).
+
 ## [v0.25.0](https://github.com/serlo/api.serlo.org/compare/v0.24.8..v0.25.0) - June 28, 2021
 
 ### Breaking Changes

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.25.0"
+  "version": "0.26.0"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.24.10-staging",
+  "version": "0.25.1-staging",
   "private": true,
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.24.9-staging",
+  "version": "0.24.10-staging",
   "private": true,
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.25.0",
+  "version": "0.24.9-staging",
   "private": true,
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.25.1-staging",
+  "version": "0.26.0",
   "private": true,
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",

--- a/packages/server/src/internals/server/graphql-middleware.ts
+++ b/packages/server/src/internals/server/graphql-middleware.ts
@@ -124,7 +124,7 @@ export function getGraphQLOptions(
           sub: string
         }
 
-        if (active) parseInt(sub, 10)
+        if (active) return parseInt(sub, 10)
         throw new ApolloError('Token expired or invalid', 'INVALID_TOKEN')
       })
     },

--- a/packages/server/src/internals/server/graphql-middleware.ts
+++ b/packages/server/src/internals/server/graphql-middleware.ts
@@ -109,7 +109,7 @@ export function getGraphQLOptions(
         if (process.env.SERVER_HYDRA_HOST === undefined) return null
         const params = new URLSearchParams()
         params.append('token', token)
-        const resp = await fetch(
+        const response = await fetch(
           `${process.env.SERVER_HYDRA_HOST}/oauth2/introspect`,
           {
             method: 'post',
@@ -119,11 +119,13 @@ export function getGraphQLOptions(
             },
           }
         )
-        const { active, sub } = (await resp.json()) as {
+        const { active, sub } = (await response.json()) as {
           active: boolean
           sub: string
         }
-        return active ? parseInt(sub, 10) : null
+
+        if (active) parseInt(sub, 10)
+        throw new ApolloError('Token expired or invalid', 'INVALID_TOKEN')
       })
     },
   }

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -879,6 +879,16 @@ async function exec(): Promise<void> {
       added: ['add property "sendMail" to subscriptions query'],
       internal: ['refactoring of tests'],
     },
+    {
+      tagName: 'v0.26.0',
+      date: '2021-06-30',
+      breakingChanges: [
+        [
+          'authorization',
+          'Throw `INVALID_TOKEN` error when user token is invalid (e.g. expired, malformed).',
+        ],
+      ],
+    },
   ])
 
   await writeFile(path.join(__dirname, '..', 'CHANGELOG.md'), content)


### PR DESCRIPTION
Needed for https://github.com/serlo/frontend/pull/1128 and already live on staging.

Instead of treating invalid tokens the same as if the client didn't pass a token at all, we now throw a custom error. This way, clients know exactly when they need to refresh the token.