### PR TITLE
Extend filter "objectId" to "entityId" and "repositoryId"

### DIFF
--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -47,6 +47,7 @@ import {
   assertSuccessfulGraphQLQuery,
   createDatabaseLayerHandler,
   createUuidHandler,
+  getTypenameAndId,
 } from '../__utils__'
 import { Service } from '~/internals/authentication'
 import { Model } from '~/internals/graphql'
@@ -330,10 +331,6 @@ function setupEvents(
       },
     })
   )
-}
-
-function getTypenameAndId(event: Model<'AbstractNotificationEvent'>) {
-  return R.pick(['__typename', 'id'], event)
 }
 
 function assignSequentialIds(events: Model<'AbstractNotificationEvent'>[]) {

--- a/__tests__/schema/events.ts
+++ b/__tests__/schema/events.ts
@@ -173,10 +173,7 @@ describe('query endpoint "events"', () => {
 
   test('with filter "objectId"', async () => {
     const events = assignSequentialIds(
-      R.concat(
-        allEvents.map(R.assoc('objectId', 42)),
-        allEvents.map(R.assoc('objectId', 23))
-      )
+      R.concat(getEventsForObject(42), getEventsForObject(23))
     )
     setupEvents(events)
 
@@ -195,7 +192,7 @@ describe('query endpoint "events"', () => {
       data: {
         events: {
           nodes: R.reverse(
-            events.slice(0, allEvents.length).map(getTypenameAndId)
+            events.slice(0, events.length / 2).map(getTypenameAndId)
           ),
         },
       },
@@ -269,14 +266,12 @@ test('User.eventsByUser returns events of this user', async () => {
 })
 
 test('AbstractEntity.events returns events for this entity', async () => {
+  const uuid = { ...article, id: 42 }
   const events = assignSequentialIds(
-    R.concat(
-      allEvents.map(R.assoc('objectId', article.id)),
-      allEvents.map(R.assoc('objectId', article.id + 1))
-    )
+    R.concat(getEventsForObject(uuid.id), getEventsForObject(uuid.id + 1))
   )
   setupEvents(events)
-  global.server.use(createUuidHandler(article))
+  global.server.use(createUuidHandler(uuid))
 
   await assertSuccessfulGraphQLQuery({
     query: gql`
@@ -293,13 +288,13 @@ test('AbstractEntity.events returns events for this entity', async () => {
         }
       }
     `,
-    variables: { id: article.id },
+    variables: { id: uuid.id },
     client,
     data: {
       uuid: {
         events: {
           nodes: R.reverse(
-            events.slice(0, allEvents.length).map(getTypenameAndId)
+            events.slice(0, events.length / 2).map(getTypenameAndId)
           ),
         },
       },
@@ -343,4 +338,14 @@ function getTypenameAndId(event: Model<'AbstractNotificationEvent'>) {
 
 function assignSequentialIds(events: Model<'AbstractNotificationEvent'>[]) {
   return events.map((event, id) => R.assoc('id', id + 1, event))
+}
+
+function getEventsForObject(objectId: number) {
+  return [
+    ...allEvents.map(R.assoc('objectId', objectId)),
+    ...allEvents.filter(R.has('entityId')).map(R.assoc('entityId', objectId)),
+    ...allEvents
+      .filter(R.has('repositoryId'))
+      .map(R.assoc('repositoryId', objectId)),
+  ]
 }

--- a/packages/server/src/schema/notification/resolvers.ts
+++ b/packages/server/src/schema/notification/resolvers.ts
@@ -21,6 +21,7 @@
  */
 import * as auth from '@serlo/authorization'
 import { ForbiddenError } from 'apollo-server'
+import * as R from 'ramda'
 
 import {
   assertUserIsAuthenticated,
@@ -142,7 +143,12 @@ export async function resolveEvents({
       return false
     if (isDefined(payload.instance) && payload.instance !== event.instance)
       return false
-    if (isDefined(payload.objectId) && payload.objectId !== event.objectId)
+    if (
+      isDefined(payload.objectId) &&
+      payload.objectId !== event.objectId &&
+      (!R.has('entityId', event) || payload.objectId !== event.entityId) &&
+      (!R.has('repositoryId', event) || payload.objectId !== event.repositoryId)
+    )
       return false
 
     return true


### PR DESCRIPTION
Before "objectId" only filtered events which are directly connected to
the uuid. However for example a CheckoutRevision is not included into
the filter for an entity since it's main target uuid is the revision and
not the entity. This quickfix extended the filter to "entityId" and
"repositoryId" as well. However this will only be a short fix since we
want to pass the filter to the database layer anyway.