### PR TITLE
Update cache after successful UserSetDescriptionMutation

### DIFF
--- a/__tests__/schema/user/set-description.ts
+++ b/__tests__/schema/user/set-description.ts
@@ -46,7 +46,9 @@ test('returns "{ success: true }" when mutation could be successfully executed',
     .withPayload({ userId: user.id, description: 'description' })
     .returns({ success: true })
 
-  await mutation.shouldReturnData({ user: { setDescription: { success: true } } })
+  await mutation.shouldReturnData({
+    user: { setDescription: { success: true } },
+  })
 })
 
 test('fails when user is not authenticated', async () => {
@@ -80,6 +82,10 @@ test('updates the cache', async () => {
   })
 
   await query.shouldReturnData({ uuid: { description: null } })
+
+  given('UserSetDescriptionMutation')
+    .withPayload({ userId: user.id, description: 'description' })
+    .returns({ success: true })
 
   await mutation.execute()
 

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -221,7 +221,7 @@ export function createSerloModel({
     mutate: (payload: DatabaseLayer.Payload<'UserSetDescriptionMutation'>) => {
       return DatabaseLayer.makeRequest('UserSetDescriptionMutation', payload)
     },
-    updateCache: async({ userId, description }, { success }) => {
+    updateCache: async ({ userId, description }, { success }) => {
       if (success) {
         await getUuid._querySpec.setCache({
           payload: { id: userId },

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -221,6 +221,18 @@ export function createSerloModel({
     mutate: (payload: DatabaseLayer.Payload<'UserSetDescriptionMutation'>) => {
       return DatabaseLayer.makeRequest('UserSetDescriptionMutation', payload)
     },
+    updateCache: async({ userId, description }, { success }) => {
+      if (success) {
+        await getUuid._querySpec.setCache({
+          payload: { id: userId },
+          getValue(current) {
+            if (!current) return
+
+            return { ...current, description: description }
+          },
+        })
+      }
+    },
   })
 
   const setEmail = createMutation({


### PR DESCRIPTION
The next fix would be to update cache ﻿after setting email. But how can we test it?

By the way, @inyono, the problem was at 
` if (!UserDecoder.is(current)) return`
that was returning to early and so not updating the cache. 