### PR TITLE
fix(alias): encode path again to match the alias in database

### DIFF
--- a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
+++ b/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts
@@ -610,7 +610,7 @@ async function resolveIdFromAlias(
     return await resolveIdFromUsername(usernameMatch.groups.username, context)
   }
 
-  cleanPath = cleanPath.slice(1)
+  cleanPath = decodePath(cleanPath.slice(1))
   // The following check is to avoid DB lookups for paths that we know do
   // not belong to UUIDs. This is a performance optimization.
   // Original code see https://github.com/serlo/database-layer/blob/71b80050ecda63d616ab34eda0fa1143cb9e3ddc/server/src/alias/model.rs#L17-L63


### PR DESCRIPTION
Before, the encoded path was sent to the database layer. It is strange that we decode, encode and decode it again
See the old code in https://github.com/serlo/api.serlo.org/pull/1573/files
I can't see the reason for this repetition back then. We may try to just decode once and not encode at all.

https://de.serlo-staging.dev/community/neue-f%C3%A4cher-themen is now working again. Unfortunatelly some Spanish alias aren't working still, I'll keep investigating.

