### PR TITLE
chore(docker): adapt name of image tag

### DIFF
--- a/packages/server/scripts/deploy-env.ts
+++ b/packages/server/scripts/deploy-env.ts
@@ -16,12 +16,12 @@ function run() {
     )
   }
   buildDockerImage({
-    name: 'api.serlo.org/server',
+    name: 'server',
     context: '../..',
     envName,
   })
   buildDockerImage({
-    name: 'api.serlo.org/swr-queue-worker',
+    name: 'swr-queue-worker',
     context: '../..',
     envName,
   })
@@ -29,7 +29,7 @@ function run() {
 
 function buildDockerImage({ name, context, envName }: DockerImageOptions) {
   const registry = process.env.DOCKER_REGISTRY || 'ghcr.io'
-  const repository = process.env.DOCKER_REPOSITORY || `serlo/${name}`
+  const repository = process.env.DOCKER_REPOSITORY || `serlo/api.serlo.org/${name}`
   const remoteName = `${registry}/${repository}`
   const date = new Date()
   const timestamp = `${date.toISOString().split('T')[0]}-${date.getTime()}`
@@ -60,7 +60,7 @@ function buildDockerImage({ name, context, envName }: DockerImageOptions) {
       ...tags.flatMap((tag) => ['-t', tag]),
       context,
       '--build-arg',
-      `image=${name.replace('api-', '')}`,
+      `image=${name}`,
     ],
     { stdio: 'inherit' },
   )

--- a/packages/server/scripts/deploy-env.ts
+++ b/packages/server/scripts/deploy-env.ts
@@ -29,7 +29,8 @@ function run() {
 
 function buildDockerImage({ name, context, envName }: DockerImageOptions) {
   const registry = process.env.DOCKER_REGISTRY || 'ghcr.io'
-  const repository = process.env.DOCKER_REPOSITORY || `serlo/api.serlo.org/${name}`
+  const repository =
+    process.env.DOCKER_REPOSITORY || `serlo/api.serlo.org/${name}`
   const remoteName = `${registry}/${repository}`
   const date = new Date()
   const timestamp = `${date.toISOString().split('T')[0]}-${date.getTime()}`


### PR DESCRIPTION
Follow up of #1696

Minor detail that led to not building the image properly. Unfortunatelly, the yarn deploy:image:staging doesn't throw errors in such cases.
