### PR TITLE
chore(github-actions): Fix job name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,5 +23,5 @@ jobs:
           load: true
           file: packages/server/docker/server/Dockerfile
           tags: api-server:PR-${{ env.PR_NUMBER }}
-      - name: Test for node api-server
+      - name: Test for node in the ${{ matrix.image }} image
         run: docker run --entrypoint='' --rm api-server:PR-${{ env.PR_NUMBER }} node --version


### PR DESCRIPTION
The job name should have the name of the image and not api-server. 
Follow up of https://github.com/serlo/api.serlo.org/pull/876.