### PR TITLE
chore(Github Actions): enable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
+version: 2
+updates:
+  # repetitive because unfortunately Dependabot ticket for wildcard support still open:
+  # https://github.com/dependabot/dependabot-core/issues/2178
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "packages/authorization"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "packages/graphql-modules"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "packages/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "packages/types"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directory: "packages/server/docker/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "docker"
+    directory: "packages/server/docker/swr-queue-worker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
@eliflores mentioned she has used this at https://github.com/patitalabs/agile-metrics-jira/blob/main/.github/dependabot.yml so that Dependabot automatically creates pull requests for version updates as you can see in https://github.com/patitalabs/agile-metrics-jira/pulls. 

We thought this might be useful here as well and so I decided to make this PR. 
If it works as we want, we may later do the same for other repositories. 

Let us know in case there are reasons for us to not want this feature enabled. 

I am unsure about the open-pull-requests-limit but decided to put a lower number for a start. 