### PR TITLE
fix: Change kratos register endpoint to always sync accounts

### DIFF
--- a/__tests__/internals/kratos-middleware.ts
+++ b/__tests__/internals/kratos-middleware.ts
@@ -36,6 +36,7 @@ describe('Kratos middleware - register endpoint', () => {
       userId: 1,
       success: true,
     })
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     kratosMock.db.executeSingleQuery<Identity> = async () => {
       return Promise.resolve([
         {


### PR DESCRIPTION
So far, we tried to move the behavior of Kratos webhook to the frontend. But frontend needed first of all the kratos id of the user after its creation in kratos database. Sometimes, kratos responds without this id.
Now, I've changed the endpoint to just sync any account it finds without a legacy id.