### PR TITLE
refactor: only query user language when requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.49.2](https://github.com/serlo/api.serlo.org/compare/v0.49.1..v0.49.2) - February 12, 2023
+
+### Fixed
+
+- user: decrease db calls due to language query
+
 ## [v0.49.1](https://github.com/serlo/api.serlo.org/compare/v0.49.0..v0.49.1) - February 8, 2023
 
 ### Fixed

--- a/__fixtures__/uuid/user.ts
+++ b/__fixtures__/uuid/user.ts
@@ -22,7 +22,6 @@
 import { Model } from '~/internals/graphql'
 import { Payload } from '~/internals/model'
 import { castToAlias, castToUuid, DiscriminatorType } from '~/model/decoder'
-import { Instance } from '~/types'
 
 export const user: Model<'User'> = {
   __typename: DiscriminatorType.User,
@@ -34,7 +33,6 @@ export const user: Model<'User'> = {
   lastLogin: '2020-03-24T09:40:55Z',
   description: null,
   roles: ['login', 'german_horizonhelper', 'sysadmin'],
-  language: Instance.De,
 }
 
 export const user2: Model<'User'> = {
@@ -47,7 +45,6 @@ export const user2: Model<'User'> = {
   lastLogin: '2019-03-23T09:20:55Z',
   description: null,
   roles: ['login'],
-  language: Instance.En,
 }
 
 export const activityByType: Payload<'serlo', 'getActivityByType'> = {

--- a/__tests-pacts__/index.ts
+++ b/__tests-pacts__/index.ts
@@ -121,7 +121,7 @@ const uuids = [
   taxonomyTermRoot,
   taxonomyTermSubject,
   taxonomyTermCurriculumTopic,
-  R.omit(['language'], user),
+  user,
   video,
   videoRevision,
 ]

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.49.1"
+  "version": "0.49.2"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "private": true,
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",

--- a/packages/server/src/model/serlo.ts
+++ b/packages/server/src/model/serlo.ts
@@ -27,7 +27,6 @@ import * as DatabaseLayer from './database-layer'
 import {
   castToUuid,
   CommentDecoder,
-  DiscriminatorType,
   EntityDecoder,
   EntityRevisionDecoder,
   NavigationDataDecoder,
@@ -59,18 +58,7 @@ export function createSerloModel({
       enableSwr: true,
       getCurrentValue: async (payload: DatabaseLayer.Payload<'UuidQuery'>) => {
         const uuid = await DatabaseLayer.makeRequest('UuidQuery', payload)
-        if (!isSupportedUuid(uuid)) return null
-        if (uuid.__typename === DiscriminatorType.User) {
-          const kratosIdentity =
-            await environment.authServices.kratos.db.getIdentityByLegacyId(
-              payload.id
-            )
-          return {
-            ...uuid,
-            language: kratosIdentity?.traits.language,
-          }
-        }
-        return uuid
+        return isSupportedUuid(uuid) ? uuid : null
       },
       staleAfter: { day: 1 },
       getKey: ({ id }) => {

--- a/packages/server/src/schema/uuid/user/resolvers.ts
+++ b/packages/server/src/schema/uuid/user/resolvers.ts
@@ -50,6 +50,7 @@ import {
 import {
   DiscriminatorType,
   EntityDecoder,
+  InstanceDecoder,
   RevisionDecoder,
   UserDecoder,
 } from '~/model/decoder'
@@ -285,6 +286,15 @@ export const resolvers: LegacyQueries<
           return node.scope + node.role
         },
       })
+    },
+    async language(user, _, { dataSources }) {
+      const kratosIdentity =
+        await dataSources.model.authServices.kratos.db.getIdentityByLegacyId(
+          user.id
+        )
+      const language = kratosIdentity?.traits.language
+
+      return InstanceDecoder.is(language) ? language : null
     },
   },
   Mutation: {

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -1450,6 +1450,11 @@ async function exec(): Promise<void> {
         date: '2023-02-08',
         fixed: ['Do not create kratos DB pool connection for single query'],
       },
+      {
+        tagName: 'v0.49.2',
+        date: '2023-02-12',
+        fixed: ['user: decrease db calls due to language query'],
+      },
     ],
   })
 


### PR DESCRIPTION
Now, it will only hit database if language is expressly requested. Since language is only used by notification mail service, it should be ok, now that we have a kind of queue there.
But in the long run we want to use kratos sdk in order to get user by legacy id, for that see https://github.com/serlo/db-migrations/issues/4