### PR TITLE
refactor(database): Allow nested transaction as in `sqlx`

### DIFF
--- a/__tests__/schema/create-event.ts
+++ b/__tests__/schema/create-event.ts
@@ -13,7 +13,7 @@ describe('createEvent', () => {
   const basePayload = {
     actorId: user.id,
     eventType: EventType.CheckoutRevision,
-    instance_id: 1,
+    instanceId: 1,
     objectId: article.id,
     stringParameters: {},
     uuidParameters: {},

--- a/__tests__/schema/create-event.ts
+++ b/__tests__/schema/create-event.ts
@@ -58,10 +58,12 @@ describe('createEvent', () => {
   })
 
   test('creates event successfully with right payload', async () => {
+    // TODO: After removing getEvent() this needs to be rewritten
+
     const initialEventsNumber = await getEventsNumber()
 
     const event = await createEvent(basePayload, getContext())
-    expect(event.__typename).toBe(basePayload.type)
+    expect(event.type).toBe(basePayload.type)
     expect(event.actorId).toBe(basePayload.actorId)
     expect(event.objectId).toBe(basePayload.objectId)
     expect(event.instance).toBe(Instance.De)

--- a/__tests__/schema/create-event.ts
+++ b/__tests__/schema/create-event.ts
@@ -20,13 +20,13 @@ describe('createEvent', () => {
 
   test('fails if actor does not exist', async () => {
     await expect(
-      createEvent({ ...basePayload, actorId: 5 }, global.database),
+      createEvent({ ...basePayload, actorId: 5 }, getContext()),
     ).rejects.toThrow()
   })
 
   test('fails if object does not exist', async () => {
     await expect(
-      createEvent({ ...basePayload, objectId: 0 }, global.database),
+      createEvent({ ...basePayload, objectId: 0 }, getContext()),
     ).rejects.toThrow()
   })
 
@@ -40,7 +40,7 @@ describe('createEvent', () => {
     await expect(
       createEvent(
         { ...basePayload, parameters: { to: 'approved' } },
-        global.database,
+        getContext(),
       ),
     ).rejects.toThrow()
 
@@ -52,7 +52,7 @@ describe('createEvent', () => {
     await expect(
       createEvent(
         { ...basePayload, parameters: { object: 40000 } },
-        global.database,
+        getContext(),
       ),
     ).rejects.toThrow()
   })
@@ -60,7 +60,7 @@ describe('createEvent', () => {
   test('creates event successfully with right payload', async () => {
     const initialEventsNumber = await getEventsNumber()
 
-    const event = await createEvent(basePayload, database)
+    const event = await createEvent(basePayload, getContext())
     expect(event.__typename).toBe(basePayload.type)
     expect(event.actorId).toBe(basePayload.actorId)
     expect(event.objectId).toBe(basePayload.objectId)
@@ -85,4 +85,8 @@ async function getEventsNumber() {
       'SELECT count(*) AS n FROM event_log',
     )
   ).n
+}
+
+function getContext() {
+  return { database: global.database }
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node'
 import crypto from 'crypto'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { createPool, type Pool, type PoolConnection } from 'mysql2/promise'
+import { createPool, type Pool } from 'mysql2/promise'
 
 import {
   defaultSpreadsheetApi,
@@ -49,10 +49,8 @@ beforeAll(() => {
 })
 
 beforeEach(async () => {
-  global.transaction = await pool.getConnection()
-  await global.transaction.beginTransaction()
-
-  global.database = new Database(global.transaction)
+  global.database = new Database(global.pool)
+  await global.database.beginTransaction()
 
   const baseCache = createCache({ timer: global.timer })
   global.cache = createNamespacedCache(baseCache, generateRandomString(10))
@@ -79,8 +77,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await global.transaction.rollback()
-  global.transaction.release()
+  await global.database.rollbackAllTransactions()
 
   await flushSentry()
   global.server.resetHandlers()
@@ -131,6 +128,5 @@ declare global {
   var sentryEvents: Event[]
   var kratos: MockKratos
   var pool: Pool
-  var transaction: PoolConnection
   var database: Database
 }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1,22 +1,97 @@
 import {
+  type Pool,
+  type PoolConnection,
   type RowDataPacket,
-  type Connection,
   type ResultSetHeader,
 } from 'mysql2/promise'
 
 export class Database {
-  constructor(private connection: Connection) {}
+  private state: DatabaseState
+  private pool: Pool
+
+  constructor(pool: Pool) {
+    this.pool = pool
+    this.state = { type: 'OutsideOfTransaction' }
+  }
 
   public async beginTransaction() {
-    await this.connection.beginTransaction()
+    if (this.state.type === 'OutsideOfTransaction') {
+      const transaction = await this.pool.getConnection()
+      await transaction.beginTransaction()
+
+      this.state = { type: 'InsideTransaction', transaction }
+    } else {
+      const { transaction } = this.state
+      const newDepth =
+        this.state.type === 'InsideSavepoint' ? this.state.depth + 1 : 0
+
+      await transaction.execute(`SAVEPOINT _savepoint_${newDepth}`)
+
+      this.state = { type: 'InsideSavepoint', transaction, depth: newDepth }
+    }
   }
 
-  public async commitTransaction() {
-    await this.connection.commit()
+  public async commitLastTransaction() {
+    if (this.state.type === 'OutsideOfTransaction') return
+
+    const { transaction } = this.state
+
+    if (this.state.type === 'InsideTransaction') {
+      await transaction.commit()
+      transaction.release()
+
+      this.state = { type: 'OutsideOfTransaction' }
+    } else {
+      const { depth } = this.state
+
+      await transaction.execute(`RELEASE SAVEPOINT _savepoint_${depth}`)
+
+      this.state =
+        depth > 0
+          ? { type: 'InsideSavepoint', transaction, depth: depth - 1 }
+          : { type: 'InsideTransaction', transaction }
+    }
   }
 
-  public async rollbackTransaction() {
-    await this.connection.rollback()
+  public async rollbackLastTransaction() {
+    if (this.state.type === 'OutsideOfTransaction') return
+
+    const { transaction } = this.state
+
+    if (this.state.type === 'InsideTransaction') {
+      await this.commitAllTransactions()
+    } else {
+      const { depth } = this.state
+
+      await transaction.execute(`ROLLBACK TO SAVEPOINT _savepoint_${depth}`)
+
+      this.state =
+        depth > 0
+          ? { type: 'InsideSavepoint', transaction, depth: depth - 1 }
+          : { type: 'InsideTransaction', transaction }
+    }
+  }
+
+  public async commitAllTransactions() {
+    if (this.state.type === 'OutsideOfTransaction') return
+
+    const { transaction } = this.state
+
+    await transaction.commit()
+    transaction.release()
+
+    this.state = { type: 'OutsideOfTransaction' }
+  }
+
+  public async rollbackAllTransactions() {
+    if (this.state.type === 'OutsideOfTransaction') return
+
+    const { transaction } = this.state
+
+    await transaction.rollback()
+    transaction.release()
+
+    this.state = { type: 'OutsideOfTransaction' }
   }
 
   public async fetchAll<T = unknown>(
@@ -46,8 +121,31 @@ export class Database {
     sql: string,
     params?: unknown[],
   ): Promise<T> {
-    const [rows] = await this.connection.execute<T>(sql, params)
+    if (this.state.type === 'OutsideOfTransaction') {
+      const [rows] = await this.pool.execute<T>(sql, params)
 
-    return rows
+      return rows
+    } else {
+      const [rows] = await this.state.transaction.execute<T>(sql, params)
+
+      return rows
+    }
   }
+}
+
+type DatabaseState = OutsideOfTransaction | InsideTransaction | InsideSavepoint
+
+interface OutsideOfTransaction {
+  type: 'OutsideOfTransaction'
+}
+
+interface InsideTransaction {
+  type: 'InsideTransaction'
+  transaction: PoolConnection
+}
+
+interface InsideSavepoint {
+  type: 'InsideSavepoint'
+  transaction: PoolConnection
+  depth: number
 }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -25,7 +25,7 @@ export class Database {
       const newDepth =
         this.state.type === 'InsideSavepoint' ? this.state.depth + 1 : 0
 
-      await transaction.execute(`SAVEPOINT _savepoint_${newDepth}`)
+      await transaction.query(`SAVEPOINT _savepoint_${newDepth}`)
 
       this.state = { type: 'InsideSavepoint', transaction, depth: newDepth }
     }
@@ -44,7 +44,7 @@ export class Database {
     } else {
       const { depth } = this.state
 
-      await transaction.execute(`RELEASE SAVEPOINT _savepoint_${depth}`)
+      await transaction.query(`RELEASE SAVEPOINT _savepoint_${depth}`)
 
       this.state =
         depth > 0
@@ -63,7 +63,7 @@ export class Database {
     } else {
       const { depth } = this.state
 
-      await transaction.execute(`ROLLBACK TO SAVEPOINT _savepoint_${depth}`)
+      await transaction.query(`ROLLBACK TO SAVEPOINT _savepoint_${depth}`)
 
       this.state =
         depth > 0

--- a/packages/server/src/schema/notification/event.ts
+++ b/packages/server/src/schema/notification/event.ts
@@ -1,5 +1,4 @@
 import { Context } from '~/context'
-import { Database } from '~/database'
 import { Instance } from '~/types'
 
 export enum EventType {

--- a/packages/server/src/schema/notification/event.ts
+++ b/packages/server/src/schema/notification/event.ts
@@ -1,3 +1,4 @@
+import { Context } from '~/context'
 import { Database } from '~/database'
 import { Instance } from '~/types'
 
@@ -43,7 +44,7 @@ interface AbstractEvent {
 
 export async function createEvent(
   { type, actorId, objectId, instance, parameters }: AbstractEvent,
-  database: Database,
+  { database }: Pick<Context, 'database'>,
 ) {
   try {
     await database.beginTransaction()
@@ -90,7 +91,7 @@ export async function createEvent(
 
     const event = await getEvent(eventId, database)
 
-    await createNotifications(event, database)
+    await createNotifications(event, { database })
 
     await database.commitLastTransaction()
 
@@ -182,14 +183,14 @@ export async function getEvent(id: number, database: Database) {
   }
 }
 
-export async function createNotifications(
+async function createNotifications(
   event: {
     actorId: number
     id: number
     objectId: number
     uuidParameters: Record<string, number>
   },
-  database: Database,
+  { database }: Pick<Context, 'database'>,
 ) {
   const { objectId, actorId } = event
 

--- a/packages/server/src/schema/notification/event.ts
+++ b/packages/server/src/schema/notification/event.ts
@@ -26,7 +26,7 @@ export async function createEvent(
     eventType,
     actorId,
     objectId,
-    instance_id,
+    instanceId,
     stringParameters,
     uuidParameters,
   }: {
@@ -34,7 +34,7 @@ export async function createEvent(
     eventType: EventType
     actorId: number
     objectId: number
-    instance_id: number
+    instanceId: number
     stringParameters: Record<string, string>
     uuidParameters: Record<string, number>
   },
@@ -62,7 +62,7 @@ export async function createEvent(
         FROM event
         WHERE name = ?
     `,
-      [actorId, objectId, instance_id, eventType],
+      [actorId, objectId, instanceId, eventType],
     )
     const eventId = (
       await database.fetchOne<{ id: number }>('SELECT LAST_INSERT_ID() as id')

--- a/packages/server/src/schema/notification/event.ts
+++ b/packages/server/src/schema/notification/event.ts
@@ -47,7 +47,7 @@ export async function createEvent(
       actorId,
     ])
     if (!user) {
-      await database.rollbackTransaction()
+      await database.rollbackLastTransaction()
       return Promise.reject(
         new Error(
           'Event cannot be saved because the acting user does not exist.',
@@ -99,7 +99,7 @@ export async function createEvent(
         [uuidId],
       )
       if (!uuid) {
-        await database.rollbackTransaction()
+        await database.rollbackLastTransaction()
         return Promise.reject(
           new Error(
             `Event cannot be saved because uuid ${uuidId} in uuidParameters does not exist.`,
@@ -134,11 +134,11 @@ export async function createEvent(
 
     await createNotifications(event, database)
 
-    await database.commitTransaction()
+    await database.commitLastTransaction()
 
     return event
   } catch (error) {
-    await database.rollbackTransaction()
+    await database.rollbackLastTransaction()
     return Promise.reject(error)
   }
 }

--- a/packages/server/src/schema/notification/event.ts
+++ b/packages/server/src/schema/notification/event.ts
@@ -48,18 +48,6 @@ export async function createEvent(
   try {
     await database.beginTransaction()
 
-    const user = await database.fetchOne('SELECT *  FROM user  WHERE id = ?', [
-      actorId,
-    ])
-    if (!user) {
-      await database.rollbackLastTransaction()
-      return Promise.reject(
-        new Error(
-          'Event cannot be saved because the acting user does not exist.',
-        ),
-      )
-    }
-
     const { insertId: eventId } = await database.mutate(
       `
       INSERT INTO event_log (actor_id, event_id, uuid_id, instance_id)


### PR DESCRIPTION
See https://github.com/launchbadge/sqlx/blob/5d6c33ed65cc2d4671a9f569c565ab18f1ea67aa/sqlx-core/src/transaction.rs#L243-L268

@AndreasHuber @hugotiburtino I need your opinion how we deal with nested transactions, see https://github.com/serlo/api.serlo.org/pull/1432/files/e8a41a52084153decd0f0d4ca49a86578fb0f93f#diff-dcef7db992983244ebc60dab598429fde8f1edb912e8f9403b73b8d2a9442d00. This PR uses savepoints to allow nested transactions. We can also omit it but then need to be more conscious where we rollback / commit since it would be always a global commit / rollback...