### PR TITLE
fix(metadata): Use static import to read version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,7 +90,7 @@ module.exports = {
 
     // eslint-plugin-import
     'import/export': 'error',
-    'import/extensions': ['error', 'never'],
+    'import/extensions': ['error', 'never', { json: 'always' }],
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-absolute-path': 'error',

--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -19,6 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
+import { version } from '../../../package.json'
 import { resolveConnection } from '../connection/utils'
 import { createNamespace, decodeId, Queries } from '~/internals/graphql'
 
@@ -85,9 +86,7 @@ export const resolvers: Queries<'metadata'> = {
       }
     },
     version() {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
-      const { version } = require('../../../package')
-      return version as string
+      return version
     },
   },
 }

--- a/packages/server/src/typings.d.ts
+++ b/packages/server/src/typings.d.ts
@@ -1,0 +1,5 @@
+// Needed to include "package.json" into source files and avoiding emitting
+// them to the `dist`
+//
+// See https://stackoverflow.com/a/61426303
+declare module '*.json'

--- a/packages/server/src/typings.d.ts
+++ b/packages/server/src/typings.d.ts
@@ -2,4 +2,9 @@
 // them to the `dist`
 //
 // See https://stackoverflow.com/a/61426303
-declare module '*.json'
+//
+// FIXME: Find a solution with `resolveJsonModule === true` and omitting the
+// error https://github.com/jaredpalmer/tsdx/blob/f0963cb2d77f00bcd8606f8e4b99250972d81b02/src/deprecated.ts#L13-L21
+declare module '*.json' {
+  export const version: string
+}

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -7,6 +7,7 @@
     "importHelpers": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "es5",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -7,7 +7,6 @@
     "importHelpers": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "es5",


### PR DESCRIPTION
Closes #681

By reading the version statically and not dynamically at runtime the version number is compiled into `/usr/src/app/packages/server/dist/api.serlo.org.cjs.production.min.js`