### PR TITLE
events: Remove set limit -> use default limit of 500

### DIFF
--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -196,9 +196,9 @@ describe('query endpoint "events"', () => {
     })
   })
 
-  test('number of returned events is bounded to 300 when first = last = undefined', async () => {
+  test('number of returned events is bounded to 500 when first = last = undefined', async () => {
     const events = assignSequentialIds(
-      R.range(0, 30).flatMap(R.always(allEvents))
+      R.range(0, 50).flatMap(R.always(allEvents))
     )
     setupEvents(events)
 
@@ -214,7 +214,7 @@ describe('query endpoint "events"', () => {
         }
       `,
       client,
-      data: { events: { nodes: events.slice(0, 300).map(getTypenameAndId) } },
+      data: { events: { nodes: events.slice(0, 500).map(getTypenameAndId) } },
     })
   })
 })

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -196,9 +196,9 @@ describe('query endpoint "events"', () => {
     })
   })
 
-  test('number of returned events is bounded to 100 when first = last = undefined', async () => {
+  test('number of returned events is bounded to 300 when first = last = undefined', async () => {
     const events = assignSequentialIds(
-      R.range(0, 10).flatMap(R.always(allEvents))
+      R.range(0, 30).flatMap(R.always(allEvents))
     )
     setupEvents(events)
 
@@ -214,7 +214,7 @@ describe('query endpoint "events"', () => {
         }
       `,
       client,
-      data: { events: { nodes: events.slice(0, 100).map(getTypenameAndId) } },
+      data: { events: { nodes: events.slice(0, 300).map(getTypenameAndId) } },
     })
   })
 })

--- a/packages/server/src/schema/notification/resolvers.ts
+++ b/packages/server/src/schema/notification/resolvers.ts
@@ -151,7 +151,6 @@ export async function resolveEvents({
   return resolveConnection({
     nodes: events,
     payload,
-    limit: 300,
     createCursor(node) {
       return node.id.toString()
     },

--- a/packages/server/src/schema/notification/resolvers.ts
+++ b/packages/server/src/schema/notification/resolvers.ts
@@ -151,7 +151,7 @@ export async function resolveEvents({
   return resolveConnection({
     nodes: events,
     payload,
-    limit: 100,
+    limit: 300,
     createCursor(node) {
       return node.id.toString()
     },


### PR DESCRIPTION
Follow up of https://github.com/serlo/api.serlo.org/issues/430#issuecomment-874935661: First I wanted to set the limit to 300 but then I thought: The limit of the API should be higher than the limit for the frontend is reasonable. Thus I end up with 500.