### PR TITLE
chore: Set default cache type to "redis" for "yarn start"

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,8 @@ ROCKET_CHAT_API_AUTH_TOKEN=an-auth-token
 ROCKET_CHAT_URL=https://community.serlo.org/
 SERLO_ORG_DATABASE_LAYER_HOST=127.0.0.1:8080
 SERLO_ORG_SECRET=serlo.org-secret
-CACHE_TYPE=empty
+# Set the following value to `empty` to disable caching
+CACHE_TYPE=redis
 
 SERVER_HYDRA_HOST=http://localhost:4445
 SERVER_KRATOS_PUBLIC_HOST=http://localhost:4433


### PR DESCRIPTION
Having no caching was introduced to test the API together with the DB-Layer so that no request hits the cache. After merging DB-Layer into the API I find it more valuable to have caching enabled with "yarn start" to test how the system works actually in our infrastructure.