### PR TITLE
test: Make MSW to bypass to DB-Layer

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -32,18 +32,7 @@ beforeAll(() => {
   global.timer = timer
   global.kratos = kratos
 
-  global.server.listen({
-    async onUnhandledRequest(req) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'Found an unhandled %s request to %s with body %s',
-        req.method,
-        req.url,
-        await req.text(),
-      )
-      return 'error'
-    },
-  })
+  global.server.listen({ onUnhandledRequest: 'bypass' })
 
   process.env.OPENAI_API_KEY = 'fake-test-key-we-are-mocking-responses'
 })


### PR DESCRIPTION
While implementing https://github.com/serlo/api.serlo.org/pull/1456 I found this bug in the tests: beforehand non mocked queries have not been forwarded to the local DB-layer => this might explain some problems we had with updating tests, ping @AndreasHuber @hugotiburtino 