### PR TITLE
fix(cache): Quit all lock managers when the cache is closed

### DIFF
--- a/packages/server/src/internals/cache/index.ts
+++ b/packages/server/src/internals/cache/index.ts
@@ -143,6 +143,10 @@ export function createCache({ timer }: { timer: Timer }): Cache {
       await client.flushdb()
     },
     async quit() {
+      for (const lockManager of Object.values(lockManagers)) {
+        await lockManager.quit()
+      }
+
       await client.quit()
     },
   }


### PR DESCRIPTION
Fixes the error in jest that there are open handles