### PR TITLE
chore(docker): Force images to refetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "redis:list": "docker compose exec redis redis-cli KEYS '*'",
     "start": "run-s start:containers start:server",
     "start:enmeshed": "docker-compose -f enmeshed/docker-compose.yml up -d",
-    "start:containers": "docker compose up --detach",
+    "start:containers": "docker compose pull && docker compose up --detach --force-recreate",
     "start:kratos": "docker compose -f docker-compose.kratos.yml up --detach",
     "start:sso": "docker compose -f docker-compose.sso.yml up --detach",
     "start:server": "yarn _start packages/server/src/server.ts server.cjs",


### PR DESCRIPTION
I changed "yarn start:containers" so that images are refetched once the tag is changed or there is a new image. Should should avoid problems when one uses a lot of preleleases of the mysql image.