### PR TITLE
Fetch a cache value only once and not twice

### DIFF
--- a/packages/server/src/internals/data-source-helper/query.ts
+++ b/packages/server/src/internals/data-source-helper/query.ts
@@ -63,7 +63,7 @@ export function createQuery<P, R>(
           spec.swrFrequency === undefined ||
           Math.random() < spec.swrFrequency
         ) {
-          await environment.swrQueue.queue({ key })
+          await environment.swrQueue.queue({ key, cacheEntry: cacheValue })
         }
 
         return decodedCacheValue.right as S


### PR DESCRIPTION
Before a cache was fetched twice: 1x for initial fetch and 2x for
checking whether it need to go to SWR queue. This PR removes one of this
fetch so that requests should be faster overall.