### PR TITLE
feat: Allow architect to sort entities

### DIFF
--- a/packages/server/src/schema/authorization/roles.ts
+++ b/packages/server/src/schema/authorization/roles.ts
@@ -55,6 +55,7 @@ const roleDefinitions: Record<Role, RoleDefinition> = {
   [Role.Architect]: {
     permissions: [
       Permission.Entity_RemoveChild,
+      Permission.Entity_OrderChildren,
       Permission.TaxonomyTerm_Change,
       Permission.TaxonomyTerm_OrderChildren,
       Permission.TaxonomyTerm_RemoveChild,


### PR DESCRIPTION
It fixes the bug described at https://trello.com/c/MvWAe9gT/256-no-sorting-option-for-architect,
since frontend currently uses this permission to allow also sorting
taxonomies. But above all, it makes sense that architect may do such
things.
