### PR TITLE
License data in ~/config

### DIFF
--- a/__fixtures__/license.ts
+++ b/__fixtures__/license.ts
@@ -20,16 +20,6 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 
-import { Model } from '~/internals/graphql'
-import { Instance } from '~/types'
+import { licenses } from '~/config'
 
-export const license: Model<'License'> = {
-  id: 1,
-  instance: Instance.De,
-  default: true,
-  title: 'title',
-  url: 'url',
-  content: 'content',
-  agreement: 'agreement',
-  iconHref: 'iconHref',
-}
+export const license = licenses[0]

--- a/__tests-pacts__/index.ts
+++ b/__tests-pacts__/index.ts
@@ -55,7 +55,6 @@ import {
   exerciseRevision,
   groupedExercise,
   groupedExerciseRevision,
-  license,
   page,
   pageRevision,
   solution,
@@ -271,10 +270,6 @@ const pactSpec: PactSpec = {
         { events: [abstractEvent], hasNextPage: true },
       ],
     ],
-  },
-  LicenseQuery: {
-    examples: [[{ id: 1 }, license]],
-    examplePayloadForNull: { id: 100 },
   },
   NavigationQuery: {
     examples: [

--- a/__tests__/schema/license.ts
+++ b/__tests__/schema/license.ts
@@ -22,7 +22,7 @@
 import { gql } from 'apollo-server'
 
 import { license } from '../../__fixtures__'
-import { Client, given } from '../__utils__'
+import { Client } from '../__utils__'
 
 const query = new Client().prepareQuery({
   query: gql`
@@ -43,14 +43,10 @@ const query = new Client().prepareQuery({
 
 describe('query "license"', () => {
   test('returns a license', async () => {
-    given('LicenseQuery').withPayload({ id: license.id }).returns(license)
-
     await query.withVariables({ id: license.id }).shouldReturnData({ license })
   })
 
   test('returns null when license with given id does not exist', async () => {
-    given('LicenseQuery').returnsNotFound()
-
     await query.withVariables({ id: 100 }).shouldReturnData({ license: null })
   })
 })

--- a/__tests__/schema/uuid/abstract-repository.ts
+++ b/__tests__/schema/uuid/abstract-repository.ts
@@ -275,7 +275,6 @@ describe('Repository', () => {
   test.each(repositoryCases)(
     '%s by id (w/ license)',
     async (_type, { repository }) => {
-      given('LicenseQuery').withPayload({ id: license.id }).returns(license)
       global.server.use(createUuidHandler(repository))
 
       await assertSuccessfulGraphQLQuery({

--- a/__tests__/schema/uuid/page.ts
+++ b/__tests__/schema/uuid/page.ts
@@ -26,7 +26,6 @@ import { page, pageRevision, license } from '../../../__fixtures__'
 import {
   assertSuccessfulGraphQLQuery,
   LegacyClient,
-  given,
   createTestClient,
   createUuidHandler,
 } from '../../__utils__'
@@ -66,7 +65,6 @@ describe('Page', () => {
   })
 
   test('by id (w/ license)', async () => {
-    given('LicenseQuery').withPayload({ id: license.id }).returns(license)
     await assertSuccessfulGraphQLQuery({
       query: gql`
         query page($id: Int!) {

--- a/packages/server/src/config/index.ts
+++ b/packages/server/src/config/index.ts
@@ -21,3 +21,4 @@
  */
 export * from './alias'
 export * from './autoreview-taxonomies'
+export * from './licenses'

--- a/packages/server/src/config/licenses.ts
+++ b/packages/server/src/config/licenses.ts
@@ -1,0 +1,214 @@
+/**
+ * This file is part of Serlo.org API
+ *
+ * Copyright (c) 2020-2022 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020-2022 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
+ */
+
+import { License } from '~/types'
+
+export const licenses = <License[]>[
+  {
+    id: 1,
+    instance: 'de',
+    default: true,
+    title: 'Dieses Werk steht unter der freien Lizenz CC BY-SA 4.0.',
+    url: 'https://creativecommons.org/licenses/by-sa/4.0/deed.de',
+    content:
+      '[[{"col":24,"content":"**Sie dürfen** das Lernmaterial beliebig **kopieren, vervielfältigen, bearbeiten** und darauf aufbauen - und zwar für beliebige Zwecke, sogar kommerziell. Dies gilt unter folgenden Bedingungen:\\n\\n### Wenn Sie **keine Veränderungen** vornehmen:\\n\\n* Sie müssen Serlo als Urheber nennen \\"Quelle: serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY-SA 4.0\\", in digitaler Form als Link zu dieser Seite: https://creativecommons.org/licenses/by-sa/4.0/\\n\\n/// Beispiel\\nWenn Sie einen Artikel von Serlo für ihre Schüler*innen kopieren, dann müssen Sie folgenden Vermerk ergänzen: **\\"Quelle: serlo.org, Lizenz: CC BY-SA 4.0\\"**\\n///\\n\\n\\n### Wenn Sie **Veränderungen** vornehmen:\\n\\n* Sie müssen Serlo als Urheber nennen \\"Quelle: serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen knapp angeben, welche Änderungen Sie vorgenommen haben \\"Zahlen vereinfacht\\" oder \\"Bild zugeschnitten\\".\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY-SA 4.0\\", in digitaler Form als Link zu dieser Seite: https://creativecommons.org/licenses/by-sa/4.0/. Die Lizenz muss für das gesamte Werk angegeben werden, zu dem Inhalt von Serlo beigetragen hat.\\n\\n/// Beispiel\\n\\n#### Beispiel 1\\n\\nWenn Sie ein Bild von Serlo bearbeiten und es in Ihr Arbeitsblatt integrieren, dann müssen Sie folgenden Vermerk bei dem Bild ergänzen: **\\"Quelle: serlo.org, Veränderungen: ...\\"** und folgenden Vermerk für das ganze Arbeitsblatt: **Lizenz: CC BY-SA 4.0\\"**\\n\\n#### Beispiel 2\\n\\nWenn Sie einen Textbaustein von Serlo in einen Text von Ihnen integrieren, dann müssen Sie zu dem gesamten Text folgendes vermerken: **\\"Teilquelle: serlo.org, Lizenz: CC BY-SA 4.0\\"**\\n\\n///"}],[{"col":24,"content":"### Offizielle Lizenz\\n\\nDies ist eine allgemeinverständliche Zusammenfassung der [offiziellen Lizenz](https://creativecommons.org/licenses/by-sa/4.0/legalcode) und ersetzt diese nicht."}]]',
+    agreement:
+      'Mit dem Speichern dieser Seite versicherst du, dass du deinen Beitrag (damit sind auch Änderungen gemeint) selbst verfasst hast bzw. dass er keine fremden Rechte verletzt. Du willigst ein, deinen Beitrag unter der <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">Creative Commons Attribution/Share-Alike Lizenz 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.de) und/oder unter einer gleichwertigen Lizenz zu veröffentlichen, welche der Serlo Education e. V. entsprechend der Regelungen in den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) festlegen darf. Falls du den Beitrag nicht selbst verfasst hast, muss er unter den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) verfügbar sein und du stimmst zu, notwendigen Lizenzanforderungen zu folgen.',
+    iconHref: 'https://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+  {
+    id: 4,
+    instance: 'de',
+    default: false,
+    title:
+      'Dieses Werk steht unter der freien Lizenz CC BY-SA 4.0 mit Namensnennung von Herrn Rudolf Brinkmann',
+    url: 'https://123mathe.de',
+    content:
+      '[[{"col":24,"content":"Die Aufgabenstellung stammt von der Mathematik Lernseite [https://123mathe.de/](https://123mathe.de/) und wurde von Herrn Rudolf Brinkmann erstellt. Serlo dankt Frau Charlotte Brinkmann für die freundliche Genehmigung zur Veröffentlichung.\\n\\nDie Aufgabe steht unter der Lizenz **CC BY-SA 4.0**. Sie dürfen die Aufgabe beliebig kopieren, vervielfältigen, bearbeiten und weiterentwickeln - für verschiedene (auch kommerzielle) Zwecke. Dies gilt unter folgenden Bedingungen:\\n\\n### Wenn Sie **keine** Veränderungen vornehmen:\\n * Sie müssen 123mathe.de und Serlo als Urheber nennen \\"Quelle: 123mathe.de & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY-SA 4.0\\", in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/] (https://creativecommons.org/licenses/by-sa/4.0/)\\n\\n/// Beispiel\\nWenn Sie eine Aufgabe von Herrn Brinkmann auf Serlo für ihre Schüler/innen kopieren, dann müssen Sie folgenden Vermerk ergänzen:**\\"Quelle: 123mathe.de & serlo.org, Lizenz: CC BY-SA 4.0\\"**\\n///\\n\\n### Wenn Sie Veränderungen vornehmen:\\n* Sie müssen 123mathe.de und Serlo als Urheber nennen \\"Quelle: 123mathe.de & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen kurz erläutern, welche Änderungen sie vorgenommen haben, z.B. \\"Zahlen vereinfacht\\" oder \\"Bild zugeschnitten\\".\\n* Sie müssen die Lizenz \\"CC BY-SA 4.0\\" angeben, in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/).\\nDie Lizenz muss für das gesamte Werk angegeben werden, zu dem dieser Inhalt beigetragen hat.\\n/// Beispiel\\nWenn Sie eine Aufgabe von 123mathe.de & Serlo bearbeiten und es in Ihr Arbeitsblatt integrieren, dann müssen Sie folgenden Vermerk bei dem Bild ergänzen: **\\"Quelle: 123mathe.de & serlo.org, Veränderungen: …\\"** und folgenden Vermerk für die Aufgabe: Lizenz: **\\"CC BY-SA 4.0\\"**\\n\\n///\\n"}]]',
+    agreement:
+      'Mit dem Speichern dieser Seite versicherst du, dass du die Veränderung des Beitrags von Herrn Rudolf Brinkmann selbst verfasst hast bzw. dass er keine fremden Rechte verletzt. Du willigst ein, deinen Beitrag unter der <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">Creative Commons Attribution/Share-Alike Lizenz 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.de) und/oder unter einer gleichwertigen Lizenz zu veröffentlichen, welche der Serlo Education e. V. entsprechend der Regelungen in den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) festlegen darf. Der Beitrag von Herrn Rudolf Brinkmann muss unter den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) verfügbar sein und du stimmst zu, notwendigen Lizenzanforderungen zu folgen.',
+    iconHref: '',
+  },
+  {
+    id: 6,
+    instance: 'de',
+    default: false,
+    title:
+      'Dieses Werk steht unter der freien Lizenz CC BY-SA 4.0 mit Namensnennung von Herrn Franz Strobl. ',
+    url: 'http://www.strobl-f.de/',
+    content:
+      '[[{"col":24,"content":"\\n\\n\\nDie Aufgenstellung stammt von der Mathematik Lernseite [www.strobl-f.de](http://www.strobl-f.de) und wurde von Herrn Franz Strobl erstellt. Serlo dankt für die freundliche Genehmigung zur Veröffentlichung.\\n\\nDie Aufgabe steht unter der **Lizenz CC BY-SA 4.0.**\\n Sie dürfen die Aufgabe beliebig kopieren, vervielfältigen, bearbeiten und weiterentwickeln - für verschiedene (auch kommerzielle) Zwecke. Dies gilt unter folgenden Bedingungen:\\n\\n### Wenn Sie **keine** Veränderungen vornehmen:\\n\\n* Sie müssen Strobl und Serlo als Urheber nennen \\"Quelle: strobl-f.de & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY-SA 4.0\\", in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0)\\n\\n/// Beispiel\\nWenn Sie eine Aufgabe von Herrn Strobl auf Serlo für ihre Schüler*innen kopieren, dann müssen Sie folgenden Vermerk ergänzen: **\\"Quelle: strobl-f.de & serlo.org, Lizenz: CC BY-SA 4.0\\"**\\n///\\n\\n\\n### Wenn Sie Veränderungen vornehmen:\\n\\n* Sie müssen Strobl und Serlo als Urheber nennen \\"Quelle: strobl-f.de & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen kurz erläutern, welche Änderungen sie vorgenommen haben, z.B. \\"Zahlen vereinfacht\\" oder \\"Bild zugeschnitten\\".\\n* Sie müssen die Lizenz \\"CC BY-SA 4.0\\" angeben, in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0). Die Lizenz muss für das gesamte Werk angegeben werden, zu dem dieser Inhalt beigetragen hat.\\n\\n/// Beispiel\\n\\nWenn Sie eine Aufgabe von Raschweb & Serlo bearbeiten und es in Ihr Arbeitsblatt integrieren, dann müssen Sie folgenden Vermerk bei dem Bild ergänzen: **\\"Quelle: strobl-f.de & serlo.org, Veränderungen: ...\\"** und folgenden Vermerk für die Aufgabe: **Lizenz: CC BY-SA 4.0\\"**\\n\\n///\\n"}]]',
+    agreement:
+      'Mit dem Speichern dieser Seite versicherst du, dass du die Veränderung des Beitrags von Herrn Franz Strobl selbst verfasst hast bzw. dass er keine fremden Rechte verletzt. Du willigst ein, deinen Beitrag unter der <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">Creative Commons Attribution/Share-Alike Lizenz 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.de) und/oder unter einer gleichwertigen Lizenz zu veröffentlichen, welche der Serlo Education e. V. entsprechend der Regelungen in den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) festlegen darf. Der Beitrag von Herrn Franz Strobl muss unter den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) verfügbar sein und du stimmst zu, notwendigen Lizenzanforderungen zu folgen.\r\n',
+    iconHref: '',
+  },
+  {
+    id: 7,
+    instance: 'de',
+    default: false,
+    title:
+      'Dieses Werk steht unter der freien Lizenz CC BY-SA 4.0 mit Namensnennung von Herrn Günther Rasch',
+    url: 'http://www.raschweb.de/',
+    content:
+      '[[{"col":24,"content":"Die Aufgenstellung stammt von der Mathematik Lernseite [www.raschweb.de](http://www.raschweb.de/) und wurde von Herrn Günther Rasch erstellt. Serlo dankt für die freundliche Genehmigung zur Veröffentlichung.\\n\\nDie Aufgabe steht unter der **Lizenz CC BY-SA 4.0.**\\n Sie dürfen die Aufgabe beliebig kopieren, vervielfältigen, bearbeiten und weiterentwickeln - für verschiedene (auch kommerzielle) Zwecke. Dies gilt unter folgenden Bedingungen:\\n\\n### Wenn Sie **keine** Veränderungen vornehmen:\\n\\n* Sie müssen Raschweb und Serlo als Urheber nennen \\"Quelle: raschweb.de & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY-SA 4.0\\", in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0)\\n\\n/// Beispiel\\nWenn Sie eine Aufgabe von Herrn Rasch auf Serlo für ihre Schüler*innen kopieren, dann müssen Sie folgenden Vermerk ergänzen: **\\"Quelle: raschweb.de & serlo.org, Lizenz: CC BY-SA 4.0\\"**\\n///\\n\\n\\n### Wenn Sie Veränderungen vornehmen:\\n\\n* Sie müssen Raschweb und Serlo als Urheber nennen \\"Quelle: raschweb.de & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen kurz erläutern, welche Änderungen sie vorgenommen haben, z.B. \\"Zahlen vereinfacht\\" oder \\"Bild zugeschnitten\\".\\n* Sie müssen die Lizenz \\"CC BY-SA 4.0\\" angeben, in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0). Die Lizenz muss für das gesamte Werk angegeben werden, zu dem dieser Inhalt beigetragen hat.\\n\\n/// Beispiel\\n\\nWenn Sie eine Aufgabe von Raschweb & Serlo bearbeiten und es in Ihr Arbeitsblatt integrieren, dann müssen Sie folgenden Vermerk bei dem Bild ergänzen: **\\"Quelle: raschweb.de & serlo.org, Veränderungen: ...\\"** und folgenden Vermerk für die Aufgabe: **Lizenz: CC BY-SA 4.0\\"**\\n\\n///\\n"}]]',
+    agreement:
+      'Mit dem Speichern dieser Seite versicherst du, dass du die Veränderung des Beitrags von Herrn Günther Rasch selbst verfasst hast bzw. dass er keine fremden Rechte verletzt. Du willigst ein, deinen Beitrag unter der <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">Creative Commons Attribution/Share-Alike Lizenz 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.de) und/oder unter einer gleichwertigen Lizenz zu veröffentlichen, welche der Serlo Education e. V. entsprechend der Regelungen in den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) festlegen darf. Der Beitrag von Herrn Günther Rasch muss unter den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) verfügbar sein und du stimmst zu, den notwendigen Lizenzanforderungen zu folgen.',
+    iconHref: '',
+  },
+  {
+    id: 10,
+    instance: 'de',
+    default: false,
+    title: 'Standard-YouTube-Lizenz',
+    url: 'https://www.youtube.com/static?gl=DE&template=terms',
+    content: 'Standard-YouTube-Lizenz',
+    agreement: '',
+    iconHref: '',
+  },
+  {
+    id: 16,
+    instance: 'de',
+    default: false,
+    title: 'Dieses Werk steht unter der Lizenz CC BY-ND 4.0',
+    url: 'https://creativecommons.org/licenses/by-nd/4.0/',
+    content:
+      '[[{"col":24,"content":"Sie dürfen das **Lernmaterial** **vervielfältigen und verbreiten**. \\n\\nDies gilt unter folgenden Bedingungen:  \\n* Sie müssen Serlo als Urheber nennen \\"Quelle: serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY-ND 4.0\\", in digitaler Form als Link zu [dieser Seite](https://creativecommons.org/licenses/by-nd/4.0/deed.de).\\n\\n/// Beispiel\\nWenn Sie einen unveränderten Textbaustein, bspw. ein Video, von Serlo in einen Text von Ihnen integrieren, dann müssen Sie zu dem gesamten Text folgendes vermerken: \\"Video: serlo.org, Lizenz: CC BY-ND 4.0\\"\\n///\\n\\nWenn Sie das Material **verändern**, dürfen Sie die bearbeitete Fassung des Materials ***nicht* verbreiten**.\\n"}],[{"col":24,"content":"###Offizielle Lizenz\\n\\nDies ist eine allgemeinverständliche Zusammenfassung der [offiziellen Lizenz](https://creativecommons.org/licenses/by-nd/4.0/deed.de)\\nund ersetzt diese nicht.\\n"}]]',
+    agreement:
+      'Mit dem Speichern dieser Seite versicherst du, dass du deinen Beitrag (damit sind auch Änderungen gemeint) selbst verfasst hast bzw. dass er keine fremden Rechte verletzt. Du willigst ein, deinen Beitrag unter der <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">Creative Commons Attribution/Share-Alike Lizenz 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.de) und/oder unter einer gleichwertigen Lizenz zu veröffentlichen, welche der Serlo Education e. V. entsprechend der Regelungen in den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) festlegen darf. Falls du den Beitrag nicht selbst verfasst hast, muss er unter den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) verfügbar sein und du stimmst zu, notwendigen Lizenzanforderungen zu folgen.\r\n\r\nDas Video steht unter der Lizenz CC BY-ND, d.h. es dürfen keine Änderungen vorgenommen werden.\r\n',
+    iconHref: '',
+  },
+  {
+    id: 19,
+    instance: 'de',
+    default: false,
+    title: 'CC BY 4.0 - Landesbildungsserver Baden-Württemberg',
+    url: 'https://www.schule-bw.de/',
+    content:
+      '[[{"col":24,"content":"Dieser Lerninhalt stammt vom Landesbildungsserver Baden-Württemberg [www.schule-bw.de](https://www.schule-bw.de/). Serlo dankt für die freundliche Genehmigung zur Veröffentlichung.\\n\\nDer Lerninhalt steht unter der **Lizenz CC BY 4.0.**\\nSie dürfen das Werk beliebig kopieren, vervielfältigen, bearbeiten und weiterentwickeln - für verschiedene (auch kommerzielle) Zwecke. Dies gilt unter folgenden Bedingungen:\\n\\n### Wenn Sie **keine** Veränderungen vornehmen:\\n\\n* Sie müssen den Landesbildungsserver Baden-Württemberg als Urheber nennen \\"Quelle: Ausgangsmaterialien des Landesbildungsservers Baden-Württemberg (www.schule-bw.de) am Institut für Bildungsanalysen Baden-Württemberg (IBBW) (https://ibbw.kultus-bw.de)\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY 4.0\\", in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by/4.0/deed.de](https://creativecommons.org/licenses/by/4.0/deed.de).\\n\\n/// Beispiel\\nWenn Sie einen Lerninhalt vom Landesbildungsserver Baden-Württemberg auf Serlo für ihre Schüler*innen kopieren, dann müssen Sie folgenden Vermerk ergänzen: **\\"Quelle: Ausgangsmaterialien des Landesbildungsservers Baden-Württemberg (www.schule-bw.de) am Institut für Bildungsanalysen Baden-Württemberg (IBBW) (https://ibbw.kultus-bw.de)**\\n///\\n\\n\\n### Wenn Sie Veränderungen vornehmen:\\n\\n* Sie müssen den Landesbildungsserver Baden-Württemberg als Urheber nennen \\"Quelle: Ausgangsmaterialien des Landesbildungsservers Baden-Württemberg (www.schule-bw.de) am Institut für Bildungsanalysen Baden-Württemberg (IBBW) (https://ibbw.kultus-bw.de)\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen kurz erläutern, welche Änderungen sie vorgenommen haben, z.B. \\"Zahlen vereinfacht\\" oder \\"Bild zugeschnitten\\".\\n* Sie müssen die Lizenz \\"CC BY 4.0\\" angeben, in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by/4.0/deed.de](https://creativecommons.org/licenses/by/4.0/deed.de). Die Lizenz muss für das gesamte Werk angegeben werden, zu dem dieser Inhalt beigetragen hat.\\n\\n/// Beispiel\\n\\nWenn Sie eine Lerninhalt vom Landesbildungsserver Baden-Württemberg bearbeiten und es in Ihr Arbeitsblatt integrieren, dann müssen Sie folgenden Vermerk bei dem Bild ergänzen: **\\"Quelle: Ausgangsmaterialien des Landesbildungsservers Baden-Württemberg (www.schule-bw.de) am Institut für Bildungsanalysen Baden-Württemberg (IBBW) (https://ibbw.kultus-bw.de), Veränderungen: ...\\"** und folgenden Vermerk für die Aufgabe: **Lizenz: CC BY 4.0\\"**\\n\\n///\\n"}]]',
+    agreement: '',
+    iconHref: '',
+  },
+  {
+    id: 24,
+    instance: 'de',
+    default: false,
+    title:
+      'Dieses Werk steht unter der freien Lizenz CC BY-SA 4.0 mit Namensnennung von MNWeG',
+    url: 'https://mnweg.org',
+    content:
+      '[[{"col":24,"content":"Das Material stammt von der Seite [mnweg.org](https://mnweg.org/). Serlo dankt dem Materialnetzwerk (MNWeG) für die freundliche Genehmigung zur Veröffentlichung.\\n\\nDas Material steht unter der Lizenz **CC BY-SA 4.0**. Sie dürfen das Material beliebig kopieren, vervielfältigen, bearbeiten und weiterentwickeln - für verschiedene (auch kommerzielle) Zwecke. Dies gilt unter folgenden Bedingungen:\\n\\n### Wenn Sie **keine** Veränderungen vornehmen:\\n * Sie müssen MNWeG und Serlo als Urheber nennen \\"Quelle: mnweg.org & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen die Lizenz angeben \\"Lizenz: CC BY-SA 4.0\\", in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/] (https://creativecommons.org/licenses/by-sa/4.0/)\\n\\n/// Beispiel\\nWenn Sie eine Aufgabe von MNWeG auf Serlo für ihre Schüler/innen kopieren, dann müssen Sie folgenden Vermerk ergänzen:**\\"Quelle: mnweg.org & serlo.org, Lizenz: CC BY-SA 4.0\\"**\\n///\\n\\n### Wenn Sie Veränderungen vornehmen:\\n* Sie müssen MNWeG und Serlo als Urheber nennen \\"Quelle: mnweg.org & serlo.org\\", in digitaler Form als Link direkt zum Lernmaterial.\\n* Sie müssen kurz erläutern, welche Änderungen sie vorgenommen haben, z.B. \\"Zahlen vereinfacht\\" oder \\"Bild zugeschnitten\\".\\n* Sie müssen die Lizenz \\"CC BY-SA 4.0\\" angeben, in digitaler Form als Link zu dieser Seite: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/).\\nDie Lizenz muss für das gesamte Werk angegeben werden, zu dem dieser Inhalt beigetragen hat.\\n/// Beispiel\\nWenn Sie eine Aufgabe von MNWeG & Serlo bearbeiten und es in Ihr Arbeitsblatt integrieren, dann müssen Sie folgenden Vermerk bei dem Bild ergänzen: **\\"Quelle: mnweg.org & serlo.org, Veränderungen: …\\"** und folgenden Vermerk für die Aufgabe: Lizenz: **\\"CC BY-SA 4.0\\"**\\n\\n///"}]]',
+    agreement:
+      'Mit dem Speichern dieser Seite versicherst du, dass du die Veränderung des Beitrags von MNWeG selbst verfasst hast bzw. dass er keine fremden Rechte verletzt. Du willigst ein, deinen Beitrag unter der <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.de">Creative Commons Attribution/Share-Alike Lizenz 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.de) und/oder unter einer gleichwertigen Lizenz zu veröffentlichen, welche der Serlo Education e. V. entsprechend der Regelungen in den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) festlegen darf. Der Beitrag von MNWeG muss unter den <a href="/21654">Nutzungsbedingungen</a> (http://de.serlo.org/21654) verfügbar sein und du stimmst zu, notwendigen Lizenzanforderungen zu folgen.',
+    iconHref: '',
+  },
+  {
+    id: 9,
+    instance: 'en',
+    default: true,
+    title: 'This content is licensed under cc-by-sa-4.0',
+    url: 'http://creativecommons.org/licenses/by/4.0/',
+    content: '[[{"col":24,"content":"siehe de.serlo"}]]',
+    agreement:
+      'By saving this page, you confirm that your contribution (including any edits you have made) is your own work, and that it does not infringe on the rights of third parties. You consent to publishing your contribution under the <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution/Share-Alike License 4.0</a> (http://creativecommons.org/licenses/by-sa/4.0/) and/or under an equivalent license chosen by the Serlo Education e.V. in accordance with the regulations laid out in the <a href="https://en.serlo.org/terms">terms of use</a> (https://en.serlo.org/terms). Should the contribution not be your own work, it must be available in accordance with the <a href="https://en.serlo.org/terms">terms of use</a> (https://en.serlo.org/terms), and you must agree to comply with any necessary license requests.',
+    iconHref: 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+  {
+    id: 14,
+    instance: 'es',
+    default: true,
+    title: 'Este contenido está licenciado bajo cc-by-sa-4.0',
+    url: 'https://creativecommons.org/licenses/by-sa/4.0/deed.es',
+    content: '',
+    agreement:
+      'Al guardar esta página, confirmas que tu contribución (incluyendo cualquier edición que hayas realizado) es tu propio trabajo, y que no infringe los derechos de terceros. Consiente en publicar su contribución bajo la <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.es">Licencia Creative Commons Attribution/Share-Alike 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.es) y/o bajo una licencia equivalente elegida por Serlo Education e.V. de acuerdo con las normas establecidas en las <a href="https://es.serlo.org/terms">condiciones de uso</a> (https://es.serlo.org/terms). En caso de que la contribución no sea un trabajo propio, deberá estar disponible de acuerdo con los <a href="https://es.serlo.org/terms">términos de uso</a> (https://es.serlo.org/terms), y deberá aceptar cumplir con cualquier solicitud de licencia necesaria.',
+    iconHref: 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+  {
+    id: 21,
+    instance: 'es',
+    default: false,
+    title: 'Licencia estándar de YouTube',
+    url: 'https://www.youtube.com/static?template=terms&gl=ES',
+    content: '[[{"col":24,"content":"Licencia estándar de YouTube"}]]',
+    agreement: '',
+    iconHref: '',
+  },
+  {
+    id: 22,
+    instance: 'es',
+    default: false,
+    title:
+      'Esta obra está bajo la licencia libre CC BY-SA 4.0 de la iniciativa colectiva África en la Escuela',
+    url: 'https://www.facebook.com/AfricaenlaEscuela/',
+    content:
+      '[[{"col":24,"content":"Esta obra es trabajo original realizado por los miembros y colaboradores de la  [iniciativa colectiva África en la Escuela.](https://www.facebook.com/AfricaenlaEscuela/) \\nSerlo agradece a África en la Escuela el amable permiso de publicación.\\n\\nEl contenido esta bajo la licencia libre [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.es) Puedes copiar y redistribuir el material en cualquier medio o formato. También remezclar, transformar y construir a partir del material para cualquier propósito (incluso comercialmente.) Bajo las siguientes condiciones:\\n\\n**Si no haces *ningún* cambio:**\\n* Debes acreditar a África en la Escuela y Serlo como autor asi,  \\"Fuente: África en la Escuela & serlo.org\\", en forma digital como un enlace directamente al material de aprendizaje.\\n* Debes indicar la licencia \\"Licencia: CC BY-SA 4.0\\", en forma digital como enlace a esta página: [https://creativecommons.org/licenses/by-sa/4.0/deed.es](https://creativecommons.org/licenses/by-sa/4.0/deed.es)\\n\\n/// Ejemplo\\nSi copias el material educativo de África en la Escuela tomado de la página web de Serlo para tus alumnos o institución educativa, tienes que añadir la siguiente nota: \\n\\n\\"**Fuente: África en la Escuela & serlo.org, Licencia: CC BY-SA 4.0**\\".\\n///\\n\\n\\n**Cuando haces *algún* cambio:**\\n* Debes acreditar a África en la Escuela y Serlo como autor así,  \\"Fuente: África en la Escuela & serlo.org\\", en forma digital como un enlace directamente al material de aprendizaje. \\n* Debes explicar brevemente qué cambios se han realizado, por ejemplo, \\"Nuevas gráficas\\", \\"Nuevas citas\\",  \\"Imágenes alteradas\\" o, “cambios en el texto”.\\n* Debes indicar la licencia \\"Licencia: CC BY-SA 4.0\\", en forma digital como enlace a esta página: [https://creativecommons.org/licenses/by-sa/4.0/deed.es](https://creativecommons.org/licenses/by-sa/4.0/deed.es) La licencia debe darse para toda la obra a la que ha contribuido este contenido.\\n\\n/// Ejemplo\\nSi editas algo de África en la Escuela & Serlo y la integras en algun trabajo tuyo, debes añadir la siguiente nota: \\n\\n\\"**Fuente: África en la Escuela & serlo.org, modificaciones: _ _ _ _. Licencia: CC BY-SA 4.0**\\".\\n\\nNo olvides listar las modificaciones hechas y poner el enlace original al material.\\n///"}]]',
+    agreement: '',
+    iconHref: 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+  {
+    id: 23,
+    instance: 'es',
+    default: false,
+    title:
+      ' Este ejercicio/tarea está bajo la licencia libre CC BY-SA 4.0 del señor Franz Strobl.',
+    url: 'http://www.strobl-f.de/',
+    content:
+      '[[{"col":24,"content":"Las tareas/ejercicios proceden del sitio en alemán de aprendizaje de matemáticas [www.strobl-f.de](http://www.strobl-f.de/) y fue creada por el Sr. Franz Strobl. Serlo agradece el amable permiso de publicación.\\n\\nLa tarea/ejercicio está licenciada bajo CC BY-SA 4.0 Puede copiar, reproducir, editar y desarrollar la tarea como desee, para diversos fines (incluso comerciales). Esto se aplica bajo las siguientes condiciones:\\n\\n**Si no realiza ningún cambio:**\\n* Debe acreditar a Strobl y Serlo como autores \\"Fuente: strobl-f.de & serlo.org\\", en forma digital como un enlace directo al material de aprendizaje.\\nDebe indicar la licencia \\"Licencia: CC BY-SA 4.0\\", en forma digital como un enlace a esta página:\\n[https://creativecommons.org/licenses/by-sa/4.0/deed.es](https://creativecommons.org/licenses/by-sa/4.0/deed.es)\\n\\n/// Ejemplo\\nSi copias una tarea/ejercicio del Sr. Strobl en Serlo para tus alumnos, tienes que añadir la siguiente nota: \\"Fuente: strobl-f.de & serlo.org, Licencia: CC BY-SA 4.0\\".\\n///\\n\\n**Si haces algún cambio:**\\n* Debe acreditar a Strobl y Serlo como autores \\"Fuente: strobl-f.de & serlo.org\\", en forma digital como un enlace directo al material de aprendizaje.\\n* Debe explicar brevemente qué cambios ha realizado, por ejemplo, \\"figuras simplificadas\\" o \\"imagen recortada\\".\\n* Deben indicar la licencia \\"CC BY-SA 4.0\\", en forma digital como un enlace a esta página: [https://creativecommons.org/licenses/by-sa/4.0/deed.es](https://creativecommons.org/licenses/by-sa/4.0/deed.es) . La licencia debe darse para toda la obra a la que ha contribuido este contenido.\\n\\n/// Ejemplo\\nSi edita una tarea del Sr. Strobl & Serlo y la integra en su hoja de trabajo, debe añadir la siguiente nota a la imagen: \\"Fuente: strobl-f.de & serlo.org, modificaciones: ...\\" y la siguiente nota para la tarea: Licencia: CC BY-SA 4.0\\".\\n///"}]]',
+    agreement:
+      'Al guardar esta página, confirmas que tu contribución (incluyendo cualquier edición que hayas realizado) es tu propio trabajo, y que no infringe los derechos de terceros. Consiente en publicar su contribución bajo la <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.es">Licencia Creative Commons Attribution/Share-Alike 4.0</a> (https://creativecommons.org/licenses/by-sa/4.0/deed.es) y/o bajo una licencia equivalente elegida por Serlo Education e.V. de acuerdo con las normas establecidas en las <a href="https://es.serlo.org/terms">condiciones de uso</a> (https://es.serlo.org/terms). En caso de que la contribución no sea un trabajo propio, deberá estar disponible de acuerdo con los <a href="https://es.serlo.org/terms">términos de uso</a> (https://es.serlo.org/terms), y deberá aceptar cumplir con cualquier solicitud de licencia necesaria.',
+    iconHref: 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+  {
+    id: 13,
+    instance: 'hi',
+    default: true,
+    title: 'This content is licensed under cc-by-sa-4.0',
+    url: 'https://creativecommons.org/licenses/by/4.0/',
+    content: '[[{"col":24,"content":"tbd"}]]',
+    agreement:
+      'By saving this page, you confirm that your contribution (including any edits you have made) is your own work, and that it does not infringe on the rights of third parties. You consent to publishing your contribution under the <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution/Share-Alike License 4.0</a> (http://creativecommons.org/licenses/by-sa/4.0/) and/or under an equivalent license chosen by the Serlo Education e.V. in accordance with the regulations laid out in the <a href="https://hi.serlo.org/terms">terms of use</a> (https://hi.serlo.org/terms). Should the contribution not be your own work, it must be available in accordance with the <a href="https://hi.serlo.org/terms">terms of use</a> (https://hi.serlo.org/terms), and you must agree to comply with any necessary license requests.',
+    iconHref: 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+  {
+    id: 17,
+    instance: 'ta',
+    default: true,
+    title: 'This content is licensed under cc-by-sa-4.0',
+    url: 'http://creativecommons.org/licenses/by/4.0/',
+    content: '[[{"col":24,"content":"siehe de.serlo.org"}]]',
+    agreement:
+      'By saving this page, you confirm that your contribution (including any edits you have made) is your own work, and that it does not infringe on the rights of third parties. You consent to publishing your contribution under the <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution/Share-Alike License 4.0</a> (http://creativecommons.org/licenses/by-sa/4.0/) and/or under an equivalent license chosen by the Serlo Education e.V. in accordance with the regulations laid out in the <a href="https://ta.serlo.org/terms">terms of use</a> (https://ta.serlo.org/terms). Should the contribution not be your own work, it must be available in accordance with the <a href="https://ta.serlo.org/terms">terms of use</a> (https://ta.serlo.org/terms), and you must agree to comply with any necessary license requests.',
+    iconHref: 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+  {
+    id: 18,
+    instance: 'fr',
+    default: true,
+    title: ' Ce contenu est sous licence cc-by-sa-4.0',
+    url: 'http://creativecommons.org/licenses/by/4.0/',
+    content:
+      '[[{"col":24,"content":"Pour plus d\'informations: [de.serlo.org](de.serlo.org)"}]]',
+    agreement:
+      'En sauvegardant cette page, tu confirmes que ta contribution (incluant chaque modification) est ton propre travail et qu’elle ne viole pas les droits de tiers. Tu consentes de publier ta contribution sous licence <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution/Share-Alike License 4.0</a> (http://creativecommons.org/licenses/by-sa/4.0/) et/ou sous une licence équivalente choisie par la Société pour l’éducation ouverte (Gesellschaft für freie Bildung e. V.) conformément aux régulations établies dans <a href="https://fr.serlo.org/terms">terms of use</a> (https://fr.serlo.org/terms). Si votre contribution n’est pas votre propre travail, elle doit être disponible conformément aux <a href="https://fr.serlo.org/terms">modalités d’utilisations</a> (https://fr.serlo.org/terms), et tu dois accepter de satisfaire toute demande de licence nécessaire.',
+    iconHref: 'http://i.creativecommons.org/l/by-sa/4.0/88x31.png',
+  },
+]

--- a/packages/server/src/model/database-layer.ts
+++ b/packages/server/src/model/database-layer.ts
@@ -184,20 +184,6 @@ export const spec = {
     }),
     canBeNull: false,
   },
-  LicenseQuery: {
-    payload: t.type({ id: t.number }),
-    response: t.type({
-      id: t.number,
-      instance: InstanceDecoder,
-      default: t.boolean,
-      title: t.string,
-      url: t.string,
-      content: t.string,
-      agreement: t.string,
-      iconHref: t.string,
-    }),
-    canBeNull: true,
-  },
   NavigationQuery: {
     payload: t.type({ instance: InstanceDecoder }),
     response: NavigationDecoder,

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -356,26 +356,6 @@ export function createSerloModel({
     environment
   )
 
-  const getLicense = createQuery(
-    {
-      decoder: DatabaseLayer.getDecoderFor('LicenseQuery'),
-      getCurrentValue: (payload: DatabaseLayer.Payload<'LicenseQuery'>) => {
-        return DatabaseLayer.makeRequest('LicenseQuery', payload)
-      },
-      enableSwr: true,
-      staleAfter: { day: 1 },
-      getKey: ({ id }) => `de.serlo.org/api/license/${id}`,
-      getPayload: (key) => {
-        const prefix = 'de.serlo.org/api/license/'
-        return key.startsWith(prefix)
-          ? O.some({ id: parseInt(key.replace(prefix, ''), 10) })
-          : O.none
-      },
-      examplePayload: { id: 1 },
-    },
-    environment
-  )
-
   const getSubjects = createQuery(
     {
       decoder: DatabaseLayer.getDecoderFor('SubjectsQuery'),
@@ -995,7 +975,6 @@ export function createSerloModel({
     getEntitiesMetadata,
     getEvents,
     getEventsAfter,
-    getLicense,
     getNavigation,
     getNavigationPayload,
     getNotificationEvent,

--- a/packages/server/src/model/types.ts
+++ b/packages/server/src/model/types.ts
@@ -89,7 +89,6 @@ export interface Models {
   GroupedExercise: t.TypeOf<typeof GroupedExerciseDecoder>
   GroupedExerciseRevision: t.TypeOf<typeof GroupedExerciseRevisionDecoder>
   Navigation: Payload<'serlo', 'getNavigation'>
-  License: Payload<'serlo', 'getLicense'>
   Page: t.TypeOf<typeof PageDecoder>
   PageRevision: t.TypeOf<typeof PageRevisionDecoder>
   Subject: { taxonomyTermId: number }

--- a/packages/server/src/schema/license/resolvers.ts
+++ b/packages/server/src/schema/license/resolvers.ts
@@ -19,13 +19,14 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
+import { licenses } from '~/config'
 import { LegacyQueries, TypeResolvers } from '~/internals/graphql'
 import { License } from '~/types'
 
 export const resolvers: TypeResolvers<License> & LegacyQueries<'license'> = {
   Query: {
-    license(_parent, { id }, { dataSources }) {
-      return dataSources.model.serlo.getLicense({ id })
+    license(_parent, { id }) {
+      return licenses.find((license) => license.id === id) ?? null
     },
   },
 }

--- a/packages/server/src/schema/uuid/abstract-repository/utils.ts
+++ b/packages/server/src/schema/uuid/abstract-repository/utils.ts
@@ -23,6 +23,7 @@ import { array as A, function as F, number as N, ord } from 'fp-ts'
 import * as t from 'io-ts'
 import R from 'ramda'
 
+import { licenses } from '~/config'
 import {
   Model,
   PickResolvers,
@@ -96,10 +97,9 @@ export function createRepositoryResolvers<R extends Model<'AbstractRevision'>>({
         },
       })
     },
-    async license(repository, _args, { dataSources }) {
-      const license = await dataSources.model.serlo.getLicense({
-        id: repository.licenseId,
-      })
+    license(repository, _args) {
+      const license =
+        licenses.find((license) => license.id === repository.licenseId) ?? null
 
       if (license === null) throw new Error('License cannot be null')
 


### PR DESCRIPTION
closes #610

There should probably be a follow up in the db-layer, since we can remove one query.

@kulla  or @hugotiburtino could you review?