### PR TITLE
refactor: Simplify code inside the loop

### DIFF
--- a/packages/server/src/schema/thread/resolvers.ts
+++ b/packages/server/src/schema/thread/resolvers.ts
@@ -370,10 +370,8 @@ async function assertUserIsAuthorizedOrTookPartInDiscussion({
   } catch {
     for (const thread of threads) {
       if (
-        thread.commentPayloads.some((comment) => comment.authorId === userId)
+        !thread.commentPayloads.some((comment) => comment.authorId === userId)
       ) {
-        continue
-      } else {
         throw new ForbiddenError(message)
       }
     }


### PR DESCRIPTION
To remove the usage of `continue`.

Follow up of https://github.com/serlo/api.serlo.org/pull/1028.