### PR TITLE
Refactorings in ~/model/serlo.ts

### DIFF
--- a/__tests-pacts__/serlo.org-database-layer/uuid/comment.ts
+++ b/__tests-pacts__/serlo.org-database-layer/uuid/comment.ts
@@ -39,6 +39,6 @@ test('Comment', async () => {
     parentId: Matchers.integer(comment.parentId),
     childrenIds: comment.childrenIds,
   })
-  const response = await global.serloModel.getUuid(comment)
+  const response = await global.serloModel.getUuid({ id: comment.id })
   expect(response).toEqual(comment)
 })

--- a/packages/server/src/schema/thread/resolvers.ts
+++ b/packages/server/src/schema/thread/resolvers.ts
@@ -172,8 +172,8 @@ export const resolvers: InterfaceResolvers<'ThreadAware'> &
       return { success: true, query: {} }
     },
     async setThreadState(_parent, payload, { dataSources, userId }) {
-      const { id, trashed } = payload.input
-      const ids = decodeThreadIds(id)
+      const { trashed } = payload.input
+      const ids = decodeThreadIds(payload.input.id)
 
       const scopes = await Promise.all(
         ids.map((id) => fetchScopeOfUuid({ id, dataSources }))
@@ -188,19 +188,12 @@ export const resolvers: InterfaceResolvers<'ThreadAware'> &
         dataSources,
       })
 
-      await dataSources.model.serlo.setUuidState({
-        ids,
-        userId,
-        trashed,
-      })
-      return {
-        success: true,
-        query: {},
-      }
+      await dataSources.model.serlo.setUuidState({ ids, userId, trashed })
+
+      return { success: true, query: {} }
     },
     async setCommentState(_parent, payload, { dataSources, userId }) {
-      const { id, trashed } = payload.input
-      const ids = id
+      const { id: ids, trashed } = payload.input
 
       const scopes = await Promise.all(
         ids.map((id) => fetchScopeOfUuid({ id, dataSources }))
@@ -215,15 +208,9 @@ export const resolvers: InterfaceResolvers<'ThreadAware'> &
         dataSources,
       })
 
-      await dataSources.model.serlo.setUuidState({
-        ids: ids,
-        trashed,
-        userId,
-      })
-      return {
-        success: true,
-        query: {},
-      }
+      await dataSources.model.serlo.setUuidState({ ids, trashed, userId })
+
+      return { success: true, query: {} }
     },
   },
 }

--- a/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
@@ -20,7 +20,6 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import * as serloAuth from '@serlo/authorization'
-import { UserInputError } from 'apollo-server'
 
 import {
   assertUserIsAuthenticated,
@@ -63,17 +62,13 @@ export const resolvers: InterfaceResolvers<'AbstractEntity'> &
         guard: serloAuth.Entity.checkoutRevision(scope),
       })
 
-      const result = await dataSources.model.serlo.checkoutEntityRevision({
+      await dataSources.model.serlo.checkoutEntityRevision({
         revisionId: castToUuid(input.revisionId),
         reason: input.reason,
         userId,
       })
 
-      if (result.success === false) {
-        throw new UserInputError(result.reason)
-      } else {
-        return { ...result, query: {} }
-      }
+      return { success: true, query: {} }
     },
     async rejectRevision(_parent, { input }, { dataSources, userId }) {
       assertUserIsAuthenticated(userId)
@@ -89,16 +84,9 @@ export const resolvers: InterfaceResolvers<'AbstractEntity'> &
         guard: serloAuth.Entity.rejectRevision(scope),
       })
 
-      const result = await dataSources.model.serlo.rejectEntityRevision({
-        ...input,
-        userId,
-      })
+      await dataSources.model.serlo.rejectEntityRevision({ ...input, userId })
 
-      if (result.success === false) {
-        throw new UserInputError(result.reason)
-      } else {
-        return { ...result, query: {} }
-      }
+      return { success: true, query: {} }
     },
   },
 }

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -99,12 +99,10 @@ export const resolvers: InterfaceResolvers<'AbstractUuid'> &
               case DiscriminatorType.User:
                 return 'User'
               default:
-                if (E.isRight(EntityTypeDecoder.decode(object.__typename))) {
+                if (EntityTypeDecoder.is(object.__typename)) {
                   return 'Entity'
                 }
-                if (
-                  E.isRight(EntityRevisionTypeDecoder.decode(object.__typename))
-                ) {
+                if (EntityRevisionTypeDecoder.is(object.__typename)) {
                   return 'EntityRevision'
                 }
                 return 'unknown'
@@ -122,15 +120,8 @@ export const resolvers: InterfaceResolvers<'AbstractUuid'> &
         dataSources,
       })
 
-      const result = await dataSources.model.serlo.setUuidState({
-        ids,
-        userId,
-        trashed,
-      })
+      await dataSources.model.serlo.setUuidState({ ids, userId, trashed })
 
-      if (result !== undefined) {
-        throw new UserInputError(result.reason)
-      }
       return { success: true, query: {} }
     },
   },

--- a/packages/server/src/schema/uuid/page/resolvers.ts
+++ b/packages/server/src/schema/uuid/page/resolvers.ts
@@ -20,7 +20,6 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 import * as serloAuth from '@serlo/authorization'
-import { UserInputError } from 'apollo-server'
 
 import {
   assertUserIsAuthenticated,
@@ -69,17 +68,13 @@ export const resolvers: TypeResolvers<Page> &
         guard: serloAuth.Page.checkoutRevision(scope),
       })
 
-      const result = await dataSources.model.serlo.checkoutPageRevision({
+      await dataSources.model.serlo.checkoutPageRevision({
         revisionId: castToUuid(input.revisionId),
         reason: input.reason,
         userId,
       })
 
-      if (result.success === false) {
-        throw new UserInputError(result.reason)
-      } else {
-        return { ...result, query: {} }
-      }
+      return { success: true, query: {} }
     },
     async rejectRevision(_parent, { input }, { dataSources, userId }) {
       assertUserIsAuthenticated(userId)
@@ -95,16 +90,9 @@ export const resolvers: TypeResolvers<Page> &
         guard: serloAuth.Page.rejectRevision(scope),
       })
 
-      const result = await dataSources.model.serlo.rejectPageRevision({
-        ...input,
-        userId,
-      })
+      await dataSources.model.serlo.rejectPageRevision({ ...input, userId })
 
-      if (result.success === false) {
-        throw new UserInputError(result.reason)
-      } else {
-        return { ...result, query: {} }
-      }
+      return { success: true, query: {} }
     },
   },
 }

--- a/packages/server/src/schema/uuid/user/resolvers.ts
+++ b/packages/server/src/schema/uuid/user/resolvers.ts
@@ -262,11 +262,7 @@ export const resolvers: LegacyQueries<
 
       const result = await dataSources.model.serlo.setEmail(input)
 
-      if (result.success) {
-        return { ...result, email: input.email }
-      } else {
-        throw new UserInputError(result.reason)
-      }
+      return { ...result, email: input.email }
     },
   },
 }


### PR DESCRIPTION
* Move handling of 400er reponse with `{ reason: "..." }` as body into handleMessage()
* Remove `expectedStatusCodes` (after the first item this is not necessary since we only allow 200er and 404er responses)