### PR TITLE
refactor(database): Add fetchOptional() + better transaction handling

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -5,6 +5,8 @@ import {
   type ResultSetHeader,
 } from 'mysql2/promise'
 
+import { InternalServerError } from './errors'
+
 export class Database {
   private state: DatabaseState
   private pool: Pool
@@ -29,9 +31,26 @@ export class Database {
 
       this.state = { type: 'InsideSavepoint', transaction, depth: newDepth }
     }
+
+    let isComittedOrRollbacked = false
+
+    return {
+      commit: async () => {
+        if (!isComittedOrRollbacked) {
+          await this.commitLastTransaction()
+          isComittedOrRollbacked = true
+        }
+      },
+      rollback: async () => {
+        if (!isComittedOrRollbacked) {
+          await this.rollbackLastTransaction()
+          isComittedOrRollbacked = true
+        }
+      },
+    }
   }
 
-  public async commitLastTransaction() {
+  private async commitLastTransaction() {
     if (this.state.type === 'OutsideOfTransaction') return
 
     const { transaction } = this.state
@@ -53,13 +72,16 @@ export class Database {
     }
   }
 
-  public async rollbackLastTransaction() {
+  private async rollbackLastTransaction() {
     if (this.state.type === 'OutsideOfTransaction') return
 
     const { transaction } = this.state
 
     if (this.state.type === 'InsideTransaction') {
-      await this.commitAllTransactions()
+      await transaction.commit()
+      transaction.release()
+
+      this.state = { type: 'OutsideOfTransaction' }
     } else {
       const { depth } = this.state
 
@@ -70,17 +92,6 @@ export class Database {
           ? { type: 'InsideSavepoint', transaction, depth: depth - 1 }
           : { type: 'InsideTransaction', transaction }
     }
-  }
-
-  public async commitAllTransactions() {
-    if (this.state.type === 'OutsideOfTransaction') return
-
-    const { transaction } = this.state
-
-    await transaction.commit()
-    transaction.release()
-
-    this.state = { type: 'OutsideOfTransaction' }
   }
 
   public async rollbackAllTransactions() {
@@ -101,11 +112,22 @@ export class Database {
     return this.execute<(T & RowDataPacket)[]>(sql, params)
   }
 
-  public async fetchOne<T = unknown>(
+  public async fetchOptional<T = unknown>(
     sql: string,
     params?: unknown[],
   ): Promise<T> {
     const [result] = await this.execute<(T & RowDataPacket)[]>(sql, params)
+
+    return result
+  }
+
+  public async fetchOne<T = unknown>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T> {
+    const result = await this.fetchOptional<T>(sql, params)
+
+    if (result == null) throw new InternalServerError()
 
     return result
   }

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -18,6 +18,12 @@ export class UserInputError extends GraphQLError {
   }
 }
 
+export class InternalServerError extends GraphQLError {
+  constructor(message = '') {
+    super(message, { extensions: { code: 'INTERNAL_SERVER_ERROR' } })
+  }
+}
+
 export class InvalidCurrentValueError extends GraphQLError {
   constructor(
     public errorContext: {

--- a/packages/server/src/schema/events/event.ts
+++ b/packages/server/src/schema/events/event.ts
@@ -34,9 +34,9 @@ export async function createEvent(
   const abstractEventPayload = toDatabaseRepresentation(payload)
   const { type, actorId, objectId, instance } = abstractEventPayload
 
-  try {
-    await database.beginTransaction()
+  const transaction = await database.beginTransaction()
 
+  try {
     const { insertId: eventId } = await database.mutate(
       `
       INSERT INTO event_log (actor_id, event_id, uuid_id, instance_id)
@@ -84,10 +84,9 @@ export async function createEvent(
 
     await createNotifications(event, { database })
 
-    await database.commitLastTransaction()
-  } catch (error) {
-    await database.rollbackLastTransaction()
-    return Promise.reject(error)
+    await transaction.commit()
+  } finally {
+    await transaction.rollback()
   }
 }
 

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -153,7 +153,7 @@ async function resolveUuidFromDatabase(
   { id }: { id: number },
   context: Pick<Context, 'database'>,
 ): Promise<Model<'AbstractUuid'> | null> {
-  const baseUuid = await context.database.fetchOne(
+  const baseUuid = await context.database.fetchOptional(
     ` select
         uuid.id as id,
         uuid.trashed,


### PR DESCRIPTION
ping @hugotiburtino @AndreasHuber This enables a much safer way to work with transactions:

```typescript
const transaction = await database.beginTransaction()

try {
  // code here which eventually throws errors
  
  await transaction.commit()
} finally {
  await transaction.rollback()
}
```

Now we know for sure:

1. Each transaction is rollbacked (regardless of the code // errors we have at the end)
2. Now committed transaction is again rollbacked due to the check inside `rollback()`