### PR TITLE
refactor: Remove exerciseFolder as raw type from data source

### DIFF
--- a/packages/server/src/model/decoder.ts
+++ b/packages/server/src/model/decoder.ts
@@ -253,7 +253,6 @@ export const TaxonomyTermTypeDecoder = t.union([
   t.literal(TaxonomyTermType.Root),
   t.literal(TaxonomyTermType.Subject),
   t.literal(TaxonomyTermType.Topic),
-  t.literal(TaxonomyTermType.ExerciseFolder),
 ])
 
 export const TaxonomyTermDecoder = t.exact(

--- a/packages/server/src/schema/uuid/taxonomy-term/resolvers.ts
+++ b/packages/server/src/schema/uuid/taxonomy-term/resolvers.ts
@@ -26,7 +26,6 @@ const typesMap = {
   subject: TaxonomyTermType.Subject,
   topicFolder: TaxonomyTermType.ExerciseFolder,
   curriculumTopicFolder: TaxonomyTermType.ExerciseFolder,
-  exerciseFolder: TaxonomyTermType.ExerciseFolder,
   topic: TaxonomyTermType.Topic,
   // fallbacks
   blog: TaxonomyTermType.Topic,


### PR DESCRIPTION
As we can see in https://github.com/serlo/database-layer/blob/main/server/src/uuid/model/taxonomy_term/mod.rs#L29
the database layer doesn't output exerciseFolder as taxonomy type. So these lines are unnecessary.
