### PR TITLE
Use node version from .tool-versions in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
           registry-url: 'https://registry.npmjs.org'
       - run: yarn --immutable --immutable-cache
       - run: yarn build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'
       - run: gcloud auth configure-docker
       - uses: google-github-actions/setup-gcloud@v1
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn deploy:images
   npm-package:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
           cache: yarn
           node-version-file: .tool-versions
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn build
       - run: echo //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} > .npmrc
         env:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache --check-cache
   build:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn build
       - run: yarn build:server
       - run: yarn build:swr-queue-worker
@@ -35,7 +35,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn lint:eslint
   prettier:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn lint:prettier
   tsc:
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn lint:tsc
   test:
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn start:redis
       - run: yarn test
   codegen:
@@ -76,7 +76,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn codegen
       - id: changes
         uses: UnicornGlobal/has-changes-action@v1.0.12

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache --check-cache
   build:
     runs-on: ubuntu-latest
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn build
       - run: yarn build:server
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn lint:eslint
   prettier:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn lint:prettier
   tsc:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn lint:tsc
   test:
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn start:redis
       - run: yarn test
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn codegen
       - id: changes

--- a/.github/workflows/pact-broker.yml
+++ b/.github/workflows/pact-broker.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn start:redis
       - run: yarn pacts
       - run: yarn pacts:publish

--- a/.github/workflows/pact-broker.yml
+++ b/.github/workflows/pact-broker.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn start:redis
       - run: yarn pacts

--- a/.github/workflows/pacts.yml
+++ b/.github/workflows/pacts.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           cache: yarn
           node-version-file: .tool-versions
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn start:redis
       - run: yarn pacts

--- a/.github/workflows/pacts.yml
+++ b/.github/workflows/pacts.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 18.x
+          node-version-file: .tool-versions
       - run: yarn --immutable --immutable-cache
       - run: yarn start:redis
       - run: yarn pacts


### PR DESCRIPTION
To bring more consistency to the version of Node.js used in CI and locally. 

Additionally, added a `cache: yarn` input that was missing in one job and added the `--check-cache` option when running yarn.

---

Follow up of https://github.com/serlo/api.serlo.org/pull/947.