### PR TITLE
Add github-actions to dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,9 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,8 +41,8 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 5
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     open-pull-requests-limit: 5


### PR DESCRIPTION
In order to also keep the GitHub Actions in our workflows up to date, let's add `github-actions` as well to the dependabot version updates.

ℹ️ Related to https://github.com/serlo/api.serlo.org/pull/882