### PR TITLE
SWR: Increase maxAge

### DIFF
--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -108,7 +108,7 @@ export function createSerloModel({
           ? uuid
           : null
       },
-      maxAge: { hour: 1 },
+      maxAge: { day: 1 },
       getKey: ({ id }) => {
         return `de.serlo.org/api/uuid/${id}`
       },
@@ -402,7 +402,6 @@ export function createSerloModel({
         }),
         t.null,
       ]),
-      enableSwr: true,
       getCurrentValue: ({
         path,
         instance,
@@ -418,7 +417,8 @@ export function createSerloModel({
           expectedStatusCodes: [200, 404],
         })
       },
-      maxAge: { hour: 1 },
+      enableSwr: true,
+      maxAge: { day: 1 },
       getKey: ({ path, instance }) => {
         const cleanPath = encodePath(decodePath(path))
         return `${instance}.serlo.org/api/alias${cleanPath}`
@@ -765,7 +765,7 @@ export function createSerloModel({
         })
       },
       enableSwr: true,
-      maxAge: { hour: 1 },
+      maxAge: { day: 1 },
       getKey: ({ id }) => {
         return `de.serlo.org/api/threads/${id}`
       },


### PR DESCRIPTION
The current SWR-Queue is too big (~ 15.000 elements) so that updates cannot be run directly. This makes problems. For example the events have not been updated for a week. A short SWR queue is also necessary for implementing https://github.com/serlo/serlo.org/issues/660 Thus by increasing the stale time this should help in this issue (for an entitiy it should be fine to update it once
in a day)