### PR TITLE
chore(prettier): Store prettier config in JSON

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,0 @@
-// eslint-disable-next-line import/no-default-export
-export default {
-  semi: false,
-  singleQuote: true,
-}


### PR DESCRIPTION
After changing the repo to ESM the prettier config couldn't be loaded for me (prettier responded with `ERR_REQUIRE_ESM` in my IDE). This fixes this bug for me.