### PR TITLE
fix(auth-script): Improve resiliency and prevent unwanted line truncation

### DIFF
--- a/scripts/authenticate.sh
+++ b/scripts/authenticate.sh
@@ -2,31 +2,54 @@
 
 source scripts/utils.sh
 
-if [ -z $1 ]; then
-  user_id=1
-else
-  user_id=$1
+user_id=${1:-1}
+
+auth_file="packages/server/src/internals/server/graphql-middleware.ts"
+
+# backup the original file if not already backed up
+backup_file="${auth_file}.bak"
+if [ ! -f "$backup_file" ]; then
+    cp "$auth_file" "$backup_file"
 fi
 
-auth_file=packages/server/src/internals/server/graphql-middleware.ts
+# Trap Ctrl+C (SIGINT) to execute the restore function
+trap restore_graphql_middleware SIGINT
 
-body_of_context_method='113,138d'
-
-sed -i -e $body_of_context_method $auth_file
-sed -i "s/context({ req }): Promise<Pick<Context, 'service' | 'userId'>> {/context(): Promise<Pick<Context, 'service' | 'userId'>> {return Promise.resolve({ service: Service.SerloCloudflareWorker,userId: $user_id,}) }/" $auth_file
+awk -v user_id="$user_id" '
+BEGIN { printing = 1; replaced = 0 }
+/async context\(\{ req \}\): Promise<Context> {/,/return \{ ...partialContext, dataSources, googleStorage \}/ {
+    if (printing && /async context\(\{ req \}\): Promise<Context> {/) {
+        printing = 0
+        replaced = 1
+        print "      async context(): Promise<Context> {"
+        print "        const googleStorage = new Storage();"
+        print "        const dataSources = {"
+        print "          model: new ModelDataSource(environment),"
+        print "        };"
+        print "        return Promise.resolve({"
+        print "          service: Service.SerloCloudflareWorker,"
+        print "          userId: " user_id ","
+        print "          googleStorage,"
+        print "          dataSources,"
+        print "        });"
+    }
+    if (/return \{ ...partialContext, dataSources, googleStorage \}/ && replaced) {
+        printing = 1
+    }
+    next
+}
+printing { print }
+' "$auth_file" > temp_file && mv temp_file "$auth_file"
 
 print_header "Authenticated as user with id $user_id"
-echo "The file '$auth_file' was changed in order to allow authentication."
+echo "The file '$auth_file' was changed to allow authentication."
 echo "Important: Do not commit this file!"
 echo "If you are editing this file, do not use this script!"
 echo "Exit: ctrl+C"
 
-trap restore_graphql_middleware SIGINT
-
 function restore_graphql_middleware() {
-  echo
-  echo "Restoring '$auth_file' to original state"
-  git restore $auth_file
+    echo "Restoring '$auth_file' to original state"
+    cp "$backup_file" "$auth_file"
 }
 
-sleep 99999m
+sleep infinity


### PR DESCRIPTION
I haven't used this script before but running `yarn auth` cuts off the `graphql-middleware.ts` file very nastily as it had the loc to be replaced hard coded.

The script now tries to find the part that needs to be replaced.

Also create a backup file (.bak) to be able to restore uncommitted changes of the middleware file.

