### PR TITLE
Refactor: Adjust to changes in the DB-Layer

### DIFF
--- a/__fixtures__/uuid/thread.ts
+++ b/__fixtures__/uuid/thread.ts
@@ -20,7 +20,7 @@
  * @link      https://github.com/serlo-org/api.serlo.org for the canonical source repository
  */
 
-import { article } from './article'
+import { article, article2 } from './article'
 import { user, user2 } from './user'
 import { Model } from '~/internals/graphql'
 import { castToAlias, castToUuid, DiscriminatorType } from '~/model/decoder'
@@ -81,6 +81,6 @@ export const comment3: Model<'Comment'> = {
   archived: false,
   content:
     'Das obere Beispiel ist "ungut". Denn man hat da Kettenrechnungen hintereinander gestellt und mehrere Gleichzeitszeichen in einer Zeile, aber am Anfang ist die Rechnung 1+2 und am Ende ist die Lösung 6. Mathematisch ist das eine falsche Schreibweise, auch wenn man üblicherweise so rechnet. Bei der zweiten Variante ist das besser gelöst, denn da wird diese Nebenrechnung nicht in die Zeile der Endlösung reingeschrieben.',
-  parentId: castToUuid(1495),
+  parentId: article2.id,
   childrenIds: [],
 }

--- a/__tests__/schema/thread/all-threads.ts
+++ b/__tests__/schema/thread/all-threads.ts
@@ -35,9 +35,9 @@ import { Model } from '~/internals/graphql'
 import { encodeSubjectId } from '~/schema/subject/utils'
 import { Instance } from '~/types'
 
-const comment4 = { ...comment3, id: nextUuid(comment3.id) }
-
 describe('allThreads', () => {
+  const comment4 = { ...comment3, id: nextUuid(comment3.id) }
+
   beforeEach(() => {
     given('UuidQuery').for(comment, comment1, comment2, comment3, comment4)
     given('UuidQuery').for(article, article2)
@@ -136,39 +136,18 @@ describe('allThreads', () => {
 
   test('parameter "subjectId"', async () => {
     given('AllThreadsQuery')
-      .withPayload({ first: 11 })
+      .withPayload({ first: 11, subjectId: article.canonicalSubjectId! })
       .returns({
-        firstCommentIds: [comment, comment1, comment3].map(R.prop('id')),
+        firstCommentIds: [comment, comment1].map(R.prop('id')),
       })
-
-    await query
-      .withVariables({ subjectId: encodeSubjectId(article.taxonomyTermIds[0]) })
-      .shouldReturnData({
-        thread: {
-          allThreads: { nodes: [comment, comment1].map(getThreadData) },
-        },
-      })
-  })
-
-  test('parameter "subjectId" with small first', async () => {
-    given('AllThreadsQuery')
-      .withPayload({ first: 3 })
-      .returns({
-        firstCommentIds: [comment, comment1, comment3].map(R.prop('id')),
-      })
-
-    given('AllThreadsQuery')
-      .withPayload({ first: 3, after: comment3.date })
-      .returns({ firstCommentIds: [comment4.id] })
 
     await query
       .withVariables({
-        first: 2,
-        subjectId: encodeSubjectId(article2.taxonomyTermIds[0]),
+        subjectId: encodeSubjectId(article.canonicalSubjectId!),
       })
       .shouldReturnData({
         thread: {
-          allThreads: { nodes: [comment3, comment4].map(getThreadData) },
+          allThreads: { nodes: [comment, comment1].map(getThreadData) },
         },
       })
   })

--- a/packages/server/src/model/database-layer.ts
+++ b/packages/server/src/model/database-layer.ts
@@ -74,7 +74,7 @@ export const spec = {
       t.type({ first: t.number }),
       t.partial({ after: t.string }),
       t.partial({ instance: InstanceDecoder }),
-      t.partial({subjectId: t.number})
+      t.partial({ subjectId: t.number }),
     ]),
     response: t.type({ firstCommentIds: t.array(t.number) }),
     canBeNull: false,

--- a/packages/server/src/model/database-layer.ts
+++ b/packages/server/src/model/database-layer.ts
@@ -74,6 +74,7 @@ export const spec = {
       t.type({ first: t.number }),
       t.partial({ after: t.string }),
       t.partial({ instance: InstanceDecoder }),
+      t.partial({subjectId: t.number})
     ]),
     response: t.type({ firstCommentIds: t.array(t.number) }),
     canBeNull: false,


### PR DESCRIPTION
This PR is related to the changes in https://github.com/serlo/database-layer/pull/430, where the threads are provided directly by the database layer, and some logic can be removed from the API.

ℹ️ https://github.com/serlo/database-layer/pull/430 needs to be merged first.
