### PR TITLE
fix(trash): remove cache after trashing and avoid repeated event

### DIFF
--- a/packages/server/src/schema/thread/resolvers.ts
+++ b/packages/server/src/schema/thread/resolvers.ts
@@ -417,18 +417,20 @@ export const resolvers: Resolvers = {
             throw new UserInputError('comment must have an instance')
           }
 
-          await setUuidState({ id, trashed }, context)
+          if (comment.trashed !== trashed) {
+            await setUuidState({ id, trashed }, context)
 
-          await createEvent(
-            {
-              __typename: NotificationEventType.SetThreadState,
-              actorId: userId,
-              archived: trashed,
-              threadId: comment.id,
-              instance,
-            },
-            context,
-          )
+            await createEvent(
+              {
+                __typename: NotificationEventType.SetThreadState,
+                actorId: userId,
+                archived: trashed,
+                threadId: comment.id,
+                instance,
+              },
+              context,
+            )
+          }
         }
 
         await transaction.commit()
@@ -483,18 +485,20 @@ export const resolvers: Resolvers = {
             throw new UserInputError('comment must have an instance')
           }
 
-          await setUuidState({ id, trashed }, context)
+          if (comment.trashed !== trashed) {
+            await setUuidState({ id, trashed }, context)
 
-          await createEvent(
-            {
-              __typename: NotificationEventType.SetThreadState,
-              actorId: userId,
-              archived: trashed,
-              threadId: comment.id,
-              instance,
-            },
-            context,
-          )
+            await createEvent(
+              {
+                __typename: NotificationEventType.SetThreadState,
+                actorId: userId,
+                archived: trashed,
+                threadId: comment.id,
+                instance,
+              },
+              context,
+            )
+          }
         }
 
         await transaction.commit()

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -137,11 +137,6 @@ export const resolvers: Resolvers = {
 
         await transaction.commit()
 
-        await UuidResolver.removeCacheEntries(
-          ids.map((id) => ({ id }), context),
-          context,
-        )
-
         return { success: true, query: {} }
       } finally {
         await transaction.rollback()

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -346,12 +346,13 @@ async function resolveUuidFromDatabase(
 
 export async function setUuidState(
   { id, trashed }: { id: number; trashed: boolean },
-  { database }: Pick<Context, 'database'>,
+  { database, cache }: Pick<Context, 'database' | 'cache'>,
 ) {
   await database.mutate('update uuid set trashed = ? where id = ?', [
     trashed ? 1 : 0,
     id,
   ])
+  await UuidResolver.removeCacheEntries([{ id }], { cache })
 }
 
 function getSortedList(listAsDict: t.TypeOf<typeof WeightedNumberList>) {

--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -121,18 +121,20 @@ export const resolvers: Resolvers = {
             context,
           })
 
-          await setUuidState({ id: object.id, trashed }, context)
+          if (object.trashed !== trashed) {
+            await setUuidState({ id: object.id, trashed }, context)
 
-          await createEvent(
-            {
-              __typename: NotificationEventType.SetUuidState,
-              actorId: userId,
-              instance: object.instance,
-              objectId: object.id,
-              trashed,
-            },
-            context,
-          )
+            await createEvent(
+              {
+                __typename: NotificationEventType.SetUuidState,
+                actorId: userId,
+                instance: object.instance,
+                objectId: object.id,
+                trashed,
+              },
+              context,
+            )
+          }
         }
 
         await transaction.commit()


### PR DESCRIPTION
It fixes the block regarding trashing comment/threads at #1514.
And minor improvement to avoid repeated trashing event.
