### PR TITLE
Release version 0.52.1 ✨ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.52.1](https://github.com/serlo/api.serlo.org/compare/v0.52.0..v0.52.1) - July 4, 2023
+
+### Internal
+
+- Update various dependencies
+
+- Update dependabot configuration
+
 ## [v0.52.0](https://github.com/serlo/api.serlo.org/compare/v0.51.1..v0.52.0) - June 26, 2023
 
 ### Added

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.52.0"
+  "version": "0.52.1"
 }

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/authorization",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",
   "author": "Serlo Education e.V.",
@@ -11,7 +11,7 @@
     "build": "tsdx build --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
-    "@serlo/api": "^0.52.0"
+    "@serlo/api": "^0.52.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api.serlo.org",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "private": true,
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     "@google-cloud/storage": "^6.10.0",
     "@ory/client": "^1.1.21",
     "@sentry/node": "^7.52.1",
-    "@serlo/authorization": "^0.52.0",
+    "@serlo/authorization": "^0.52.1",
     "apollo-datasource-rest": "^3.7.0",
     "apollo-server": "^3.11.1",
     "apollo-server-core": "^3.11.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/api",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "repository": "serlo/api.serlo.org",
   "license": "Apache-2.0",
   "author": "Serlo Education e.V.",

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -1500,6 +1500,14 @@ async function exec(): Promise<void> {
           'Add pact tests for entity revision and page revision',
         ],
       },
+      {
+        tagName: 'v0.52.1',
+        date: '2023-07-04',
+        internal: [
+          'Update various dependencies',
+          'Update dependabot configuration',
+        ],
+      },
     ],
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,7 +4016,7 @@ __metadata:
     "@graphql-codegen/typescript-resolvers": ^3.2.1
     "@ory/client": ^1.1.21
     "@sentry/node": ^7.52.1
-    "@serlo/authorization": ^0.52.0
+    "@serlo/authorization": ^0.52.1
     "@types/basic-auth": ^1.1.3
     "@types/bull-arena": ^3.0.7
     "@types/graphql-modules": ^0.52.0
@@ -4061,7 +4061,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@serlo/api@^0.52.0, @serlo/api@workspace:packages/types":
+"@serlo/api@^0.52.1, @serlo/api@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@serlo/api@workspace:packages/types"
   dependencies:
@@ -4072,11 +4072,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@serlo/authorization@^0.52.0, @serlo/authorization@workspace:packages/authorization":
+"@serlo/authorization@^0.52.1, @serlo/authorization@workspace:packages/authorization":
   version: 0.0.0-use.local
   resolution: "@serlo/authorization@workspace:packages/authorization"
   dependencies:
-    "@serlo/api": ^0.52.0
+    "@serlo/api": ^0.52.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR:

* Updates the `changelog.ts` with the changes included in tag `0.52.1`
* Bump the version of the `@serlo/authorization`, `@types/graphql-modules`, `@serlo/api.serlo.org` and `@serlo/api` packages to  `0.52.1 ` using [`scripts/update_version.sh`](https://github.com/serlo/api.serlo.org/blob/main/scripts/update_version.sh).\

<details>
<summary>Why?</summary>
Given that various dependencies have been updated since the <a href="https://github.com/serlo/api.serlo.org/releases/tag/v0.52.0">last 0.52.0 release</a>, it may be healthy, to catch any possible issues sooner, to release a new version of the api and deploy it to staging ✨ 
</details>

<details>
<summary>Commits to be released</summary>
See the diff <a href="https://github.com/serlo/api.serlo.org/compare/v0.52.0...9284379">here.</a>
</details>
