### PR TITLE
fix: Fix pact tests 

### DIFF
--- a/__fixtures__/uuid/article.ts
+++ b/__fixtures__/uuid/article.ts
@@ -52,3 +52,18 @@ export const articleRevision: Model<'ArticleRevision'> = {
   metaDescription: 'metaDescription',
   metaTitle: 'metaTitle',
 }
+
+export const articleRevision2: Model<'ArticleRevision'> = {
+  __typename: EntityRevisionType.ArticleRevision,
+  id: castToUuid(30672),
+  trashed: false,
+  alias: castToAlias('/mathe/30672/parabel'),
+  date: '2014-03-01 20:45:56Z',
+  authorId: user.id,
+  repositoryId: article.id,
+  title: 'title',
+  content: castToNonEmptyString('content'),
+  changes: 'changes',
+  metaDescription: 'metaDescription',
+  metaTitle: 'metaTitle',
+}

--- a/__fixtures__/uuid/page.ts
+++ b/__fixtures__/uuid/page.ts
@@ -27,3 +27,15 @@ export const pageRevision: Model<'PageRevision'> = {
   authorId: user.id,
   repositoryId: page.id,
 }
+
+export const pageRevision2: Model<'PageRevision'> = {
+  __typename: DiscriminatorType.PageRevision,
+  id: castToUuid(33220),
+  trashed: false,
+  alias: castToAlias('/entity/repository/compare/0/33220'),
+  title: 'title',
+  content: 'content',
+  date: '2014-11-26 15:08:48Z',
+  authorId: user.id,
+  repositoryId: page.id,
+}

--- a/__tests-pacts__/index.ts
+++ b/__tests-pacts__/index.ts
@@ -38,6 +38,7 @@ import {
   groupedExerciseRevision,
   page,
   pageRevision,
+  pageRevision2,
   solution,
   solutionRevision,
   taxonomyTermCurriculumTopic,
@@ -370,7 +371,7 @@ const pactSpec: PactSpec = {
     examples: [
       [
         {
-          revisionId: pageRevision.id,
+          revisionId: pageRevision2.id,
           userId: user.id,
           reason: '',
         },
@@ -384,7 +385,7 @@ const pactSpec: PactSpec = {
     examples: [
       [
         {
-          revisionId: pageRevision.id,
+          revisionId: pageRevision2.id,
           userId: user.id,
           reason: '',
         },

--- a/__tests-pacts__/index.ts
+++ b/__tests-pacts__/index.ts
@@ -22,6 +22,7 @@ import {
   appletRevision,
   article,
   articleRevision,
+  articleRevision2,
   checkoutRevisionNotificationEvent,
   comment,
   comment3,
@@ -203,7 +204,7 @@ const pactSpec: PactSpec = {
     examples: [
       [
         {
-          revisionId: articleRevision.id,
+          revisionId: articleRevision2.id,
           userId: user.id,
           reason: '',
         },
@@ -217,7 +218,7 @@ const pactSpec: PactSpec = {
     examples: [
       [
         {
-          revisionId: articleRevision.id,
+          revisionId: articleRevision2.id,
           userId: user.id,
           reason: '',
         },


### PR DESCRIPTION
This PR updates the revision ids used in the following pact examples:

* EntityCheckoutRevisionMutation
* EntityRejectRevisionMutation
* PageCheckoutRevisionMutation
* PageRejectRevisionMutation

in order to fix the following two issues:  https://github.com/serlo/api.serlo.org/issues/911 and https://github.com/serlo/database-layer/issues/458.