### PR TITLE
test: Move taxonomyTermQuery to __utils__

### DIFF
--- a/__tests__/__utils__/index.ts
+++ b/__tests__/__utils__/index.ts
@@ -3,6 +3,7 @@ import * as R from 'ramda'
 export * from './assertions'
 export * from './handlers'
 export * from './services'
+export * from './query'
 
 export function getTypenameAndId(value: { __typename: string; id: number }) {
   return R.pick(['__typename', 'id'], value)

--- a/__tests__/__utils__/query.ts
+++ b/__tests__/__utils__/query.ts
@@ -1,0 +1,36 @@
+import gql from 'graphql-tag'
+
+import { Client } from './assertions'
+
+export const taxonomyTermQuery = new Client().prepareQuery({
+  query: gql`
+    query ($id: Int!) {
+      uuid(id: $id) {
+        __typename
+        ... on TaxonomyTerm {
+          id
+          trashed
+          type
+          instance
+          alias
+          title
+          name
+          description
+          weight
+          taxonomyId
+          path {
+            id
+          }
+          parent {
+            id
+          }
+          children {
+            nodes {
+              id
+            }
+          }
+        }
+      }
+    }
+  `,
+})

--- a/__tests__/schema/taxonomy-term/create-entity-links.ts
+++ b/__tests__/schema/taxonomy-term/create-entity-links.ts
@@ -1,8 +1,7 @@
 import gql from 'graphql-tag'
 
 import { exercise } from '../../../__fixtures__'
-import { Client } from '../../__utils__'
-import { taxonomyTermQuery } from '../uuid/taxonomy-term'
+import { Client, taxonomyTermQuery } from '../../__utils__'
 
 const input = {
   entityIds: [32321, 1855],

--- a/__tests__/schema/taxonomy-term/delete-entity-links.ts
+++ b/__tests__/schema/taxonomy-term/delete-entity-links.ts
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 
-import { Client } from '../../__utils__'
-import { taxonomyTermQuery } from '../uuid/taxonomy-term'
+import { Client, taxonomyTermQuery } from '../../__utils__'
 
 const input = {
   entityIds: [29910, 1501],

--- a/__tests__/schema/taxonomy-term/sort.ts
+++ b/__tests__/schema/taxonomy-term/sort.ts
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 
-import { Client } from '../../__utils__'
-import { taxonomyTermQuery } from '../uuid/taxonomy-term'
+import { Client, taxonomyTermQuery } from '../../__utils__'
 
 const input = {
   childrenIds: [18888, 18887, 21069, 18884, 23256, 18232, 18885, 18886],

--- a/__tests__/schema/uuid/taxonomy-term.ts
+++ b/__tests__/schema/uuid/taxonomy-term.ts
@@ -1,39 +1,4 @@
-import gql from 'graphql-tag'
-
-import { Client } from '../../__utils__'
-
-export const taxonomyTermQuery = new Client().prepareQuery({
-  query: gql`
-    query ($id: Int!) {
-      uuid(id: $id) {
-        __typename
-        ... on TaxonomyTerm {
-          id
-          trashed
-          type
-          instance
-          alias
-          title
-          name
-          description
-          weight
-          taxonomyId
-          path {
-            id
-          }
-          parent {
-            id
-          }
-          children {
-            nodes {
-              id
-            }
-          }
-        }
-      }
-    }
-  `,
-})
+import { taxonomyTermQuery } from '../../__utils__'
 
 test('TaxonomyTerm root', async () => {
   await taxonomyTermQuery.withVariables({ id: 3 }).shouldReturnData({


### PR DESCRIPTION
When a test file imports another one their tests are also executed when the file is called => So we move it to `__tests__/__utils__/`

I move it into an extra PR so that the other PRs are easier to review.