### PR TITLE
test(set-thread-status): remove dependency of test on certain ID

### DIFF
--- a/__tests__/schema/thread/set-thread-status.ts
+++ b/__tests__/schema/thread/set-thread-status.ts
@@ -70,21 +70,30 @@ test('status is actually changed', async function () {
     })
     .withVariables({ first: 1 })
 
-  await threadQuery.shouldReturnData({
+  const queryResult = await threadQuery.getData()
+  const data = queryResult as {
     thread: {
-      allThreads: { nodes: [{ id: 'dDM1MTYz', status: 'noStatus' }] },
-    },
-  })
+      allThreads: {
+        nodes: Array<{ id: string; status: string }>
+      }
+    }
+  }
+
+  const firstNode = data.thread.allThreads.nodes[0]
+  const queriedId = firstNode.id
+  const queriedStatus = firstNode.status
+
+  expect(queriedStatus).toBe('noStatus')
 
   await mutation
     .withContext({ userId: moderator.id })
-    .withInput({ id: 'dDM1MTYz', status: 'done' })
+    .withInput({ id: queriedId, status: 'done' })
     .shouldReturnData({
       thread: { setThreadStatus: { success: true } },
     })
 
   await threadQuery.shouldReturnData({
-    thread: { allThreads: { nodes: [{ id: 'dDM1MTYz', status: 'done' }] } },
+    thread: { allThreads: { nodes: [{ id: queriedId, status: 'done' }] } },
   })
 })
 

--- a/__tests__/schema/thread/set-thread-status.ts
+++ b/__tests__/schema/thread/set-thread-status.ts
@@ -68,7 +68,7 @@ test('status is actually changed', async function () {
         }
       `,
     })
-    .withVariables({ first: 1 })
+    .withVariables({ first: 3 })
 
   const queryResult = await threadQuery.getData()
   const data = queryResult as {
@@ -79,21 +79,24 @@ test('status is actually changed', async function () {
     }
   }
 
-  const firstNode = data.thread.allThreads.nodes[0]
-  const queriedId = firstNode.id
-  const queriedStatus = firstNode.status
-
-  expect(queriedStatus).toBe('noStatus')
+  const threadIDs = data.thread.allThreads.nodes.map((node) => {
+    expect(node.status).toBe('noStatus')
+    return node.id
+  })
 
   await mutation
     .withContext({ userId: moderator.id })
-    .withInput({ id: queriedId, status: 'done' })
+    .withInput({ id: threadIDs, status: 'done' })
     .shouldReturnData({
       thread: { setThreadStatus: { success: true } },
     })
 
   await threadQuery.shouldReturnData({
-    thread: { allThreads: { nodes: [{ id: queriedId, status: 'done' }] } },
+    thread: {
+      allThreads: {
+        nodes: threadIDs.map((id) => ({ id, status: 'done' })),
+      },
+    },
   })
 })
 


### PR DESCRIPTION
I did not feel comfortable without having a test for the mutation taking an array of IDs, as this was where the first implementation attempt had an error. I also made the test independent of the specific IDs.