### PR TITLE
deleted-entities: Filter course pages out

### DIFF
--- a/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-entity/resolvers.ts
@@ -89,7 +89,7 @@ export const resolvers: Resolvers = {
             AND (? is null OR instance.subdomain = ?)
             AND event.event_type_id = 10
             AND uuid.trashed = 1
-            AND entity.type_id NOT IN (35, 39, 40, 41, 42, 43, 44)
+            AND entity.type_id NOT IN (35, 39, 40, 41, 42, 43, 44, 8)
         GROUP BY uuid.id
         ORDER BY dateOfDeletion DESC
         LIMIT ?;


### PR DESCRIPTION
Since the course pages are just there now to low "backwards compatibility" they don't need to be restored, and are going to be anyway completely deleted some day.