### PR TITLE
fix: filter empty values in Active Donnors spreadsheet

### DIFF
--- a/packages/server/src/schema/uuid/user/resolvers.ts
+++ b/packages/server/src/schema/uuid/user/resolvers.ts
@@ -474,6 +474,7 @@ function extractIDsFromFirstColumn(
       }),
     ),
     E.map((rows) => rows.slice(1).map(R.trim)),
+    E.map((rows) => rows.filter(row => row)),
     E.map(
       assertAll({
         assertion: (entry) => /^\d+$/.test(entry),

--- a/packages/server/src/schema/uuid/user/resolvers.ts
+++ b/packages/server/src/schema/uuid/user/resolvers.ts
@@ -474,7 +474,7 @@ function extractIDsFromFirstColumn(
       }),
     ),
     E.map((rows) => rows.slice(1).map(R.trim)),
-    E.map((rows) => rows.filter(row => row)),
+    E.map((rows) => rows.filter((row) => row)),
     E.map(
       assertAll({
         assertion: (entry) => /^\d+$/.test(entry),


### PR DESCRIPTION
From 6th March until now we got a lot of errors of kind 
`Error: invalid entry in activeDonorSpreadsheet`
It happened because there is an empty string in the middle of the column in the spreadsheet.
Filtering it solves the issue.

