### PR TITLE
test: Rename "database" to "databaseForTests"

### DIFF
--- a/__tests__/__utils__/assertions.ts
+++ b/__tests__/__utils__/assertions.ts
@@ -42,7 +42,7 @@ export class Client {
             swrQueue: emptySwrQueue,
             authServices,
             timer: global.timer,
-            database: global.database,
+            database: global.databaseForTests,
           }),
         },
         service: this.context?.service ?? Service.SerloCloudflareWorker,
@@ -60,7 +60,7 @@ export class Client {
             }
           },
         } as unknown as Storage,
-        database: global.database,
+        database: global.databaseForTests,
         cache: global.cache,
         swrQueue: emptySwrQueue,
         authServices,

--- a/__tests__/schema/event-types.ts
+++ b/__tests__/schema/event-types.ts
@@ -80,7 +80,7 @@ test('adds a notification', async () => {
   const lastEvent = await getLastEvent()
 
   expect(
-    await database.fetchAll(
+    await databaseForTests.fetchAll(
       'select * from notification_event where event_log_id = ?',
       [lastEvent.id],
     ),
@@ -103,7 +103,7 @@ test('fails if object does not exist', async () => {
 test('fails if name from parameters is invalid', async () => {
   const initialEventsNumber = await getEventsNumber()
 
-  await global.database.mutate(
+  await global.databaseForTests.mutate(
     'delete from event_parameter_name where name = "discussion"',
   )
 
@@ -308,12 +308,12 @@ function getApiResult(event: Record<string, unknown>): Record<string, unknown> {
 
 async function getEventsNumber() {
   return (
-    await global.database.fetchOne<{ n: number }>(
+    await global.databaseForTests.fetchOne<{ n: number }>(
       'SELECT count(*) AS n FROM event_log',
     )
   ).n
 }
 
 function getContext() {
-  return { database: global.database }
+  return { database: global.databaseForTests }
 }

--- a/__tests__/schema/metadata.ts
+++ b/__tests__/schema/metadata.ts
@@ -71,7 +71,7 @@ describe('endpoint "resources"', () => {
   })
 
   test('shows description when it is set', async () => {
-    await global.database.mutate(`
+    await global.databaseForTests.mutate(`
       update entity_revision_field
       set value = "description for entity 2153"
       where id = 41509 and field = "meta_description";`)

--- a/__tests__/schema/notification.ts
+++ b/__tests__/schema/notification.ts
@@ -31,7 +31,7 @@ const query = new Client({ userId: 1194 }).prepareQuery({
 
 describe('notifications', () => {
   beforeEach(async () => {
-    await global.database.mutate(`
+    await global.databaseForTests.mutate(`
       update notification set seen = 1, email = 1,
       email_sent = 1 where id = 11599
     `)

--- a/__tests__/schema/thread/all-threads.ts
+++ b/__tests__/schema/thread/all-threads.ts
@@ -102,7 +102,7 @@ describe('allThreads', () => {
 
   test('parameter "instance"', async () => {
     // temporary solution because all comments in dump are German
-    await global.database.mutate(
+    await global.databaseForTests.mutate(
       `UPDATE comment SET instance_id = 2 WHERE id = ${comment1.id}`,
     )
 
@@ -115,7 +115,7 @@ describe('allThreads', () => {
         thread: { allThreads: { nodes: [comment1].map(getThreadData) } },
       })
 
-    await database.mutate(
+    await databaseForTests.mutate(
       `UPDATE comment SET instance_id = 1 WHERE id = ${comment1.id}`,
     )
   })

--- a/__tests__/schema/user/set-email.ts
+++ b/__tests__/schema/user/set-email.ts
@@ -21,7 +21,7 @@ const query = new Client({ userId: user.id })
 test('returns "{ success: true }" when mutation could be successfully executed', async () => {
   await query.shouldReturnData({ user: { setEmail: { success: true } } })
 
-  const { email } = await database.fetchOne<{ email: string }>(
+  const { email } = await databaseForTests.fetchOne<{ email: string }>(
     'select email from user where id = ?',
     [input.userId],
   )

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -38,8 +38,8 @@ beforeAll(() => {
 })
 
 beforeEach(async () => {
-  global.database = new Database(global.pool)
-  await global.database.beginTransaction()
+  global.databaseForTests = new Database(global.pool)
+  await global.databaseForTests.beginTransaction()
 
   const baseCache = createCache({ timer: global.timer })
   global.cache = createNamespacedCache(baseCache, generateRandomString(10))
@@ -66,7 +66,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await global.database.rollbackAllTransactions()
+  await global.databaseForTests.rollbackAllTransactions()
 
   await flushSentry()
   global.server.resetHandlers()
@@ -78,7 +78,7 @@ afterEach(async () => {
 
 afterAll(async () => {
   global.server.close()
-  await global.database.close()
+  await global.databaseForTests.close()
 })
 
 class MockTimer implements Timer {
@@ -118,5 +118,5 @@ declare global {
   var sentryEvents: Event[]
   var kratos: MockKratos
   var pool: Pool
-  var database: Database
+  var databaseForTests: Database
 }

--- a/packages/server/src/schema/thread/resolvers.ts
+++ b/packages/server/src/schema/thread/resolvers.ts
@@ -385,7 +385,7 @@ export const resolvers: Resolvers = {
       }
     },
     async setCommentState(_parent, payload, context) {
-      const { userId } = context
+      const { database, userId } = context
       const { id: ids, trashed } = payload.input
 
       const scopes = await Promise.all(


### PR DESCRIPTION
This avoids errors like #1512 where the global `database` object is used (which is only set during tests). Actually it might be better to not use globals variables in the tests but this should be an easy fix that such errors will not occur again.