### PR TITLE
refactor(graphql): add licenseId to all types that have license field

### DIFF
--- a/__fixtures__/index.ts
+++ b/__fixtures__/index.ts
@@ -1,3 +1,3 @@
-export * from './license'
+export * from './license-id'
 export * from './notification'
 export * from './uuid'

--- a/__fixtures__/license-id.ts
+++ b/__fixtures__/license-id.ts
@@ -1,0 +1,1 @@
+export const licenseId = 1

--- a/__fixtures__/license.ts
+++ b/__fixtures__/license.ts
@@ -1,3 +1,0 @@
-export const license = {
-  id: 1,
-}

--- a/__fixtures__/uuid/applet.ts
+++ b/__fixtures__/uuid/applet.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -19,7 +19,7 @@ export const applet: Model<'Applet'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(35597),
   revisionIds: [35597].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   canonicalSubjectId: castToUuid(23593),
   taxonomyTermIds: [5].map(castToUuid),
 }

--- a/__fixtures__/uuid/article.ts
+++ b/__fixtures__/uuid/article.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -18,7 +18,7 @@ export const article: Model<'Article'> = {
   alias: castToAlias('/mathe/1855/parabel'),
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(30674),
-  licenseId: license.id,
+  licenseId,
   taxonomyTermIds: [5].map(castToUuid),
   revisionIds: [30674].map(castToUuid),
   canonicalSubjectId: castToUuid(5),
@@ -32,7 +32,7 @@ export const article2: Model<'Article'> = {
   alias: castToAlias('/mathe/1495/addition'),
   date: '2014-03-01T20:36:44Z',
   currentRevisionId: castToUuid(32614),
-  licenseId: license.id,
+  licenseId,
   taxonomyTermIds: [17744].map(castToUuid),
   revisionIds: [32614].map(castToUuid),
   canonicalSubjectId: castToUuid(17744),

--- a/__fixtures__/uuid/course-page.ts
+++ b/__fixtures__/uuid/course-page.ts
@@ -1,6 +1,6 @@
 import { course } from './course'
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -20,7 +20,7 @@ export const coursePage: Model<'CoursePage'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(19277),
   revisionIds: [19277].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   parentId: course.id,
   canonicalSubjectId: castToUuid(5),
 }

--- a/__fixtures__/uuid/course.ts
+++ b/__fixtures__/uuid/course.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -19,7 +19,7 @@ export const course: Model<'Course'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(30713),
   revisionIds: [30713].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   taxonomyTermIds: [5].map(castToUuid),
   pageIds: [18521].map(castToUuid),
   canonicalSubjectId: castToUuid(5),

--- a/__fixtures__/uuid/event.ts
+++ b/__fixtures__/uuid/event.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -19,7 +19,7 @@ export const event: Model<'Event'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(35555),
   revisionIds: [35555].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   taxonomyTermIds: [5].map(castToUuid),
   canonicalSubjectId: castToUuid(5),
 }

--- a/__fixtures__/uuid/exercise-group.ts
+++ b/__fixtures__/uuid/exercise-group.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -19,7 +19,7 @@ export const exerciseGroup: Model<'ExerciseGroup'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(2218),
   revisionIds: [2218].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   taxonomyTermIds: [5].map(castToUuid),
   exerciseIds: [2219].map(castToUuid),
   canonicalSubjectId: castToUuid(5),

--- a/__fixtures__/uuid/exercise.ts
+++ b/__fixtures__/uuid/exercise.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -19,7 +19,7 @@ export const exercise: Model<'Exercise'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(29638),
   revisionIds: [29638].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   taxonomyTermIds: [5].map(castToUuid),
   canonicalSubjectId: castToUuid(5),
 }

--- a/__fixtures__/uuid/grouped-exercise.ts
+++ b/__fixtures__/uuid/grouped-exercise.ts
@@ -1,6 +1,6 @@
 import { exerciseGroup } from './exercise-group'
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import { Payload } from '~/internals/model'
 import {
@@ -27,7 +27,7 @@ export const groupedExercise: Model<'GroupedExercise'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(2220),
   revisionIds: [2220].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   parentId: exerciseGroup.id,
   canonicalSubjectId: castToUuid(5),
 }

--- a/__fixtures__/uuid/page.ts
+++ b/__fixtures__/uuid/page.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import { castToAlias, castToUuid, DiscriminatorType } from '~/model/decoder'
 import { Instance } from '~/types'
@@ -13,7 +13,7 @@ export const page: Model<'Page'> = {
   date: '2015-02-28T02:06:40Z',
   currentRevisionId: castToUuid(35476),
   revisionIds: [35476].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
 }
 
 export const pageRevision: Model<'PageRevision'> = {

--- a/__fixtures__/uuid/video.ts
+++ b/__fixtures__/uuid/video.ts
@@ -1,5 +1,5 @@
 import { user } from './user'
-import { license } from '../license'
+import { licenseId } from '../license-id'
 import { Model } from '~/internals/graphql'
 import {
   castToAlias,
@@ -19,7 +19,7 @@ export const video: Model<'Video'> = {
   date: '2014-03-01T20:45:56Z',
   currentRevisionId: castToUuid(16114),
   revisionIds: [16114].map(castToUuid),
-  licenseId: license.id,
+  licenseId,
   taxonomyTermIds: [5].map(castToUuid),
   canonicalSubjectId: castToUuid(5),
 }

--- a/__tests__/schema/entity/set.ts
+++ b/__tests__/schema/entity/set.ts
@@ -24,6 +24,7 @@ import {
   exerciseGroupRevision,
   groupedExerciseRevision,
   videoRevision,
+  licenseId,
 } from '../../../__fixtures__'
 import { given, Client, nextUuid, getTypenameAndId } from '../../__utils__'
 import { autoreviewTaxonomyIds } from '~/config'
@@ -223,7 +224,7 @@ testCases.forEach((testCase) => {
       input: {
         changes,
         needsReview,
-        licenseId: 1,
+        licenseId,
         subscribeThis,
         subscribeThisByEmail,
         fields: testCase.fieldsToDBLayer,

--- a/__tests__/schema/entity/update-license.ts
+++ b/__tests__/schema/entity/update-license.ts
@@ -47,16 +47,14 @@ test('returns "{ success: true }" when mutation could be successfully executed',
         query ($id: Int!) {
           uuid(id: $id) {
             ... on Article {
-              license {
-                id
-              }
+              licenseId
             }
           }
         }
       `,
     })
     .withVariables({ id: article.id })
-    .shouldReturnData({ uuid: { license: { id: newLicenseId } } })
+    .shouldReturnData({ uuid: { licenseId: newLicenseId } })
 })
 
 test('fails when user is not authenticated', async () => {

--- a/__tests__/schema/uuid/abstract-repository.ts
+++ b/__tests__/schema/uuid/abstract-repository.ts
@@ -18,7 +18,7 @@ import {
   exerciseRevision,
   groupedExercise,
   groupedExerciseRevision,
-  license,
+  licenseId,
   page,
   pageRevision,
   user,
@@ -222,16 +222,14 @@ describe('Repository', () => {
             query license($id: Int!) {
               uuid(id: $id) {
                 ... on AbstractRepository {
-                  license {
-                    id
-                  }
+                  licenseId
                 }
               }
             }
           `,
         })
         .withVariables({ id: repository.id })
-        .shouldReturnData({ uuid: { license } })
+        .shouldReturnData({ uuid: { licenseId } })
     },
   )
 

--- a/__tests__/schema/uuid/page.ts
+++ b/__tests__/schema/uuid/page.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 import * as R from 'ramda'
 
-import { page, pageRevision, license } from '../../../__fixtures__'
+import { page, pageRevision, licenseId } from '../../../__fixtures__'
 import { given, Client } from '../../__utils__'
 
 describe('Page', () => {
@@ -39,16 +39,14 @@ describe('Page', () => {
           query page($id: Int!) {
             uuid(id: $id) {
               ... on Page {
-                license {
-                  id
-                }
+                licenseId
               }
             }
           }
         `,
       })
       .withVariables(page)
-      .shouldReturnData({ uuid: { license } })
+      .shouldReturnData({ uuid: { licenseId } })
   })
 })
 

--- a/packages/server/src/schema/uuid/abstract-entity/types.graphql
+++ b/packages/server/src/schema/uuid/abstract-entity/types.graphql
@@ -17,6 +17,7 @@ interface AbstractEntity {
   alias: String!
   title: String!
   license: License!
+  licenseId: Int!
   subject: Subject
 }
 

--- a/packages/server/src/schema/uuid/abstract-entity/utils.ts
+++ b/packages/server/src/schema/uuid/abstract-entity/utils.ts
@@ -19,7 +19,7 @@ export function createEntityResolvers<
   revisionDecoder: t.Type<R, unknown>
 }): PickResolvers<
   'AbstractEntity',
-  'alias' | 'threads' | 'license' | 'events' | 'subject' | 'title'
+  'alias' | 'threads' | 'license' | 'licenseId' | 'events' | 'subject' | 'title'
 > &
   // TODO: Add threads to "AbstractEntity"
   PickResolvers<'AbstractRepository', 'threads'> & {

--- a/packages/server/src/schema/uuid/abstract-exercise/types.graphql
+++ b/packages/server/src/schema/uuid/abstract-exercise/types.graphql
@@ -7,6 +7,7 @@ interface AbstractExercise {
   alias: String!
   title: String!
   license: License!
+  licenseId: Int!
   currentRevision: AbstractExerciseRevision
   events(
     after: String

--- a/packages/server/src/schema/uuid/abstract-repository/types.graphql
+++ b/packages/server/src/schema/uuid/abstract-repository/types.graphql
@@ -26,6 +26,7 @@ interface AbstractRepository {
   date: DateTime!
   instance: Instance!
   license: License!
+  licenseId: Int!
   # Implicitly has the following field
   # currentRevision: AbstractRevision
 }

--- a/packages/server/src/schema/uuid/abstract-repository/utils.ts
+++ b/packages/server/src/schema/uuid/abstract-repository/utils.ts
@@ -22,7 +22,7 @@ export function createRepositoryResolvers<R extends Model<'AbstractRevision'>>({
   revisionDecoder: t.Type<R, unknown>
 }): PickResolvers<
   'AbstractRepository',
-  'alias' | 'threads' | 'license' | 'events' | 'title'
+  'alias' | 'threads' | 'license' | 'licenseId' | 'events' | 'title'
 > & {
   currentRevision: ResolverFunction<
     R | null,
@@ -82,6 +82,9 @@ export function createRepositoryResolvers<R extends Model<'AbstractRevision'>>({
       return {
         id: repository.licenseId,
       }
+    },
+    licenseId(repository, _args) {
+      return repository.licenseId
     },
   }
 }

--- a/packages/server/src/schema/uuid/abstract-taxonomy-term-child/types.graphql
+++ b/packages/server/src/schema/uuid/abstract-taxonomy-term-child/types.graphql
@@ -15,6 +15,7 @@ interface AbstractTaxonomyTermChild {
   date: DateTime!
   instance: Instance!
   license: License!
+  licenseId: Int!
   taxonomyTerms(
     after: String
     before: String

--- a/packages/server/src/schema/uuid/applet/types.graphql
+++ b/packages/server/src/schema/uuid/applet/types.graphql
@@ -22,6 +22,7 @@ type Applet implements AbstractUuid & AbstractRepository & AbstractEntity & Abst
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: AppletRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/article/types.graphql
+++ b/packages/server/src/schema/uuid/article/types.graphql
@@ -22,6 +22,7 @@ type Article implements AbstractUuid & AbstractRepository & AbstractEntity & Abs
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: ArticleRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/course-page/types.graphql
+++ b/packages/server/src/schema/uuid/course-page/types.graphql
@@ -22,6 +22,7 @@ type CoursePage implements AbstractUuid & AbstractRepository & AbstractEntity & 
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: CoursePageRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/course/types.graphql
+++ b/packages/server/src/schema/uuid/course/types.graphql
@@ -22,6 +22,7 @@ type Course implements AbstractUuid & AbstractRepository & AbstractEntity & Abst
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: CourseRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/event/types.graphql
+++ b/packages/server/src/schema/uuid/event/types.graphql
@@ -22,6 +22,7 @@ type Event implements AbstractUuid & AbstractRepository & AbstractEntity & Abstr
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: EventRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/exercise-group/types.graphql
+++ b/packages/server/src/schema/uuid/exercise-group/types.graphql
@@ -22,6 +22,7 @@ type ExerciseGroup implements AbstractUuid & AbstractRepository & AbstractEntity
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: ExerciseGroupRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/exercise/types.graphql
+++ b/packages/server/src/schema/uuid/exercise/types.graphql
@@ -22,6 +22,7 @@ type Exercise implements AbstractUuid & AbstractRepository & AbstractEntity & Ab
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: ExerciseRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/grouped-exercise/types.graphql
+++ b/packages/server/src/schema/uuid/grouped-exercise/types.graphql
@@ -22,6 +22,7 @@ type GroupedExercise implements AbstractUuid & AbstractRepository & AbstractEnti
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: GroupedExerciseRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/page/types.graphql
+++ b/packages/server/src/schema/uuid/page/types.graphql
@@ -22,6 +22,7 @@ type Page implements AbstractUuid & AbstractRepository & InstanceAware & ThreadA
   alias: String!
   title: String!
   license: License!
+  licenseId: Int!
   currentRevision: PageRevision
   revisions(
     after: String

--- a/packages/server/src/schema/uuid/video/types.graphql
+++ b/packages/server/src/schema/uuid/video/types.graphql
@@ -22,6 +22,7 @@ type Video implements AbstractUuid & AbstractRepository & AbstractEntity & Abstr
   title: String!
   date: DateTime!
   license: License!
+  licenseId: Int!
   currentRevision: VideoRevision
   revisions(
     after: String

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -28,6 +28,7 @@ export type AbstractEntity = {
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   subject?: Maybe<Subject>;
   title: Scalars['String']['output'];
   trashed: Scalars['Boolean']['output'];
@@ -86,6 +87,7 @@ export type AbstractExercise = {
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   title: Scalars['String']['output'];
   trashed: Scalars['Boolean']['output'];
 };
@@ -150,6 +152,7 @@ export type AbstractRepository = {
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   threads: ThreadsConnection;
   title: Scalars['String']['output'];
   trashed: Scalars['Boolean']['output'];
@@ -214,6 +217,7 @@ export type AbstractTaxonomyTermChild = {
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   taxonomyTerms: TaxonomyTermConnection;
   title: Scalars['String']['output'];
   trashed: Scalars['Boolean']['output'];
@@ -301,6 +305,7 @@ export type Applet = AbstractEntity & AbstractRepository & AbstractTaxonomyTermC
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: AppletRevisionConnection;
   subject?: Maybe<Subject>;
   taxonomyTerms: TaxonomyTermConnection;
@@ -400,6 +405,7 @@ export type Article = AbstractEntity & AbstractRepository & AbstractTaxonomyTerm
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: ArticleRevisionConnection;
   subject?: Maybe<Subject>;
   taxonomyTerms: TaxonomyTermConnection;
@@ -567,6 +573,7 @@ export type Course = AbstractEntity & AbstractRepository & AbstractTaxonomyTermC
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   pages: Array<CoursePage>;
   revisions: CourseRevisionConnection;
   subject?: Maybe<Subject>;
@@ -629,6 +636,7 @@ export type CoursePage = AbstractEntity & AbstractRepository & AbstractUuid & In
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: CoursePageRevisionConnection;
   subject?: Maybe<Subject>;
   threads: ThreadsConnection;
@@ -998,6 +1006,7 @@ export type Event = AbstractEntity & AbstractRepository & AbstractTaxonomyTermCh
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: EventRevisionConnection;
   subject?: Maybe<Subject>;
   taxonomyTerms: TaxonomyTermConnection;
@@ -1109,6 +1118,7 @@ export type Exercise = AbstractEntity & AbstractExercise & AbstractRepository & 
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: ExerciseRevisionConnection;
   subject?: Maybe<Subject>;
   taxonomyTerms: TaxonomyTermConnection;
@@ -1164,6 +1174,7 @@ export type ExerciseGroup = AbstractEntity & AbstractRepository & AbstractTaxono
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: ExerciseGroupRevisionConnection;
   subject?: Maybe<Subject>;
   taxonomyTerms: TaxonomyTermConnection;
@@ -1318,6 +1329,7 @@ export type GroupedExercise = AbstractEntity & AbstractExercise & AbstractReposi
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: GroupedExerciseRevisionConnection;
   subject?: Maybe<Subject>;
   threads: ThreadsConnection;
@@ -1576,6 +1588,7 @@ export type Page = AbstractRepository & AbstractUuid & InstanceAware & ThreadAwa
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: PageRevisionConnection;
   threads: ThreadsConnection;
   title: Scalars['String']['output'];
@@ -2673,6 +2686,7 @@ export type Video = AbstractEntity & AbstractRepository & AbstractTaxonomyTermCh
   id: Scalars['Int']['output'];
   instance: Instance;
   license: License;
+  licenseId: Scalars['Int']['output'];
   revisions: VideoRevisionConnection;
   subject?: Maybe<Subject>;
   taxonomyTerms: TaxonomyTermConnection;
@@ -3264,6 +3278,7 @@ export type AbstractEntityResolvers<ContextType = Context, ParentType extends Re
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   trashed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -3304,6 +3319,7 @@ export type AbstractExerciseResolvers<ContextType = Context, ParentType extends 
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   trashed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 };
@@ -3351,6 +3367,7 @@ export type AbstractRepositoryResolvers<ContextType = Context, ParentType extend
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   threads?: Resolver<ResolversTypes['ThreadsConnection'], ParentType, ContextType, Partial<AbstractRepositoryThreadsArgs>>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   trashed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -3377,6 +3394,7 @@ export type AbstractTaxonomyTermChildResolvers<ContextType = Context, ParentType
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   taxonomyTerms?: Resolver<ResolversTypes['TaxonomyTermConnection'], ParentType, ContextType, Partial<AbstractTaxonomyTermChildTaxonomyTermsArgs>>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   trashed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -3426,6 +3444,7 @@ export type AppletResolvers<ContextType = Context, ParentType extends ResolversP
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['AppletRevisionConnection'], ParentType, ContextType, Partial<AppletRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   taxonomyTerms?: Resolver<ResolversTypes['TaxonomyTermConnection'], ParentType, ContextType, Partial<AppletTaxonomyTermsArgs>>;
@@ -3468,6 +3487,7 @@ export type ArticleResolvers<ContextType = Context, ParentType extends Resolvers
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['ArticleRevisionConnection'], ParentType, ContextType, Partial<ArticleRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   taxonomyTerms?: Resolver<ResolversTypes['TaxonomyTermConnection'], ParentType, ContextType, Partial<ArticleTaxonomyTermsArgs>>;
@@ -3548,6 +3568,7 @@ export type CourseResolvers<ContextType = Context, ParentType extends ResolversP
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   pages?: Resolver<Array<ResolversTypes['CoursePage']>, ParentType, ContextType, Partial<CoursePagesArgs>>;
   revisions?: Resolver<ResolversTypes['CourseRevisionConnection'], ParentType, ContextType, Partial<CourseRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
@@ -3567,6 +3588,7 @@ export type CoursePageResolvers<ContextType = Context, ParentType extends Resolv
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['CoursePageRevisionConnection'], ParentType, ContextType, Partial<CoursePageRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   threads?: Resolver<ResolversTypes['ThreadsConnection'], ParentType, ContextType, Partial<CoursePageThreadsArgs>>;
@@ -3780,6 +3802,7 @@ export type EventResolvers<ContextType = Context, ParentType extends ResolversPa
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['EventRevisionConnection'], ParentType, ContextType, Partial<EventRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   taxonomyTerms?: Resolver<ResolversTypes['TaxonomyTermConnection'], ParentType, ContextType, Partial<EventTaxonomyTermsArgs>>;
@@ -3834,6 +3857,7 @@ export type ExerciseResolvers<ContextType = Context, ParentType extends Resolver
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['ExerciseRevisionConnection'], ParentType, ContextType, Partial<ExerciseRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   taxonomyTerms?: Resolver<ResolversTypes['TaxonomyTermConnection'], ParentType, ContextType, Partial<ExerciseTaxonomyTermsArgs>>;
@@ -3852,6 +3876,7 @@ export type ExerciseGroupResolvers<ContextType = Context, ParentType extends Res
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['ExerciseGroupRevisionConnection'], ParentType, ContextType, Partial<ExerciseGroupRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   taxonomyTerms?: Resolver<ResolversTypes['TaxonomyTermConnection'], ParentType, ContextType, Partial<ExerciseGroupTaxonomyTermsArgs>>;
@@ -3929,6 +3954,7 @@ export type GroupedExerciseResolvers<ContextType = Context, ParentType extends R
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['GroupedExerciseRevisionConnection'], ParentType, ContextType, Partial<GroupedExerciseRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   threads?: Resolver<ResolversTypes['ThreadsConnection'], ParentType, ContextType, Partial<GroupedExerciseThreadsArgs>>;
@@ -4077,6 +4103,7 @@ export type PageResolvers<ContextType = Context, ParentType extends ResolversPar
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['PageRevisionConnection'], ParentType, ContextType, Partial<PageRevisionsArgs>>;
   threads?: Resolver<ResolversTypes['ThreadsConnection'], ParentType, ContextType, Partial<PageThreadsArgs>>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -4578,6 +4605,7 @@ export type VideoResolvers<ContextType = Context, ParentType extends ResolversPa
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
   license?: Resolver<ResolversTypes['License'], ParentType, ContextType>;
+  licenseId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   revisions?: Resolver<ResolversTypes['VideoRevisionConnection'], ParentType, ContextType, Partial<VideoRevisionsArgs>>;
   subject?: Resolver<Maybe<ResolversTypes['Subject']>, ParentType, ContextType>;
   taxonomyTerms?: Resolver<ResolversTypes['TaxonomyTermConnection'], ParentType, ContextType, Partial<VideoTaxonomyTermsArgs>>;


### PR DESCRIPTION
Since moving the license data to the frontend having a `License` type with one field does not make sense.
This is a small change, but I like keeping the api clean and It's also good to do stuff like this from time to time so I don't forget how it works 😉.

This is step one: Add a new field, the idea is that this PR can be deployed without risk at any time
When the frontend is then adapted we can remove the `license` in the next PR.

intended change for both steps:
``` diff
{
  uuid(id: 277272) {
    ... on Article {
-      license {
-        id
-      }
+      licenseId
    }
  }
}
