### PR TITLE
fix: get X-SERLO-EDITOR-TESTING header from req context

### DIFF
--- a/packages/server/src/internals/server/graphql-middleware.ts
+++ b/packages/server/src/internals/server/graphql-middleware.ts
@@ -27,6 +27,14 @@ const SessionDecoder = t.type({
   identity: IdentityDecoder,
 })
 
+const BodyWithSerloEditorTestingHeader = t.type({
+  context: t.type({
+    headers: t.type({
+      'X-SERLO-EDITOR-TESTING': t.string,
+    }),
+  }),
+})
+
 export async function applyGraphQLMiddleware({
   app,
   cache,
@@ -60,8 +68,9 @@ export async function applyGraphQLMiddleware({
     expressMiddleware(server, {
       async context({ req }): Promise<Context> {
         const isSerloEditorTesting =
-          req.headers['X-SERLO-EDITOR-TESTING'] ===
-          process.env.SERVER_SERLO_EDITOR_TESTING_SECRET
+          BodyWithSerloEditorTestingHeader.is(req.body) &&
+          req.body.context.headers['X-SERLO-EDITOR-TESTING'] ===
+            process.env.SERVER_SERLO_EDITOR_TESTING_SECRET
         const googleStorage = new Storage()
         const database = new Database(pool)
         const dataSources = {


### PR DESCRIPTION
Initially, I expected the header passed by the Editor [here](https://github.com/serlo/frontend/blob/staging/packages/editor/src/editor-integration/image-with-testing-config.ts#L110) to be available in `request.headers`. That was not the case, however 😄 