### PR TITLE
fix(db-migration): only run migrations automatically in local env

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -27,6 +27,8 @@ ARG image
 WORKDIR /usr/src/app
 COPY --from=build_dist /usr/src/app/dist dist
 COPY --from=build_node_modules /usr/src/app/node_modules node_modules
+COPY packages/db-migrations/database.json packages/db-migrations/database.json
+RUN mkdir packages/db-migrations/migrations
 RUN cp dist/${image}.cjs dist/entrypoint.cjs 2>/dev/null
 ENTRYPOINT ["node", "dist/entrypoint.cjs"]
 # for server and swr queue worker respectively, but EXPOSE is anyway just for documentation

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -18,7 +18,6 @@ COPY packages/authorization packages/authorization
 COPY packages/db-migrations packages/db-migrations
 COPY packages/server packages/server
 RUN yarn build:${image}
-RUN yarn migrate:build
 
 FROM base as build_node_modules
 RUN yarn workspaces focus --all --production
@@ -27,9 +26,7 @@ FROM node:20-alpine as release
 ARG image
 WORKDIR /usr/src/app
 COPY --from=build_dist /usr/src/app/dist dist
-COPY --from=build_dist /usr/src/app/packages/db-migrations/migrations packages/db-migrations/migrations
 COPY --from=build_node_modules /usr/src/app/node_modules node_modules
-COPY packages/db-migrations/database.json packages/db-migrations/database.json
 RUN cp dist/${image}.cjs dist/entrypoint.cjs 2>/dev/null
 ENTRYPOINT ["node", "dist/entrypoint.cjs"]
 # for server and swr queue worker respectively, but EXPOSE is anyway just for documentation

--- a/packages/server/src/internals/server/index.ts
+++ b/packages/server/src/internals/server/index.ts
@@ -22,7 +22,7 @@ export { getGraphQLOptions } from './graphql-middleware'
 export async function start() {
   dotenv.config()
 
-  if (process.env.ENVIRONMENT !== 'production') await migrateDB()
+  if (process.env.ENVIRONMENT === 'local') await migrateDB()
 
   initializeSentry({ context: 'server' })
   const timer = createTimer()


### PR DESCRIPTION
Indeed, it caused that api scaled horizonally, leading to many
instances of the server, running the same migration.
