### PR TITLE
refactor!: remove cohesive field from ExerciseGroup

### DIFF
--- a/__fixtures__/uuid/exercise-group.ts
+++ b/__fixtures__/uuid/exercise-group.ts
@@ -18,7 +18,6 @@ export const exerciseGroupRevision: Model<'ExerciseGroupRevision'> = {
   date: '2014-09-15T15:28:35Z',
   authorId: user.id,
   repositoryId: exerciseGroupId,
-  cohesive: false,
   content: castToNonEmptyString('content'),
   changes: 'changes',
 }

--- a/__tests__/schema/entity/set.ts
+++ b/__tests__/schema/entity/set.ts
@@ -35,7 +35,6 @@ import { Instance } from '~/types'
 
 interface EntityFields {
   title: string
-  cohesive: boolean
   content: string
   description: string
   metaTitle: string
@@ -45,7 +44,6 @@ interface EntityFields {
 
 const ALL_POSSIBLE_FIELDS: EntityFields = {
   title: 'title',
-  cohesive: false,
   content: 'content',
   description: 'description',
   metaTitle: 'metaTitle',
@@ -69,7 +67,7 @@ const fieldKeys: Record<
   [EntityType.CoursePage]: ['title', 'content'],
   [EntityType.Event]: ['title', 'content', 'metaTitle', 'metaDescription'],
   [EntityType.Exercise]: ['content'],
-  [EntityType.ExerciseGroup]: ['cohesive', 'content'],
+  [EntityType.ExerciseGroup]: ['content'],
   [EntityType.Video]: ['title', 'content', 'url'],
 }
 const entities = [
@@ -114,7 +112,6 @@ class EntitySetTestCase {
   get fieldsToDBLayer() {
     if (this.entityType === EntityType.ExerciseGroup) {
       return {
-        cohesive: this.fields.cohesive!.toString(),
         content: this.fields.content!,
       }
     } else if (this.entityType === EntityType.Course) {

--- a/__tests__/schema/uuid/exercise-group.ts
+++ b/__tests__/schema/uuid/exercise-group.ts
@@ -48,7 +48,6 @@ describe('ExerciseGroup', () => {
                 id
                 trashed
                 date
-                cohesive
                 content
                 changes
               }
@@ -59,15 +58,7 @@ describe('ExerciseGroup', () => {
       .withVariables({ id: exerciseGroupRevision.id })
       .shouldReturnData({
         uuid: R.pick(
-          [
-            '__typename',
-            'id',
-            'trashed',
-            'date',
-            'cohesive',
-            'content',
-            'changes',
-          ],
+          ['__typename', 'id', 'trashed', 'date', 'content', 'changes'],
           exerciseGroupRevision,
         ),
       })

--- a/packages/server/src/model/decoder.ts
+++ b/packages/server/src/model/decoder.ts
@@ -339,7 +339,6 @@ export const ExerciseGroupRevisionDecoder = t.exact(
     AbstractEntityRevisionDecoder,
     t.type({
       __typename: t.literal(EntityRevisionType.ExerciseGroupRevision),
-      cohesive: t.boolean,
     }),
   ]),
 )

--- a/packages/server/src/schema/uuid/abstract-entity/entity-set-handler.ts
+++ b/packages/server/src/schema/uuid/abstract-entity/entity-set-handler.ts
@@ -21,7 +21,6 @@ export interface SetAbstractEntityInput {
   needsReview: boolean
   entityId?: number
   parentId?: number
-  cohesive?: boolean
   content?: string
   description?: string
   metaDescription?: string
@@ -58,7 +57,6 @@ export function createSetEntityResolver({
       input,
     )
     const fieldKeys = [
-      'cohesive',
       'content',
       'description',
       'metaDescription',

--- a/packages/server/src/schema/uuid/abstract-entity/types.graphql
+++ b/packages/server/src/schema/uuid/abstract-entity/types.graphql
@@ -63,7 +63,6 @@ interface AbstractEntityRevision {
   metaDescription: String
 
   url: String
-  cohesive: Boolean
 }
 
 type AbstractEntityConnection {
@@ -202,7 +201,6 @@ input SetExerciseGroupInput {
   entityId: Int
   parentId: Int
 
-  cohesive: Boolean!
   content: String!
 }
 

--- a/packages/server/src/schema/uuid/applet/types.graphql
+++ b/packages/server/src/schema/uuid/applet/types.graphql
@@ -71,7 +71,6 @@ type AppletRevision implements AbstractUuid & AbstractRevision & AbstractEntityR
   metaDescription: String!
 
   url: String!
-  cohesive: Boolean
 }
 
 type AppletRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/schema/uuid/article/types.graphql
+++ b/packages/server/src/schema/uuid/article/types.graphql
@@ -71,7 +71,6 @@ type ArticleRevision implements AbstractUuid & AbstractRevision & AbstractEntity
   metaDescription: String!
 
   url: String
-  cohesive: Boolean
 }
 
 type ArticleRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/schema/uuid/course-page/types.graphql
+++ b/packages/server/src/schema/uuid/course-page/types.graphql
@@ -66,7 +66,6 @@ type CoursePageRevision implements AbstractUuid & AbstractRevision & AbstractEnt
   metaDescription: String
 
   url: String
-  cohesive: Boolean
 }
 
 type CoursePageRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/schema/uuid/course/types.graphql
+++ b/packages/server/src/schema/uuid/course/types.graphql
@@ -72,7 +72,6 @@ type CourseRevision implements AbstractUuid & AbstractRevision & AbstractEntityR
   metaDescription: String!
 
   url: String
-  cohesive: Boolean
 }
 
 type CourseRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/schema/uuid/event/types.graphql
+++ b/packages/server/src/schema/uuid/event/types.graphql
@@ -70,7 +70,6 @@ type EventRevision implements AbstractUuid & AbstractRevision & AbstractEntityRe
   metaDescription: String!
 
   url: String
-  cohesive: Boolean
 }
 
 type EventRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/schema/uuid/exercise-group/types.graphql
+++ b/packages/server/src/schema/uuid/exercise-group/types.graphql
@@ -71,7 +71,6 @@ type ExerciseGroupRevision implements AbstractUuid & AbstractRevision & Abstract
   metaDescription: String
 
   url: String
-  cohesive: Boolean!
 }
 
 type ExerciseGroupRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/schema/uuid/exercise/types.graphql
+++ b/packages/server/src/schema/uuid/exercise/types.graphql
@@ -71,7 +71,6 @@ type ExerciseRevision implements AbstractUuid & AbstractRevision & AbstractEntit
   metaDescription: String
 
   url: String
-  cohesive: Boolean
 }
 
 type ExerciseRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/schema/uuid/video/types.graphql
+++ b/packages/server/src/schema/uuid/video/types.graphql
@@ -71,7 +71,6 @@ type VideoRevision implements AbstractUuid & AbstractRevision & AbstractEntityRe
   metaDescription: String
 
   url: String!
-  cohesive: Boolean
 }
 
 type VideoRevisionConnection implements AbstractEntityRevisionConnection {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -71,7 +71,6 @@ export type AbstractEntityCursor = {
 export type AbstractEntityRevision = {
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -334,7 +333,6 @@ export type AppletRevision = AbstractEntityRevision & AbstractRevision & Abstrac
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -435,7 +433,6 @@ export type ArticleRevision = AbstractEntityRevision & AbstractRevision & Abstra
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -659,7 +656,6 @@ export type CoursePageRevision = AbstractEntityRevision & AbstractRevision & Abs
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -706,7 +702,6 @@ export type CourseRevision = AbstractEntityRevision & AbstractRevision & Abstrac
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -1040,7 +1035,6 @@ export type EventRevision = AbstractEntityRevision & AbstractRevision & Abstract
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -1208,7 +1202,6 @@ export type ExerciseGroupRevision = AbstractEntityRevision & AbstractRevision & 
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive: Scalars['Boolean']['output'];
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -1262,7 +1255,6 @@ export type ExerciseRevision = AbstractEntityRevision & AbstractRevision & Abstr
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -1849,7 +1841,6 @@ export type SetEventInput = {
 
 export type SetExerciseGroupInput = {
   changes: Scalars['String']['input'];
-  cohesive: Scalars['Boolean']['input'];
   content: Scalars['String']['input'];
   entityId?: InputMaybe<Scalars['Int']['input']>;
   needsReview: Scalars['Boolean']['input'];
@@ -2646,7 +2637,6 @@ export type VideoRevision = AbstractEntityRevision & AbstractRevision & Abstract
   alias: Scalars['String']['output'];
   author: User;
   changes: Scalars['String']['output'];
-  cohesive?: Maybe<Scalars['Boolean']['output']>;
   content: Scalars['String']['output'];
   date: Scalars['DateTime']['output'];
   events: AbstractNotificationEventConnection;
@@ -3206,7 +3196,6 @@ export type AbstractEntityRevisionResolvers<ContextType = Context, ParentType ex
   __resolveType: TypeResolveFn<'AppletRevision' | 'ArticleRevision' | 'CoursePageRevision' | 'CourseRevision' | 'EventRevision' | 'ExerciseGroupRevision' | 'ExerciseRevision' | 'VideoRevision', ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<AbstractEntityRevisionEventsArgs>>;
@@ -3343,7 +3332,6 @@ export type AppletRevisionResolvers<ContextType = Context, ParentType extends Re
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<AppletRevisionEventsArgs>>;
@@ -3385,7 +3373,6 @@ export type ArticleRevisionResolvers<ContextType = Context, ParentType extends R
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<ArticleRevisionEventsArgs>>;
@@ -3483,7 +3470,6 @@ export type CoursePageRevisionResolvers<ContextType = Context, ParentType extend
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<CoursePageRevisionEventsArgs>>;
@@ -3509,7 +3495,6 @@ export type CourseRevisionResolvers<ContextType = Context, ParentType extends Re
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<CourseRevisionEventsArgs>>;
@@ -3702,7 +3687,6 @@ export type EventRevisionResolvers<ContextType = Context, ParentType extends Res
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<EventRevisionEventsArgs>>;
@@ -3773,7 +3757,6 @@ export type ExerciseGroupRevisionResolvers<ContextType = Context, ParentType ext
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<ExerciseGroupRevisionEventsArgs>>;
@@ -3806,7 +3789,6 @@ export type ExerciseRevisionResolvers<ContextType = Context, ParentType extends 
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<ExerciseRevisionEventsArgs>>;
@@ -4460,7 +4442,6 @@ export type VideoRevisionResolvers<ContextType = Context, ParentType extends Res
   alias?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   changes?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  cohesive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   events?: Resolver<ResolversTypes['AbstractNotificationEventConnection'], ParentType, ContextType, Partial<VideoRevisionEventsArgs>>;


### PR DESCRIPTION
Again `tsc` breaks locally (node version does not matter as far as I tested).
I got it running with `export NODE_OPTIONS=--max-old-space-size=8192` but it still feels like some memory leak / circular type refs problem.