### PR TITLE
fix: Read MYSQL_URI env var after loading .env

### DIFF
--- a/packages/server/src/model/database.ts
+++ b/packages/server/src/model/database.ts
@@ -3,12 +3,13 @@ import * as mysql from 'mysql2/promise'
 import { log } from '../internals/log'
 import { UserInputError } from '~/errors'
 
-const pool = mysql.createPool(process.env.MYSQL_URI)
 
 export const runSql = async <T extends mysql.RowDataPacket>(
   query: string,
   params?: unknown[] | undefined,
 ): Promise<T[]> => {
+  const pool = mysql.createPool(process.env.MYSQL_URI)
+
   let connection: mysql.PoolConnection | null = null
   try {
     connection = await pool.getConnection()


### PR DESCRIPTION
Since the server/index.ts imports the database.ts file and just then loads the .env file, it hasn't read the MYSQL_URI yet. So yarn start hasn't worked so far because of that.
It works in the deployments, because they use real env vars.

An even better solution is to make the pool in a createDatabase function, that gets called only at the datasources.
