### PR TITLE
fix(enmeshed): fix econnreset between connector and mongodb

### DIFF
--- a/enmeshed/docker-compose.yml
+++ b/enmeshed/docker-compose.yml
@@ -19,8 +19,7 @@ services:
 
   enmeshed-mongodb:
     container_name: enmeshed-mongodb
-    # See https://github.com/docker-library/mongo/issues/485 for usage of tag 4.4.6.
-    image: mongo:4.4.6
+    image: mongo:latest
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: password


### PR DESCRIPTION
As it is recommended
(see https://enmeshed.eu/integrate/connector-installation#mongodb)
we should use always the latest version of mongodb.


