### PR TITLE
refactor: Remove unused user endpoints like `activeAuthors`

### DIFF
--- a/__tests__/schema/uuid/user.ts
+++ b/__tests__/schema/uuid/user.ts
@@ -18,14 +18,11 @@ import {
   givenSpreadsheet,
   hasInternalServerError,
   nextUuid,
-  returnsJson,
-  returnsMalformedJson,
   given,
   Client,
 } from '../../__utils__'
 import { Model } from '~/internals/graphql'
 import { MajorDimension } from '~/model'
-import { castToUuid } from '~/model/decoder'
 import { Instance } from '~/types'
 
 const client = new Client()
@@ -558,133 +555,6 @@ describe('User', () => {
     })
   })
 })
-
-describe('endpoint activeAuthors', () => {
-  test('returns list of active authors', async () => {
-    given('ActiveAuthorsQuery').returns([user.id, user2.id])
-
-    await expectUserIds({ endpoint: 'activeAuthors', ids: [user.id, user2.id] })
-  })
-
-  test('returns only users', async () => {
-    given('ActiveAuthorsQuery').returns([user.id, article.id])
-    given('UuidQuery').for(article)
-
-    await expectUserIds({ endpoint: 'activeAuthors', ids: [user.id] })
-    await assertErrorEvent({ errorContext: { invalidElements: [article] } })
-  })
-})
-
-describe('endpoint activeReviewers', () => {
-  test('returns list of active reviewers', async () => {
-    given('ActiveReviewersQuery').returns([user.id, user2.id])
-
-    await expectUserIds({
-      endpoint: 'activeReviewers',
-      ids: [user.id, user2.id],
-    })
-  })
-
-  test('returns only users', async () => {
-    given('ActiveReviewersQuery').returns([user.id, article.id])
-    given('UuidQuery').for(article)
-
-    await expectUserIds({ endpoint: 'activeReviewers', ids: [user.id] })
-    await assertErrorEvent({ errorContext: { invalidElements: [article] } })
-  })
-})
-
-describe('endpoint activeDonors', () => {
-  test('returns list of users', async () => {
-    givenActiveDonors([user, user2])
-    given('UuidQuery').for(user2)
-
-    await expectUserIds({ endpoint: 'activeDonors', ids: [user.id, user2.id] })
-  })
-
-  test('returned list only contains user', async () => {
-    givenActiveDonors([user, article])
-    given('UuidQuery').for(article)
-
-    await expectUserIds({ endpoint: 'activeDonors', ids: [user.id] })
-    await assertErrorEvent({ errorContext: { invalidElements: [article] } })
-  })
-
-  describe('parser', () => {
-    test('removes entries which are no valid uuids', async () => {
-      givenActiveDonorsSpreadsheet([['Header', '23', 'foo', '-1', '', '1.5']])
-
-      await expectUserIds({ endpoint: 'activeDonors', ids: [23] })
-      await assertErrorEvent({
-        message: 'invalid entry in activeDonorSpreadsheet',
-        errorContext: { invalidElements: ['foo', '-1', '', '1.5'] },
-      })
-    })
-
-    test('cell entries are trimmed of leading and trailing whitespaces', async () => {
-      givenActiveDonorsSpreadsheet([['Header', ' 10 ', '  20']])
-
-      await expectUserIds({ endpoint: 'activeDonors', ids: [10, 20] })
-    })
-
-    describe('returns empty list', () => {
-      test('when spreadsheet is empty', async () => {
-        givenActiveDonorsSpreadsheet([[]])
-
-        await expectUserIds({ endpoint: 'activeDonors', ids: [] })
-      })
-
-      test('when spreadsheet api responds with invalid json data', async () => {
-        givenSpreadheetApi(returnsJson({ json: {} }))
-
-        await expectUserIds({ endpoint: 'activeDonors', ids: [] })
-        await assertErrorEvent()
-      })
-
-      test('when spreadsheet api responds with malformed json', async () => {
-        givenSpreadheetApi(returnsMalformedJson())
-
-        await expectUserIds({ endpoint: 'activeDonors', ids: [] })
-        await assertErrorEvent()
-      })
-
-      test('when spreadsheet api has an internal server error', async () => {
-        givenSpreadheetApi(hasInternalServerError())
-
-        await expectUserIds({ endpoint: 'activeDonors', ids: [] })
-        await assertErrorEvent()
-      })
-    })
-  })
-})
-
-async function expectUserIds({
-  endpoint,
-  ids,
-}: {
-  endpoint: 'activeReviewers' | 'activeAuthors' | 'activeDonors'
-  ids: number[]
-}) {
-  ids.map(castToUuid).forEach((id) => given('UuidQuery').for({ ...user, id }))
-  const nodes = ids.map((id) => {
-    return { __typename: 'User', id }
-  })
-
-  await new Client()
-    .prepareQuery({
-      query: gql`
-      query {
-        ${endpoint} {
-          nodes {
-            __typename
-            id
-          }
-        }
-      }
-    `,
-    })
-    .shouldReturnData({ [endpoint]: { nodes } })
-}
 
 function givenActiveDonors(users: Model<'AbstractUuid'>[]) {
   const values = [['Header', ...users.map((user) => user.id.toString())]]

--- a/packages/server/src/schema/uuid/user/types.graphql
+++ b/packages/server/src/schema/uuid/user/types.graphql
@@ -55,24 +55,6 @@ type User implements AbstractUuid & ThreadAware {
 }
 
 extend type Query {
-  activeAuthors(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): UserConnection!
-  activeDonors(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): UserConnection!
-  activeReviewers(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): UserConnection!
   user: UserQuery!
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1822,9 +1822,6 @@ export type PageRevisionCursor = {
 
 export type Query = {
   __typename?: 'Query';
-  activeAuthors: UserConnection;
-  activeDonors: UserConnection;
-  activeReviewers: UserConnection;
   ai: AiQuery;
   authorization: Scalars['JSON']['output'];
   entity?: Maybe<EntityQuery>;
@@ -1840,30 +1837,6 @@ export type Query = {
   user: UserQuery;
   uuid?: Maybe<Applet | AppletRevision | Article | ArticleRevision | Comment | Course | CoursePage | CoursePageRevision | CourseRevision | Event | EventRevision | Exercise | ExerciseGroup | ExerciseGroupRevision | ExerciseRevision | GroupedExercise | GroupedExerciseRevision | Page | PageRevision | TaxonomyTerm | User | Video | VideoRevision>;
   version: Scalars['String']['output'];
-};
-
-
-export type QueryActiveAuthorsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryActiveDonorsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryActiveReviewersArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -4405,9 +4378,6 @@ export type PageRevisionCursorResolvers<ContextType = Context, ParentType extend
 };
 
 export type QueryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  activeAuthors?: Resolver<ResolversTypes['UserConnection'], ParentType, ContextType, Partial<QueryActiveAuthorsArgs>>;
-  activeDonors?: Resolver<ResolversTypes['UserConnection'], ParentType, ContextType, Partial<QueryActiveDonorsArgs>>;
-  activeReviewers?: Resolver<ResolversTypes['UserConnection'], ParentType, ContextType, Partial<QueryActiveReviewersArgs>>;
   ai?: Resolver<ResolversTypes['AiQuery'], ParentType, ContextType>;
   authorization?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
   entity?: Resolver<Maybe<ResolversTypes['EntityQuery']>, ParentType, ContextType>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1818,9 +1818,6 @@ export type PageRevisionCursor = {
 
 export type Query = {
   __typename?: 'Query';
-  activeAuthors: UserConnection;
-  activeDonors: UserConnection;
-  activeReviewers: UserConnection;
   ai: AiQuery;
   authorization: Scalars['JSON']['output'];
   entity?: Maybe<EntityQuery>;
@@ -1836,30 +1833,6 @@ export type Query = {
   user: UserQuery;
   uuid?: Maybe<AbstractUuid>;
   version: Scalars['String']['output'];
-};
-
-
-export type QueryActiveAuthorsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryActiveDonorsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryActiveReviewersArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 


### PR DESCRIPTION
See https://kulla.github.io/2023-11-10-unused-graphql-properties-at-serlo/report.html#Query.activeAuthors

@elbotho @Entkenntnis Can you double check that the report is right?