### PR TITLE
build(docker-compose): set platform for database-layer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,4 @@ services:
       - DATABASE_MAX_CONNECTIONS=5
       - DATABASE_URL=mysql://root:secret@mysql:3306/serlo
       - ENV=development
+    platform: linux/amd64


### PR DESCRIPTION
I had warnings when starting the containers, because my machine is arm64.