### PR TITLE
Add an extra step to setup NODE_OPTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Run `yarn build` to build the packages 'authorization' and 'types'.
 
 Make sure Docker is running and then run `yarn start` to start Redis.
 
+#### Setup NODE_OPTIONS
+
+If in the `/etc/hosts` file of your host you have the `::1` (IPv6) mapped to `localhost`, you will additionally need
+to set: `--dns-result-order=ipv4first` in the `NODE_OPTIONS` environment variable:
+
+```bash
+export NODE_OPTIONS=--dns-result-order=ipv4first
+```
+
 ### Run tests
 
 - `yarn test` runs the unit tests (requires `yarn start:redis` beforehand)


### PR DESCRIPTION
To add `export NODE_OPTIONS=--dns-result-order=ipv4first` and so that `localhost` resolves to 127.0.0.1 (IPv6) in the case when /etc/hosts also has a mapping for `::1` (IPv6) to `localhost`.

See https://github.com/nodejs/node/issues/40702#issuecomment-1103623246 and https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1407717012 for more context.

ℹ️ This is a problem that I ran into when setting up this repository, and that maybe could help other developers ✨ 