### PR TITLE
fix(taxonomy): use right event when unlinking entity from taxonomy

### DIFF
--- a/__fixtures__/notification.ts
+++ b/__fixtures__/notification.ts
@@ -74,18 +74,6 @@ export const createEntityLinkNotificationEvent: Model<'CreateEntityLinkNotificat
     childId: coursePage.id,
   }
 
-export const removeEntityLinkNotificationEvent: Model<'RemoveEntityLinkNotificationEvent'> =
-  {
-    __typename: NotificationEventType.RemoveEntityLink,
-    id: 55273,
-    instance: Instance.De,
-    date: '2014-03-01T20:45:56Z',
-    actorId: user.id,
-    objectId: coursePage.id,
-    parentId: course.id,
-    childId: coursePage.id,
-  }
-
 export const createEntityRevisionNotificationEvent: Model<'CreateEntityRevisionNotificationEvent'> =
   {
     __typename: NotificationEventType.CreateEntityRevision,

--- a/__tests__/schema/event-types.ts
+++ b/__tests__/schema/event-types.ts
@@ -13,7 +13,6 @@ import {
   createTaxonomyTermNotificationEvent,
   createThreadNotificationEvent,
   rejectRevisionNotificationEvent,
-  removeEntityLinkNotificationEvent,
   removeTaxonomyLinkNotificationEvent,
   setLicenseNotificationEvent,
   setTaxonomyParentNotificationEvent,
@@ -46,7 +45,6 @@ describe('creates event successfully with right payload', () => {
     createTaxonomyTermNotificationEvent,
     createThreadNotificationEvent,
     rejectRevisionNotificationEvent,
-    removeEntityLinkNotificationEvent,
     removeTaxonomyLinkNotificationEvent,
     setLicenseNotificationEvent,
     setTaxonomyParentNotificationEvent,
@@ -194,15 +192,6 @@ async function getLastEvent() {
                   id
                 }
                 reason
-              }
-
-              ... on RemoveEntityLinkNotificationEvent {
-                parent {
-                  id
-                }
-                child {
-                  id
-                }
               }
 
               ... on RemoveTaxonomyLinkNotificationEvent {

--- a/packages/server/src/model/decoder.ts
+++ b/packages/server/src/model/decoder.ts
@@ -449,7 +449,6 @@ export enum NotificationEventType {
   CreateTaxonomyLink = 'CreateTaxonomyLinkNotificationEvent',
   CreateThread = 'CreateThreadNotificationEvent',
   RejectRevision = 'RejectRevisionNotificationEvent',
-  RemoveEntityLink = 'RemoveEntityLinkNotificationEvent',
   RemoveTaxonomyLink = 'RemoveTaxonomyLinkNotificationEvent',
   SetLicense = 'SetLicenseNotificationEvent',
   SetTaxonomyTerm = 'SetTaxonomyTermNotificationEvent',
@@ -538,17 +537,6 @@ export const CreateEntityLinkNotificationEventDecoder = t.exact(
     AbstractNotificationEventDecoder,
     t.type({
       __typename: t.literal(NotificationEventType.CreateEntityLink),
-      parentId: t.number,
-      childId: t.number,
-    }),
-  ]),
-)
-
-export const RemoveEntityLinkNotificationEventDecoder = t.exact(
-  t.intersection([
-    AbstractNotificationEventDecoder,
-    t.type({
-      __typename: t.literal(NotificationEventType.RemoveEntityLink),
       parentId: t.number,
       childId: t.number,
     }),
@@ -649,7 +637,6 @@ export const NotificationEventDecoder = t.union([
   CreateTaxonomyLinkNotificationEventDecoder,
   CreateThreadNotificationEventDecoder,
   RejectRevisionNotificationEventDecoder,
-  RemoveEntityLinkNotificationEventDecoder,
   RemoveTaxonomyLinkNotificationEventDecoder,
   SetLicenseNotificationEventDecoder,
   SetTaxonomyTermNotificationEventDecoder,

--- a/packages/server/src/model/types.ts
+++ b/packages/server/src/model/types.ts
@@ -33,7 +33,6 @@ import {
   PageDecoder,
   PageRevisionDecoder,
   RejectRevisionNotificationEventDecoder,
-  RemoveEntityLinkNotificationEventDecoder,
   RemoveTaxonomyLinkNotificationEventDecoder,
   SetLicenseNotificationEventDecoder,
   SetTaxonomyParentNotificationEventDecoder,
@@ -107,9 +106,6 @@ export interface Models {
   >
   RejectRevisionNotificationEvent: t.TypeOf<
     typeof RejectRevisionNotificationEventDecoder
-  >
-  RemoveEntityLinkNotificationEvent: t.TypeOf<
-    typeof RemoveEntityLinkNotificationEventDecoder
   >
   SetLicenseNotificationEvent: t.TypeOf<
     typeof SetLicenseNotificationEventDecoder

--- a/packages/server/src/schema/event-types/resolvers.ts
+++ b/packages/server/src/schema/event-types/resolvers.ts
@@ -187,18 +187,6 @@ export const resolvers: Resolvers = {
     },
   },
 
-  RemoveEntityLinkNotificationEvent: {
-    ...createNotificationEventResolvers(),
-    async parent(event, _args, context) {
-      const id = event.parentId
-      return UuidResolver.resolveWithDecoder(EntityDecoder, { id }, context)
-    },
-    async child(event, _args, context) {
-      const id = event.childId
-      return UuidResolver.resolveWithDecoder(EntityDecoder, { id }, context)
-    },
-  },
-
   CreateEntityLinkNotificationEvent: {
     ...createNotificationEventResolvers(),
     async parent(event, _args, context) {

--- a/packages/server/src/schema/event-types/types.graphql
+++ b/packages/server/src/schema/event-types/types.graphql
@@ -127,16 +127,6 @@ type CreateTaxonomyTermNotificationEvent implements AbstractNotificationEvent & 
   taxonomyTerm: TaxonomyTerm!
 }
 
-type RemoveEntityLinkNotificationEvent implements AbstractNotificationEvent & InstanceAware {
-  id: Int!
-  instance: Instance!
-  date: DateTime!
-  actor: User!
-  objectId: Int!
-  parent: AbstractEntity!
-  child: AbstractEntity!
-}
-
 type CreateEntityLinkNotificationEvent implements AbstractNotificationEvent & InstanceAware {
   id: Int!
   instance: Instance!

--- a/packages/server/src/schema/events/event.ts
+++ b/packages/server/src/schema/events/event.ts
@@ -169,9 +169,7 @@ export function toGraphQLModel(
       __typename: NotificationEventType.SetLicense,
       repositoryId: event.objectId,
     }
-  } else if (
-    event.type === EventType.CreateEntityLink 
-  ) {
+  } else if (event.type === EventType.CreateEntityLink) {
     return {
       ...base,
       __typename: NotificationEventType.CreateEntityLink,
@@ -274,9 +272,7 @@ function toDatabaseRepresentation(
       type: EventType.SetLicense,
       objectId: event.repositoryId,
     }
-  } else if (
-    event.__typename === NotificationEventType.CreateEntityLink 
-  ) {
+  } else if (event.__typename === NotificationEventType.CreateEntityLink) {
     return {
       ...base,
       type: EventType.CreateEntityLink,

--- a/packages/server/src/schema/events/event.ts
+++ b/packages/server/src/schema/events/event.ts
@@ -14,7 +14,6 @@ enum EventType {
   CreateEntity = 'entity/create',
   SetLicense = 'license/object/set',
   CreateEntityLink = 'entity/link/create',
-  RemoveEntityLink = 'entity/link/remove',
   CreateEntityRevision = 'entity/revision/add',
   CheckoutRevision = 'entity/revision/checkout',
   RejectRevision = 'entity/revision/reject',
@@ -171,15 +170,11 @@ export function toGraphQLModel(
       repositoryId: event.objectId,
     }
   } else if (
-    event.type === EventType.CreateEntityLink ||
-    event.type === EventType.RemoveEntityLink
+    event.type === EventType.CreateEntityLink 
   ) {
     return {
       ...base,
-      __typename:
-        event.type === EventType.CreateEntityLink
-          ? NotificationEventType.CreateEntityLink
-          : NotificationEventType.RemoveEntityLink,
+      __typename: NotificationEventType.CreateEntityLink,
       childId: event.objectId,
       parentId: event.uuidParameter,
     }
@@ -280,15 +275,11 @@ function toDatabaseRepresentation(
       objectId: event.repositoryId,
     }
   } else if (
-    event.__typename === NotificationEventType.CreateEntityLink ||
-    event.__typename === NotificationEventType.RemoveEntityLink
+    event.__typename === NotificationEventType.CreateEntityLink 
   ) {
     return {
       ...base,
-      type:
-        event.__typename === NotificationEventType.CreateEntityLink
-          ? EventType.CreateEntityLink
-          : EventType.RemoveEntityLink,
+      type: EventType.CreateEntityLink,
       objectId: event.childId,
       uuidParameter: event.parentId,
     }
@@ -375,7 +366,6 @@ type GraphQLEventModels =
   | Model<'CreateEntityNotificationEvent'>
   | Model<'SetLicenseNotificationEvent'>
   | Model<'CreateEntityLinkNotificationEvent'>
-  | Model<'RemoveEntityLinkNotificationEvent'>
   | Model<'CreateEntityRevisionNotificationEvent'>
   | Model<'CheckoutRevisionNotificationEvent'>
   | Model<'RejectRevisionNotificationEvent'>
@@ -393,7 +383,6 @@ type PayloadForNewEvent =
   | Omit<Model<'CreateEntityNotificationEvent'>, 'id' | 'date' | 'objectId'>
   | Omit<Model<'SetLicenseNotificationEvent'>, 'id' | 'date' | 'objectId'>
   | Omit<Model<'CreateEntityLinkNotificationEvent'>, 'id' | 'date' | 'objectId'>
-  | Omit<Model<'RemoveEntityLinkNotificationEvent'>, 'id' | 'date' | 'objectId'>
   | Omit<
       Model<'CreateEntityRevisionNotificationEvent'>,
       'id' | 'date' | 'objectId'
@@ -446,10 +435,6 @@ const DatabaseEventRepresentations = {
   }),
   CreateEntityLink: getDatabaseRepresentationDecoder({
     type: EventType.CreateEntityLink,
-    parameters: t.type({ uuidParameter: t.number }),
-  }),
-  RemoveEntityLink: getDatabaseRepresentationDecoder({
-    type: EventType.RemoveEntityLink,
     parameters: t.type({ uuidParameter: t.number }),
   }),
   CreateEntityRevision: getDatabaseRepresentationDecoder({
@@ -509,7 +494,6 @@ export const DatabaseEventRepresentation: t.Type<DatabaseEventRepresentation> =
     DatabaseEventRepresentations.CreateTaxonomyLink,
     DatabaseEventRepresentations.CreateThread,
     DatabaseEventRepresentations.RejectRevision,
-    DatabaseEventRepresentations.RemoveEntityLink,
     DatabaseEventRepresentations.RemoveTaxonomyLink,
     DatabaseEventRepresentations.RestoreThread,
     DatabaseEventRepresentations.RestoreUuid,

--- a/packages/server/src/schema/uuid/taxonomy-term/resolvers.ts
+++ b/packages/server/src/schema/uuid/taxonomy-term/resolvers.ts
@@ -319,7 +319,7 @@ export const resolvers: Resolvers = {
 
           await createEvent(
             {
-              __typename: NotificationEventType.RemoveEntityLink,
+              __typename: NotificationEventType.RemoveTaxonomyLink,
               actorId: userId,
               instance: taxonomyTerm.instance,
               parentId: taxonomyTermId,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -78,7 +78,7 @@ export type AbstractNotificationEvent = {
 
 export type AbstractNotificationEventConnection = {
   __typename?: 'AbstractNotificationEventConnection';
-  nodes: Array<CheckoutRevisionNotificationEvent | CreateCommentNotificationEvent | CreateEntityLinkNotificationEvent | CreateEntityNotificationEvent | CreateEntityRevisionNotificationEvent | CreateTaxonomyLinkNotificationEvent | CreateTaxonomyTermNotificationEvent | CreateThreadNotificationEvent | RejectRevisionNotificationEvent | RemoveEntityLinkNotificationEvent | RemoveTaxonomyLinkNotificationEvent | SetLicenseNotificationEvent | SetTaxonomyParentNotificationEvent | SetTaxonomyTermNotificationEvent | SetThreadStateNotificationEvent | SetUuidStateNotificationEvent>;
+  nodes: Array<CheckoutRevisionNotificationEvent | CreateCommentNotificationEvent | CreateEntityLinkNotificationEvent | CreateEntityNotificationEvent | CreateEntityRevisionNotificationEvent | CreateTaxonomyLinkNotificationEvent | CreateTaxonomyTermNotificationEvent | CreateThreadNotificationEvent | RejectRevisionNotificationEvent | RemoveTaxonomyLinkNotificationEvent | SetLicenseNotificationEvent | SetTaxonomyParentNotificationEvent | SetTaxonomyTermNotificationEvent | SetThreadStateNotificationEvent | SetUuidStateNotificationEvent>;
   pageInfo: PageInfo;
 };
 
@@ -960,7 +960,7 @@ export type Notification = {
   __typename?: 'Notification';
   email: Scalars['Boolean']['output'];
   emailSent: Scalars['Boolean']['output'];
-  event?: Maybe<CheckoutRevisionNotificationEvent | CreateCommentNotificationEvent | CreateEntityLinkNotificationEvent | CreateEntityNotificationEvent | CreateEntityRevisionNotificationEvent | CreateTaxonomyLinkNotificationEvent | CreateTaxonomyTermNotificationEvent | CreateThreadNotificationEvent | RejectRevisionNotificationEvent | RemoveEntityLinkNotificationEvent | RemoveTaxonomyLinkNotificationEvent | SetLicenseNotificationEvent | SetTaxonomyParentNotificationEvent | SetTaxonomyTermNotificationEvent | SetThreadStateNotificationEvent | SetUuidStateNotificationEvent>;
+  event?: Maybe<CheckoutRevisionNotificationEvent | CreateCommentNotificationEvent | CreateEntityLinkNotificationEvent | CreateEntityNotificationEvent | CreateEntityRevisionNotificationEvent | CreateTaxonomyLinkNotificationEvent | CreateTaxonomyTermNotificationEvent | CreateThreadNotificationEvent | RejectRevisionNotificationEvent | RemoveTaxonomyLinkNotificationEvent | SetLicenseNotificationEvent | SetTaxonomyParentNotificationEvent | SetTaxonomyTermNotificationEvent | SetThreadStateNotificationEvent | SetUuidStateNotificationEvent>;
   id: Scalars['Int']['output'];
   unread: Scalars['Boolean']['output'];
 };
@@ -1181,17 +1181,6 @@ export type RejectRevisionNotificationEvent = AbstractNotificationEvent & Instan
   reason: Scalars['String']['output'];
   repository: Applet | Article | Course | CoursePage | Event | Exercise | ExerciseGroup | Page | Video;
   revision: AppletRevision | ArticleRevision | CoursePageRevision | CourseRevision | EventRevision | ExerciseGroupRevision | ExerciseRevision | PageRevision | VideoRevision;
-};
-
-export type RemoveEntityLinkNotificationEvent = AbstractNotificationEvent & InstanceAware & {
-  __typename?: 'RemoveEntityLinkNotificationEvent';
-  actor: User;
-  child: Applet | Article | Course | CoursePage | Event | Exercise | ExerciseGroup | Video;
-  date: Scalars['DateTime']['output'];
-  id: Scalars['Int']['output'];
-  instance: Instance;
-  objectId: Scalars['Int']['output'];
-  parent: Applet | Article | Course | CoursePage | Event | Exercise | ExerciseGroup | Video;
 };
 
 export type RemoveTaxonomyLinkNotificationEvent = AbstractNotificationEvent & InstanceAware & {
@@ -1954,12 +1943,12 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
   AbstractEntity: ( ModelOf<Applet> ) | ( ModelOf<Article> ) | ( ModelOf<Course> ) | ( ModelOf<CoursePage> ) | ( ModelOf<Event> ) | ( ModelOf<Exercise> ) | ( ModelOf<ExerciseGroup> ) | ( ModelOf<Video> );
   AbstractEntityRevision: ( ModelOf<AppletRevision> ) | ( ModelOf<ArticleRevision> ) | ( ModelOf<CoursePageRevision> ) | ( ModelOf<CourseRevision> ) | ( ModelOf<EventRevision> ) | ( ModelOf<ExerciseGroupRevision> ) | ( ModelOf<ExerciseRevision> ) | ( ModelOf<VideoRevision> );
   AbstractEntityRevisionConnection: ( ModelOf<AppletRevisionConnection> ) | ( ModelOf<ArticleRevisionConnection> ) | ( ModelOf<CoursePageRevisionConnection> ) | ( ModelOf<CourseRevisionConnection> ) | ( ModelOf<EventRevisionConnection> ) | ( ModelOf<ExerciseGroupRevisionConnection> ) | ( ModelOf<ExerciseRevisionConnection> ) | ( ModelOf<VideoRevisionConnection> );
-  AbstractNotificationEvent: ( ModelOf<Omit<CheckoutRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<CreateCommentNotificationEvent> ) | ( ModelOf<Omit<CreateEntityLinkNotificationEvent, 'child' | 'parent'> & { child: _RefType['AbstractEntity'], parent: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityNotificationEvent, 'entity'> & { entity: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityRevisionNotificationEvent, 'entity' | 'entityRevision'> & { entity: _RefType['AbstractRepository'], entityRevision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<CreateTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<CreateTaxonomyTermNotificationEvent> ) | ( ModelOf<Omit<CreateThreadNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> ) | ( ModelOf<Omit<RejectRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<RemoveEntityLinkNotificationEvent, 'child' | 'parent'> & { child: _RefType['AbstractEntity'], parent: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<RemoveTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<Omit<SetLicenseNotificationEvent, 'repository'> & { repository: _RefType['AbstractRepository'] }> ) | ( ModelOf<SetTaxonomyParentNotificationEvent> ) | ( ModelOf<SetTaxonomyTermNotificationEvent> ) | ( ModelOf<SetThreadStateNotificationEvent> ) | ( ModelOf<Omit<SetUuidStateNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> );
+  AbstractNotificationEvent: ( ModelOf<Omit<CheckoutRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<CreateCommentNotificationEvent> ) | ( ModelOf<Omit<CreateEntityLinkNotificationEvent, 'child' | 'parent'> & { child: _RefType['AbstractEntity'], parent: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityNotificationEvent, 'entity'> & { entity: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityRevisionNotificationEvent, 'entity' | 'entityRevision'> & { entity: _RefType['AbstractRepository'], entityRevision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<CreateTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<CreateTaxonomyTermNotificationEvent> ) | ( ModelOf<Omit<CreateThreadNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> ) | ( ModelOf<Omit<RejectRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<RemoveTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<Omit<SetLicenseNotificationEvent, 'repository'> & { repository: _RefType['AbstractRepository'] }> ) | ( ModelOf<SetTaxonomyParentNotificationEvent> ) | ( ModelOf<SetTaxonomyTermNotificationEvent> ) | ( ModelOf<SetThreadStateNotificationEvent> ) | ( ModelOf<Omit<SetUuidStateNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> );
   AbstractRepository: ( ModelOf<Applet> ) | ( ModelOf<Article> ) | ( ModelOf<Course> ) | ( ModelOf<CoursePage> ) | ( ModelOf<Event> ) | ( ModelOf<Exercise> ) | ( ModelOf<ExerciseGroup> ) | ( ModelOf<Page> ) | ( ModelOf<Video> );
   AbstractRevision: ( ModelOf<AppletRevision> ) | ( ModelOf<ArticleRevision> ) | ( ModelOf<CoursePageRevision> ) | ( ModelOf<CourseRevision> ) | ( ModelOf<EventRevision> ) | ( ModelOf<ExerciseGroupRevision> ) | ( ModelOf<ExerciseRevision> ) | ( ModelOf<PageRevision> ) | ( ModelOf<VideoRevision> );
   AbstractTaxonomyTermChild: ( ModelOf<Applet> ) | ( ModelOf<Article> ) | ( ModelOf<Course> ) | ( ModelOf<Event> ) | ( ModelOf<Exercise> ) | ( ModelOf<ExerciseGroup> ) | ( ModelOf<Video> );
   AbstractUuid: ( ModelOf<Applet> ) | ( ModelOf<AppletRevision> ) | ( ModelOf<Article> ) | ( ModelOf<ArticleRevision> ) | ( ModelOf<Omit<Comment, 'legacyObject'> & { legacyObject: _RefType['AbstractUuid'] }> ) | ( ModelOf<Course> ) | ( ModelOf<CoursePage> ) | ( ModelOf<CoursePageRevision> ) | ( ModelOf<CourseRevision> ) | ( ModelOf<Event> ) | ( ModelOf<EventRevision> ) | ( ModelOf<Exercise> ) | ( ModelOf<ExerciseGroup> ) | ( ModelOf<ExerciseGroupRevision> ) | ( ModelOf<ExerciseRevision> ) | ( ModelOf<Page> ) | ( ModelOf<PageRevision> ) | ( ModelOf<TaxonomyTerm> ) | ( ModelOf<User> ) | ( ModelOf<Video> ) | ( ModelOf<VideoRevision> );
-  InstanceAware: ( ModelOf<Applet> ) | ( ModelOf<Article> ) | ( ModelOf<Omit<CheckoutRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Course> ) | ( ModelOf<CoursePage> ) | ( ModelOf<CreateCommentNotificationEvent> ) | ( ModelOf<Omit<CreateEntityLinkNotificationEvent, 'child' | 'parent'> & { child: _RefType['AbstractEntity'], parent: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityNotificationEvent, 'entity'> & { entity: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityRevisionNotificationEvent, 'entity' | 'entityRevision'> & { entity: _RefType['AbstractRepository'], entityRevision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<CreateTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<CreateTaxonomyTermNotificationEvent> ) | ( ModelOf<Omit<CreateThreadNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> ) | ( ModelOf<Event> ) | ( ModelOf<Exercise> ) | ( ModelOf<ExerciseGroup> ) | ( ModelOf<Page> ) | ( ModelOf<Omit<RejectRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<RemoveEntityLinkNotificationEvent, 'child' | 'parent'> & { child: _RefType['AbstractEntity'], parent: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<RemoveTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<Omit<SetLicenseNotificationEvent, 'repository'> & { repository: _RefType['AbstractRepository'] }> ) | ( ModelOf<SetTaxonomyParentNotificationEvent> ) | ( ModelOf<SetTaxonomyTermNotificationEvent> ) | ( ModelOf<SetThreadStateNotificationEvent> ) | ( ModelOf<Omit<SetUuidStateNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> ) | ( ModelOf<TaxonomyTerm> ) | ( ModelOf<Video> );
+  InstanceAware: ( ModelOf<Applet> ) | ( ModelOf<Article> ) | ( ModelOf<Omit<CheckoutRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Course> ) | ( ModelOf<CoursePage> ) | ( ModelOf<CreateCommentNotificationEvent> ) | ( ModelOf<Omit<CreateEntityLinkNotificationEvent, 'child' | 'parent'> & { child: _RefType['AbstractEntity'], parent: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityNotificationEvent, 'entity'> & { entity: _RefType['AbstractEntity'] }> ) | ( ModelOf<Omit<CreateEntityRevisionNotificationEvent, 'entity' | 'entityRevision'> & { entity: _RefType['AbstractRepository'], entityRevision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<CreateTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<CreateTaxonomyTermNotificationEvent> ) | ( ModelOf<Omit<CreateThreadNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> ) | ( ModelOf<Event> ) | ( ModelOf<Exercise> ) | ( ModelOf<ExerciseGroup> ) | ( ModelOf<Page> ) | ( ModelOf<Omit<RejectRevisionNotificationEvent, 'repository' | 'revision'> & { repository: _RefType['AbstractRepository'], revision: _RefType['AbstractRevision'] }> ) | ( ModelOf<Omit<RemoveTaxonomyLinkNotificationEvent, 'child'> & { child: _RefType['AbstractUuid'] }> ) | ( ModelOf<Omit<SetLicenseNotificationEvent, 'repository'> & { repository: _RefType['AbstractRepository'] }> ) | ( ModelOf<SetTaxonomyParentNotificationEvent> ) | ( ModelOf<SetTaxonomyTermNotificationEvent> ) | ( ModelOf<SetThreadStateNotificationEvent> ) | ( ModelOf<Omit<SetUuidStateNotificationEvent, 'object'> & { object: _RefType['AbstractUuid'] }> ) | ( ModelOf<TaxonomyTerm> ) | ( ModelOf<Video> );
   ThreadAware: ( ModelOf<Applet> ) | ( ModelOf<AppletRevision> ) | ( ModelOf<Article> ) | ( ModelOf<ArticleRevision> ) | ( ModelOf<Course> ) | ( ModelOf<CoursePage> ) | ( ModelOf<CoursePageRevision> ) | ( ModelOf<CourseRevision> ) | ( ModelOf<Event> ) | ( ModelOf<EventRevision> ) | ( ModelOf<Exercise> ) | ( ModelOf<ExerciseGroup> ) | ( ModelOf<ExerciseGroupRevision> ) | ( ModelOf<ExerciseRevision> ) | ( ModelOf<Page> ) | ( ModelOf<PageRevision> ) | ( ModelOf<TaxonomyTerm> ) | ( ModelOf<User> ) | ( ModelOf<Video> ) | ( ModelOf<VideoRevision> );
 };
 
@@ -2053,7 +2042,6 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   RejectRevisionInput: ResolverTypeWrapper<ModelOf<RejectRevisionInput>>;
   RejectRevisionNotificationEvent: ResolverTypeWrapper<ModelOf<Omit<RejectRevisionNotificationEvent, 'repository' | 'revision'> & { repository: ResolversTypes['AbstractRepository'], revision: ResolversTypes['AbstractRevision'] }>>;
-  RemoveEntityLinkNotificationEvent: ResolverTypeWrapper<ModelOf<Omit<RemoveEntityLinkNotificationEvent, 'child' | 'parent'> & { child: ResolversTypes['AbstractEntity'], parent: ResolversTypes['AbstractEntity'] }>>;
   RemoveTaxonomyLinkNotificationEvent: ResolverTypeWrapper<ModelOf<Omit<RemoveTaxonomyLinkNotificationEvent, 'child'> & { child: ResolversTypes['AbstractUuid'] }>>;
   ResourceMetadataConnection: ResolverTypeWrapper<ModelOf<ResourceMetadataConnection>>;
   Role: ResolverTypeWrapper<ModelOf<Role>>;
@@ -2202,7 +2190,6 @@ export type ResolversParentTypes = {
   Query: {};
   RejectRevisionInput: ModelOf<RejectRevisionInput>;
   RejectRevisionNotificationEvent: ModelOf<Omit<RejectRevisionNotificationEvent, 'repository' | 'revision'> & { repository: ResolversParentTypes['AbstractRepository'], revision: ResolversParentTypes['AbstractRevision'] }>;
-  RemoveEntityLinkNotificationEvent: ModelOf<Omit<RemoveEntityLinkNotificationEvent, 'child' | 'parent'> & { child: ResolversParentTypes['AbstractEntity'], parent: ResolversParentTypes['AbstractEntity'] }>;
   RemoveTaxonomyLinkNotificationEvent: ModelOf<Omit<RemoveTaxonomyLinkNotificationEvent, 'child'> & { child: ResolversParentTypes['AbstractUuid'] }>;
   ResourceMetadataConnection: ModelOf<ResourceMetadataConnection>;
   ScopedRole: ModelOf<ScopedRole>;
@@ -2303,7 +2290,7 @@ export type AbstractEntityRevisionConnectionResolvers<ContextType = Context, Par
 };
 
 export type AbstractNotificationEventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['AbstractNotificationEvent'] = ResolversParentTypes['AbstractNotificationEvent']> = {
-  __resolveType: TypeResolveFn<'CheckoutRevisionNotificationEvent' | 'CreateCommentNotificationEvent' | 'CreateEntityLinkNotificationEvent' | 'CreateEntityNotificationEvent' | 'CreateEntityRevisionNotificationEvent' | 'CreateTaxonomyLinkNotificationEvent' | 'CreateTaxonomyTermNotificationEvent' | 'CreateThreadNotificationEvent' | 'RejectRevisionNotificationEvent' | 'RemoveEntityLinkNotificationEvent' | 'RemoveTaxonomyLinkNotificationEvent' | 'SetLicenseNotificationEvent' | 'SetTaxonomyParentNotificationEvent' | 'SetTaxonomyTermNotificationEvent' | 'SetThreadStateNotificationEvent' | 'SetUuidStateNotificationEvent', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'CheckoutRevisionNotificationEvent' | 'CreateCommentNotificationEvent' | 'CreateEntityLinkNotificationEvent' | 'CreateEntityNotificationEvent' | 'CreateEntityRevisionNotificationEvent' | 'CreateTaxonomyLinkNotificationEvent' | 'CreateTaxonomyTermNotificationEvent' | 'CreateThreadNotificationEvent' | 'RejectRevisionNotificationEvent' | 'RemoveTaxonomyLinkNotificationEvent' | 'SetLicenseNotificationEvent' | 'SetTaxonomyParentNotificationEvent' | 'SetTaxonomyTermNotificationEvent' | 'SetThreadStateNotificationEvent' | 'SetUuidStateNotificationEvent', ParentType, ContextType>;
   actor?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -2804,7 +2791,7 @@ export type ExperimentMutationResolvers<ContextType = Context, ParentType extend
 };
 
 export type InstanceAwareResolvers<ContextType = Context, ParentType extends ResolversParentTypes['InstanceAware'] = ResolversParentTypes['InstanceAware']> = {
-  __resolveType: TypeResolveFn<'Applet' | 'Article' | 'CheckoutRevisionNotificationEvent' | 'Course' | 'CoursePage' | 'CreateCommentNotificationEvent' | 'CreateEntityLinkNotificationEvent' | 'CreateEntityNotificationEvent' | 'CreateEntityRevisionNotificationEvent' | 'CreateTaxonomyLinkNotificationEvent' | 'CreateTaxonomyTermNotificationEvent' | 'CreateThreadNotificationEvent' | 'Event' | 'Exercise' | 'ExerciseGroup' | 'Page' | 'RejectRevisionNotificationEvent' | 'RemoveEntityLinkNotificationEvent' | 'RemoveTaxonomyLinkNotificationEvent' | 'SetLicenseNotificationEvent' | 'SetTaxonomyParentNotificationEvent' | 'SetTaxonomyTermNotificationEvent' | 'SetThreadStateNotificationEvent' | 'SetUuidStateNotificationEvent' | 'TaxonomyTerm' | 'Video', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'Applet' | 'Article' | 'CheckoutRevisionNotificationEvent' | 'Course' | 'CoursePage' | 'CreateCommentNotificationEvent' | 'CreateEntityLinkNotificationEvent' | 'CreateEntityNotificationEvent' | 'CreateEntityRevisionNotificationEvent' | 'CreateTaxonomyLinkNotificationEvent' | 'CreateTaxonomyTermNotificationEvent' | 'CreateThreadNotificationEvent' | 'Event' | 'Exercise' | 'ExerciseGroup' | 'Page' | 'RejectRevisionNotificationEvent' | 'RemoveTaxonomyLinkNotificationEvent' | 'SetLicenseNotificationEvent' | 'SetTaxonomyParentNotificationEvent' | 'SetTaxonomyTermNotificationEvent' | 'SetThreadStateNotificationEvent' | 'SetUuidStateNotificationEvent' | 'TaxonomyTerm' | 'Video', ParentType, ContextType>;
   instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
 };
 
@@ -2960,17 +2947,6 @@ export type RejectRevisionNotificationEventResolvers<ContextType = Context, Pare
   reason?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   repository?: Resolver<ResolversTypes['AbstractRepository'], ParentType, ContextType>;
   revision?: Resolver<ResolversTypes['AbstractRevision'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RemoveEntityLinkNotificationEventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['RemoveEntityLinkNotificationEvent'] = ResolversParentTypes['RemoveEntityLinkNotificationEvent']> = {
-  actor?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
-  child?: Resolver<ResolversTypes['AbstractEntity'], ParentType, ContextType>;
-  date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  instance?: Resolver<ResolversTypes['Instance'], ParentType, ContextType>;
-  objectId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  parent?: Resolver<ResolversTypes['AbstractEntity'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -3366,7 +3342,6 @@ export type Resolvers<ContextType = Context> = {
   PageRevisionConnection?: PageRevisionConnectionResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   RejectRevisionNotificationEvent?: RejectRevisionNotificationEventResolvers<ContextType>;
-  RemoveEntityLinkNotificationEvent?: RemoveEntityLinkNotificationEventResolvers<ContextType>;
   RemoveTaxonomyLinkNotificationEvent?: RemoveTaxonomyLinkNotificationEventResolvers<ContextType>;
   ResourceMetadataConnection?: ResourceMetadataConnectionResolvers<ContextType>;
   ScopedRole?: ScopedRoleResolvers<ContextType>;


### PR DESCRIPTION
It caused the bug described at this [slack thread](https://serlo.slack.com/archives/C0BMSC431/p1718355154116269).
After merging course pages, we won't have entity link anymore, that's why I removed it.

Follow up: https://github.com/serlo/api.serlo.org/issues/1617
