### PR TITLE
db migration deployment: set to old way and make ci

### DIFF
--- a/.github/workflows/push-migration-image.yml
+++ b/.github/workflows/push-migration-image.yml
@@ -1,0 +1,17 @@
+name: Push DB migration image
+on:
+  # not a problem if we do it at every push because it will check if the image already exists
+  push:
+
+jobs:
+  docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: serlo/configure-repositories/actions/setup-node@main
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'
+      - run: gcloud auth configure-docker
+      - uses: google-github-actions/setup-gcloud@v2
+      - run: yarn migrate:push-image

--- a/packages/db-migrations/Dockerfile
+++ b/packages/db-migrations/Dockerfile
@@ -15,5 +15,7 @@ RUN yarn plugin import workspace-tools
 RUN yarn workspaces focus --production
 COPY --from=build_migrations /app/migrations migrations
 COPY migrations/package.json migrations/package.json
+COPY database.json .
+
 ENTRYPOINT ["yarn", "db-migrate"]
 CMD ["up"]

--- a/packages/db-migrations/database.json
+++ b/packages/db-migrations/database.json
@@ -1,3 +1,3 @@
 {
-  "dev": { "ENV": "MYSQL_URI" }
+  "dev": { "ENV": "DATABASE" }
 }

--- a/packages/db-migrations/database.json
+++ b/packages/db-migrations/database.json
@@ -1,3 +1,3 @@
 {
-  "dev": { "ENV": "DATABASE" }
+  "dev": { "ENV": "MYSQL_URI" }
 }

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/db-migrations",
-  "version": "1.1.0-staging.0",
+  "version": "1.1.0-staging.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/db-migrations",
-  "version": "1.0.0",
+  "version": "1.1.0-staging.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/db-migrations",
-  "version": "1.1.0-staging.1",
+  "version": "1.1.0-staging.2",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/db-migrations/scripts/push-image.ts
+++ b/packages/db-migrations/scripts/push-image.ts
@@ -19,7 +19,7 @@ void run()
 async function run() {
   const { version } = await fetchPackageJSON()
   buildDockerImage({
-    name: 'db-migration',
+    name: 'api-db-migration',
     version,
     Dockerfile: path.join(root, 'Dockerfile'),
     context: '.',


### PR DESCRIPTION
Keep the old name of the container for convenience for now. Changing the name would give more consistency, but it is not important now.