### PR TITLE
feat(metadata): Add caching of metadata queries

### DIFF
--- a/packages/server/src/cache.ts
+++ b/packages/server/src/cache.ts
@@ -141,6 +141,7 @@ export function createCache({ timer }: { timer: Timer }): Cache {
 
       await client.quit()
     },
+    keys: (pattern) => client.keys(pattern),
   }
 }
 
@@ -152,6 +153,7 @@ export function createEmptyCache(): Cache {
     ready: async () => {},
     flush: async () => {},
     quit: async () => {},
+    keys: () => Promise.resolve([]),
   }
 }
 
@@ -175,6 +177,7 @@ export function createNamespacedCache(cache: Cache, namespace: string): Cache {
     quit() {
       return cache.quit()
     },
+    keys: (pattern) => cache.keys(namespace + pattern),
   }
 }
 

--- a/packages/server/src/context/cache.ts
+++ b/packages/server/src/context/cache.ts
@@ -17,6 +17,7 @@ export interface Cache {
   ready(): Promise<void>
   flush(): Promise<void>
   quit(): Promise<void>
+  keys(pattern: string): Promise<string[]>
 }
 
 export enum Priority {


### PR DESCRIPTION
@hugotiburtino @AndreasHuber (and others who like to contribute as well). In this PR I started to add caching support for querying metadata.

The main idea (in order to enable caching support regardless on the `after` value passed to the query / regardless from which starting point a long list is accessed): We store chunks of the whole list in the cache which are indexed by the `after` value. Those chunks should have no "hole" in between, meaning that the `after` value of the next chunk is the id of the last element of the previous chunk. Instead of using the MySQL query, the stored chunks in Redis are accessed.

In local tests it decreases the amount of time needed to query the whole metadata API from `16s` to `3,5s`:

```
kulla @ sole ~/workspace/serlo/metadata-exports (HoyY2-kulla-2024-04-14-12-08)                                       
└─ $ ▶ for i in {1..10}; do time pipenv run python download_metadata.py /tmp/metadata.json; done                     
INFO: 8645 metadata records downloaded                                                                               
                                                                                                                     
real    0m16,080s                                                                                                    
user    0m1,804s                                                                                                     
sys     0m0,237s                                                                                                     
INFO: 8645 metadata records downloaded                                                                               
                                                                                                                     
real    0m3,737s                                                                                                     
user    0m1,617s                                                                                                     
sys     0m0,151s                                                                                                     
INFO: 8645 metadata records downloaded  
```

My question for you: Is the better performance worth the additional complexity of caching (please have a look at the implementation). Needed tasks for the PR to be mergable:

- [ ] Fix merge conflicts
- [ ] Store the new helper functions somewhere suitable
- [ ] Add decoder to check cached value
- [ ] Add job in the SWR-Queue worker to update the cache