### PR TITLE
createQuery: Add setting to ignore cached value when it is too old

### DIFF
--- a/__tests__/__utils__/test-client.ts
+++ b/__tests__/__utils__/test-client.ts
@@ -26,6 +26,7 @@ import {
 } from 'apollo-server-testing'
 
 import { Service } from '~/internals/authentication'
+import { Environment } from '~/internals/environment'
 import { Context } from '~/internals/graphql'
 import { getGraphQLOptions } from '~/internals/server'
 import { emptySwrQueue } from '~/internals/swr-queue'
@@ -36,10 +37,7 @@ export function createTestClient(
   args?: Partial<Pick<Context, 'service' | 'userId'>>
 ): Client {
   const server = new ApolloServer({
-    ...getGraphQLOptions({
-      cache: global.cache,
-      swrQueue: emptySwrQueue,
-    }),
+    ...getGraphQLOptions(createTestEnvironment()),
     context(): Pick<Context, 'service' | 'userId'> {
       return {
         service: args?.service ?? Service.SerloCloudflareWorker,
@@ -48,4 +46,8 @@ export function createTestClient(
     },
   })
   return createApolloTestClient(server)
+}
+
+export function createTestEnvironment(): Environment {
+  return { cache: global.cache, swrQueue: emptySwrQueue }
 }

--- a/__tests__/examples/data-sources/how-to-create-a-mutation.ts
+++ b/__tests__/examples/data-sources/how-to-create-a-mutation.ts
@@ -36,16 +36,12 @@ describe('How to create a mutation in a data source: update the content of an ar
   // contents are indexed by the article's id.
   let contentDatabase: Record<number, string | undefined>
 
-  // This object simulates our dataSources object. It contains the data source
-  // `database` which has the only function `updateContent`. This function is
-  // a mutation which accepts two arguments (the `id` of the article and the
-  // new content `newContent`), makes the mutation and returns an object containing
-  // the success of the operation in the property `success`.
+  // This object simulates our `dataSources` object. It contains the data source
+  // `database` which has the only function `updateContent`.
   let dataSources: {
     database: {
-      // `Mutation<P, R>` is the type a mutation in the data source has. `P`
-      // defines the arguments to the mutation and `R` the result of the
-      // operation.
+      // `Mutation<P, R>` is the type a mutation has. `P` defines the arguments
+      // to the mutation and `R` the result of the operation.
       updateContent: Mutation<
         { id: number; newContent: string },
         { success: boolean }
@@ -96,14 +92,11 @@ describe('How to create a mutation in a data source: update the content of an ar
         updateContent: createMutation({
           // Since the return type shall be `{ success: boolean }` we add
           // an io-ts decoder for this type. This is used during runtime to
-          // check the returned value. So we can notice when the called API
-          // does something weired.
+          // check the returned value.
           decoder: t.strict({ success: t.boolean }),
 
           // Function which does the actual mutation. Since we will need to wait
-          // until the fetch completes we use "async" here + "await" in the
-          // function body. The type `{ id: number, newContent: string }`
-          // defines the arguments for this function.
+          // until the fetch completes we use "async" + "await" here.
           async mutate({ id, newContent }: { id: number; newContent: string }) {
             // Call to the API of the database to update the content of the
             // article. We use "await" to wait until the fetch completes.
@@ -129,8 +122,8 @@ describe('How to create a mutation in a data source: update the content of an ar
     }
   })
 
-  // How the created mutation can be used
-  // ====================================
+  // # How the created mutation can be used
+
   describe('calling the created mutation will execute the mutation', () => {
     test('case when the article exists (mutation was successfull)', async () => {
       // We call the mutation function to update an article (here we use "await"

--- a/__tests__/examples/data-sources/how-to-create-a-query.ts
+++ b/__tests__/examples/data-sources/how-to-create-a-query.ts
@@ -1,0 +1,168 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020-2021 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020-2021 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+import { option as O } from 'fp-ts'
+import * as t from 'io-ts'
+import { rest } from 'msw'
+import fetch from 'node-fetch'
+
+import { createTestEnvironment } from '../../__utils__'
+import { createQuery, Query } from '~/internals/data-source-helper/query'
+
+describe('How to create a query in a data source: Fetching the content of an article', () => {
+  // # Prerequisites
+
+  // Lets assume we want to fetch the content of an article. The following
+  // object simulates a database whereby the article's
+  // contents are indexed by the article's id.
+  let contentDatabase: Record<number, string | undefined>
+
+  // This object simulates our dataSources object. It contains the data source
+  // `database` which has the only function `getContent`.
+  let dataSources: {
+    database: {
+      // `Query<P, R>` is the type a query in the data source has. `P`
+      // defines the arguments to the query and `R` the result of the
+      // operation. So `getContent()` receives a dictionary with the article's
+      // id. It returns a dictionary with the article's id and content or `null`
+      // when the article does not exist.
+      getContent: Query<{ id: number }, { id: number; content: string } | null>
+    }
+  }
+
+  beforeEach(async () => {
+    // Some initial values for the database
+    contentDatabase = {
+      [42]: 'Hello world!',
+      [100]: 'This is another article.',
+    }
+
+    // REST API in front of the database which exposes a GET endpoint
+    // /article/:id with which the content of an article can be fetched.
+    global.server.use(
+      rest.get<never, { id: number; content: string }, { id: string }>(
+        'http://database-api.serlo.org/article/:id',
+        (req, res, ctx) => {
+          const id = parseInt(req.params.id)
+
+          // given id is not a number -> return with "400 Bad Request"
+          if (Number.isNaN(id)) return res(ctx.status(400))
+
+          const content = contentDatabase[id]
+
+          if (content !== undefined) {
+            // article with given id is in database
+            return res(ctx.json({ id, content }))
+          } else {
+            // No article found -> return "404 Not Found"
+            return res(ctx.status(404))
+          }
+        }
+      )
+    )
+
+    // We assume that the cache is empty in each of the following test cases
+    await global.cache.remove({ key: 'article/42' })
+
+    dataSources = {
+      database: {
+        // # The actual code to create the query
+
+        // Here we create the query with the helper function
+        // `createQuery()`
+        getContent: createQuery(
+          {
+            // Here we add an io-ts decoder for the returned value. It is used
+            // during runtime to check the returned value. So we can notice when
+            // the called API does something weired.
+            decoder: t.union([
+              t.strict({ id: t.number, content: t.string }),
+              t.null,
+            ]),
+
+            // Function which does the actual fetching. Since we will need to wait
+            // until the fetch completes we use "async" + "await" here.
+            async getCurrentValue({ id }: { id: number }) {
+              const url = `http://database-api.serlo.org/article/${id}`
+              const res = await fetch(url)
+
+              return res.status === 404 ? null : ((await res.json()) as unknown)
+            },
+
+            // We want to enable SWR for this endpoint
+            enableSwr: true,
+
+            // After one hour an cached value shall be considered to be stale
+            staleAfter: { hour: 1 },
+
+            // After one day no cached value shall be used
+            maxAge: { day: 1 },
+
+            getKey({ id }) {
+              return `article/${id}`
+            },
+
+            getPayload(key) {
+              if (!key.startsWith('article/')) return O.none
+
+              const id = parseInt(key.substring('article/'.length))
+
+              return Number.isNaN(id) ? O.none : O.some({ id })
+            },
+          },
+          // In the actual code you will pass the `environment` variable here
+          createTestEnvironment()
+        ),
+      },
+    }
+  })
+
+  // # How the created query can be used
+
+  test('calling the query function will execute a query in the data source', async () => {
+    const result = await dataSources.database.getContent({ id: 42 })
+
+    expect(result).toEqual({ id: 42, content: 'Hello world!' })
+  })
+
+  test('the result of the query function is cached', async () => {
+    // First call which fills the cache
+    await dataSources.database.getContent({ id: 42 })
+
+    // An assumed change in the original database
+    contentDatabase[42] = 'New content'
+
+    // The cached value of the first execution is returned
+    const result = await dataSources.database.getContent({ id: 42 })
+
+    expect(result).toEqual({ id: 42, content: 'Hello world!' })
+  })
+
+  test('cached value is ignored when it is older than `maxAge`', async () => {
+    await dataSources.database.getContent({ id: 42 })
+    contentDatabase[42] = 'New content'
+    await global.timer.waitFor({ days: 2 })
+
+    const result = await dataSources.database.getContent({ id: 42 })
+
+    expect(result).toEqual({ id: 42, content: 'New content' })
+  })
+})

--- a/packages/server/src/internals/data-source-helper/query.ts
+++ b/packages/server/src/internals/data-source-helper/query.ts
@@ -43,7 +43,10 @@ export function createQuery<P, R>(
     customDecoder?: t.Type<S>
   ): Promise<S> {
     const key = spec.getKey(payload)
-    const cacheValue = await environment.cache.get<R>({ key })
+    const cacheValue = await environment.cache.get<R>({
+      key,
+      maxAge: spec.maxAge,
+    })
 
     const decoder = customDecoder ?? t.unknown
 
@@ -188,7 +191,13 @@ export interface QuerySpec<Payload, Result> {
   /**
    * Age after which a value is considered to be stale in the SWR algorithm.
    */
-  maxAge: Time | undefined
+  staleAfter?: Time
+
+  /**
+   * Time after which the cached value is considered to be so old that it will
+   * be updated directly
+   */
+  maxAge?: Time
 
   /**
    * Function which calculates the cache key based on the passed payload. It is

--- a/packages/server/src/internals/swr-queue.ts
+++ b/packages/server/src/internals/swr-queue.ts
@@ -297,10 +297,12 @@ async function shouldProcessJob({
   if (!spec.enableSwr) {
     return E.left('SWR disabled.')
   }
-  const maxAge =
-    spec.maxAge === undefined ? undefined : timeToMilliseconds(spec.maxAge)
+  const staleAfter =
+    spec.staleAfter === undefined
+      ? undefined
+      : timeToMilliseconds(spec.staleAfter)
   const age = timer.now() - cacheEntry.value.lastModified
-  if (maxAge === undefined || age <= maxAge) {
+  if (staleAfter === undefined || age <= staleAfter) {
     return E.left('cache non-stale.')
   }
   const payload = spec.getPayload(key)

--- a/packages/server/src/internals/timer.ts
+++ b/packages/server/src/internals/timer.ts
@@ -19,10 +19,6 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
-
-/**
- *
- */
 export interface Timer {
   now: typeof Date.now
 }

--- a/packages/server/src/model/chat.ts
+++ b/packages/server/src/model/chat.ts
@@ -32,7 +32,7 @@ export function createChatModel({ environment }: { environment: Environment }) {
     {
       decoder: t.strict({ success: t.boolean }),
       enableSwr: true,
-      maxAge: { hour: 3 },
+      staleAfter: { hour: 3 },
       getCurrentValue: async ({ username }: { username: string }) => {
         return await fetchChatApi({
           endpoint: 'users.info',

--- a/packages/server/src/model/google-spreadsheet-api.ts
+++ b/packages/server/src/model/google-spreadsheet-api.ts
@@ -104,7 +104,7 @@ export function createGoogleSpreadsheetApiModel({
           return specifyErrorLocation(E.left({ error: E.toError(error) }))
         }
       },
-      maxAge: { hour: 1 },
+      staleAfter: { hour: 1 },
       getKey: (args) => {
         const { spreadsheetId, range } = args
         const majorDimension = args.majorDimension ?? MajorDimension.Rows

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -108,7 +108,7 @@ export function createSerloModel({
           ? uuid
           : null
       },
-      maxAge: { day: 1 },
+      staleAfter: { day: 1 },
       getKey: ({ id }) => {
         return `de.serlo.org/api/uuid/${id}`
       },
@@ -170,7 +170,7 @@ export function createSerloModel({
         })
         return (await response.json()) as number[]
       },
-      maxAge: { hour: 1 },
+      staleAfter: { hour: 1 },
       getKey: () => {
         return 'de.serlo.org/api/user/active-authors'
       },
@@ -195,7 +195,7 @@ export function createSerloModel({
         })
         return (await response.json()) as number[]
       },
-      maxAge: { hour: 1 },
+      staleAfter: { hour: 1 },
       getKey: () => {
         return 'de.serlo.org/api/user/active-reviewers'
       },
@@ -222,7 +222,7 @@ export function createSerloModel({
           expectedStatusCodes: [200],
         })
       },
-      maxAge: { minutes: 10 },
+      staleAfter: { minutes: 10 },
       getKey: ({ userId }) => {
         return `de.serlo.org/api/user/activity-by-type/${userId}`
       },
@@ -307,7 +307,7 @@ export function createSerloModel({
           expectedStatusCodes: [200],
         })
       },
-      maxAge: { hour: 1 },
+      staleAfter: { hour: 1 },
       getKey: ({ instance }) => {
         return `${instance}.serlo.org/api/navigation`
       },
@@ -418,7 +418,7 @@ export function createSerloModel({
         })
       },
       enableSwr: true,
-      maxAge: { day: 1 },
+      staleAfter: { day: 1 },
       getKey: ({ path, instance }) => {
         const cleanPath = encodePath(decodePath(path))
         return `${instance}.serlo.org/api/alias${cleanPath}`
@@ -456,7 +456,7 @@ export function createSerloModel({
         })
       },
       enableSwr: true,
-      maxAge: { day: 1 },
+      staleAfter: { day: 1 },
       getKey: ({ id }) => `de.serlo.org/api/license/${id}`,
       getPayload: (key) => {
         const prefix = 'de.serlo.org/api/license/'
@@ -482,7 +482,7 @@ export function createSerloModel({
         })
       },
       enableSwr: true,
-      maxAge: { day: 1 },
+      staleAfter: { day: 1 },
       getKey() {
         return 'serlo.org/subjects'
       },
@@ -524,7 +524,8 @@ export function createSerloModel({
         return result
       },
       enableSwr: true,
-      maxAge: { minutes: 2 },
+      staleAfter: { minutes: 2 },
+      maxAge: { hour: 1 },
       getKey() {
         return 'serlo.org/unrevised'
       },
@@ -550,7 +551,7 @@ export function createSerloModel({
           ? null
           : notificationEvent
       },
-      maxAge: { day: 1 },
+      staleAfter: { day: 1 },
       getKey: ({ id }) => {
         return `de.serlo.org/api/event/${id}`
       },
@@ -622,7 +623,8 @@ export function createSerloModel({
         }
       },
       enableSwr: true,
-      maxAge: { minute: 2 },
+      staleAfter: { minute: 2 },
+      maxAge: { hour: 1 },
     },
     environment
   )
@@ -647,7 +649,7 @@ export function createSerloModel({
           expectedStatusCodes: [200],
         })
       },
-      maxAge: { hour: 1 },
+      staleAfter: { hour: 1 },
       getKey: ({ userId }) => {
         return `de.serlo.org/api/notifications/${userId}`
       },
@@ -701,7 +703,7 @@ export function createSerloModel({
           expectedStatusCodes: [200],
         })
       },
-      maxAge: { hour: 1 },
+      staleAfter: { hour: 1 },
       getKey: ({ userId }) => {
         return `de.serlo.org/api/subscriptions/${userId}`
       },
@@ -765,7 +767,7 @@ export function createSerloModel({
         })
       },
       enableSwr: true,
-      maxAge: { day: 1 },
+      staleAfter: { day: 1 },
       getKey: ({ id }) => {
         return `de.serlo.org/api/threads/${id}`
       },


### PR DESCRIPTION
This should solve the issue with the events not being updated regularly. (see Slack messages)