### PR TITLE
refactor(metadata)!: Remove deprecated `entities`

### DIFF
--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -36,18 +36,6 @@ export const resolvers: Resolvers = {
         email: 'de@serlo.org',
       }
     },
-    /**
-     * TODO: Remove when property is not used any more by WLO and Datenraum (NBP).
-     *
-     * @deprecated
-     */
-    entities(parent, args, context, info) {
-      if (typeof resolvers.MetadataQuery?.resources === 'function') {
-        return resolvers.MetadataQuery.resources(parent, args, context, info)
-      } else {
-        throw new Error('Illegal State')
-      }
-    },
     async resources(_parent, payload, { database }) {
       // Change the default value of this variable whenever you change the
       // resolver in a way that any crawler should fetch all resources again

--- a/packages/server/src/schema/metadata/types.graphql
+++ b/packages/server/src/schema/metadata/types.graphql
@@ -3,15 +3,6 @@ extend type Query {
 }
 
 type MetadataQuery {
-  entities(
-    first: Int
-    after: String
-    instance: Instance
-    modifiedAfter: String
-  ): ResourceMetadataConnection!
-    @deprecated(
-      reason: "Please use the `resources` field instead. This property will be deleted."
-    )
   resources(
     first: Int
     after: String

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1127,19 +1127,9 @@ export type MediaUpload = {
 
 export type MetadataQuery = {
   __typename?: 'MetadataQuery';
-  /** @deprecated Please use the `resources` field instead. This property will be deleted. */
-  entities: ResourceMetadataConnection;
   publisher: Scalars['JSONObject']['output'];
   resources: ResourceMetadataConnection;
   version: Scalars['String']['output'];
-};
-
-
-export type MetadataQueryEntitiesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  instance?: InputMaybe<Instance>;
-  modifiedAfter?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -3135,7 +3125,6 @@ export type MediaUploadResolvers<ContextType = Context, ParentType extends Resol
 };
 
 export type MetadataQueryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['MetadataQuery'] = ResolversParentTypes['MetadataQuery']> = {
-  entities?: Resolver<ResolversTypes['ResourceMetadataConnection'], ParentType, ContextType, Partial<MetadataQueryEntitiesArgs>>;
   publisher?: Resolver<ResolversTypes['JSONObject'], ParentType, ContextType>;
   resources?: Resolver<ResolversTypes['ResourceMetadataConnection'], ParentType, ContextType, Partial<MetadataQueryResourcesArgs>>;
   version?: Resolver<ResolversTypes['String'], ParentType, ContextType>;


### PR DESCRIPTION
I created a new PR to avoid merge conflicts. You can merge this PR together with #1404 

The property can be deleted after WLO changed their crawler + we now use https://github.com/serlo/metadata-exports for Datenraum (their old crawler is not in use any more)