### PR TITLE
fix: Fix metadata to fully match AMB Standard

### DIFF
--- a/__tests__/schema/metadata.ts
+++ b/__tests__/schema/metadata.ts
@@ -29,6 +29,9 @@ test('endpoint `publisher` returns publisher', async () => {
     })
 })
 
+/**
+ * For more complete and complex tests go to `serlo/metadata-exports` and run `pipenv run validate_local`. Remember to run `yarn mysql:import-anonymous-data` first.
+ */
 describe('endpoint "resources"', () => {
   const query = new Client().prepareQuery({
     query: gql`

--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -150,6 +150,7 @@ export const resolvers: Resolvers = {
             AND type.name IN ("applet", "article", "course", "text-exercise",
                               "text-exercise-group", "video")
             AND NOT subject_mapping.subject_id = 146728
+            AND license.url NOT LIKE "https://www.youtube.com/static?%"
         GROUP BY entity.id
         ORDER BY entity.id
         LIMIT ?

--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -1,5 +1,6 @@
 import * as R from 'ramda'
 
+import { captureErrorEvent } from '~/error-event'
 import { UserInputError } from '~/errors'
 import { createNamespace, decodeId } from '~/internals/graphql'
 import { resolveConnection } from '~/schema/connection/utils'
@@ -515,6 +516,15 @@ function getRaWSubject(id: number): RawSubject[] {
     case 148619:
       return [{ id: '1043', scheme: Scheme.SchoolSubject }]
     default:
+      captureErrorEvent({
+        error: new Error(
+          'metadata: subject could not be mapped to field `about`',
+        ),
+        errorContext: {
+          subjectId: id,
+          warning: 'It will break the export to Mein Bildungsraum',
+        },
+      })
       return []
   }
 }

--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -112,8 +112,8 @@ export const resolvers: Resolvers = {
             JOIN subject_mapping ON subject_mapping.taxonomy_id = child.parent_id
             -- "Fächer im Aufbau" taxonomy is on the level of normal Serlo subjects, therefore we need a level below it.
             -- "Partner" taxonomy is below the subject "Mathematik", but we only want the entities with the specific partner as the subject.
-            WHERE child.parent_id NOT IN (87993, 106081, 146728)
-                -- Exclude content under "Baustelle", "Community", "Zum Testen" and "Testbereich" taxonomies
+            -- Exclude content under "Baustelle", "Community" (from de, en and es instances), "Zum Testen" and "Testbereich" taxonomies
+            WHERE child.parent_id NOT IN (87993, 106081, 146728, 48537, 164234)
                 AND child.id NOT IN (75211, 105140, 107772, 135390, 25107, 106082)
         )
         SELECT

--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -113,7 +113,7 @@ export const resolvers: Resolvers = {
             -- "Fächer im Aufbau" taxonomy is on the level of normal Serlo subjects, therefore we need a level below it.
             -- "Partner" taxonomy is below the subject "Mathematik", but we only want the entities with the specific partner as the subject.
             -- Exclude content under "Baustelle", "Community" (from de, en and es instances), "Zum Testen" and "Testbereich" taxonomies
-            WHERE child.parent_id NOT IN (87993, 106081, 146728, 48537, 164234)
+            WHERE child.parent_id NOT IN (87993, 106081, 146728, 48537, 164234, 141588)
                 AND child.id NOT IN (75211, 105140, 107772, 135390, 25107, 106082)
         )
         SELECT

--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -402,10 +402,12 @@ enum Scheme {
 function getRaWSubject(id: number): RawSubject[] {
   switch (id) {
     // Mathematik (Schule)
+    // Chancenwerk 268835 has only created math content so far
     case 5:
     case 23593:
     case 141587:
     case 169580:
+    case 268835:
       return [{ id: '1017', scheme: Scheme.SchoolSubject }]
 
     // Nachhaltigkeit => Biologie, Ethik (Schule)
@@ -420,7 +422,9 @@ function getRaWSubject(id: number): RawSubject[] {
     case 18230:
       return [{ id: '1002', scheme: Scheme.SchoolSubject }]
     // Biologie (Schule)
+    // Forensik 195927
     case 23362:
+    case 195927:
       return [{ id: '1001', scheme: Scheme.SchoolSubject }]
     // Englisch (Shule)
     case 25979:
@@ -437,7 +441,6 @@ function getRaWSubject(id: number): RawSubject[] {
     // Informatik (Schule)
     case 47899:
       return [{ id: '1013', scheme: Scheme.SchoolSubject }]
-
     // Politik => Politik, Sachunterricht (Schule)
     case 79159:
     case 107556:
@@ -461,8 +464,10 @@ function getRaWSubject(id: number): RawSubject[] {
     case 112723:
       return [{ id: '1006', scheme: Scheme.SchoolSubject }]
     // Geschichte (Schule)
+    // Estudios en Diásporas Africanas 242308
     case 136362:
     case 140528:
+    case 242308:
       return [{ id: '1011', scheme: Scheme.SchoolSubject }]
     // Wirtschaftskunde (Schule)
     case 137757:
@@ -506,6 +511,16 @@ function getRaWSubject(id: number): RawSubject[] {
       return [
         { id: '1043', scheme: Scheme.SchoolSubject },
         { id: '1005', scheme: Scheme.SchoolSubject },
+      ]
+    // Lerntipps,  => Erziehungswissenschaft (Schule)
+    case 181883:
+    case 148619:
+      return [{ id: '1043', scheme: Scheme.SchoolSubject }]
+    // Schlau-Werkstatt,  => Mathematik, Deutsch als Zweitsprache (Schule)
+    case 146870:
+      return [
+        { id: '1017', scheme: Scheme.SchoolSubject },
+        { id: '1006', scheme: Scheme.SchoolSubject },
       ]
     default:
       return []

--- a/packages/server/src/schema/metadata/resolvers.ts
+++ b/packages/server/src/schema/metadata/resolvers.ts
@@ -113,7 +113,7 @@ export const resolvers: Resolvers = {
             -- "Fächer im Aufbau" taxonomy is on the level of normal Serlo subjects, therefore we need a level below it.
             -- "Partner" taxonomy is below the subject "Mathematik", but we only want the entities with the specific partner as the subject.
             -- Exclude content under "Baustelle", "Community" (from de, en and es instances), "Zum Testen" and "Testbereich" taxonomies
-            WHERE child.parent_id NOT IN (87993, 106081, 146728, 48537, 164234, 141588)
+            WHERE child.parent_id NOT IN (87993, 106081, 146728, 48537, 164234, 141588, 268835, 146870)
                 AND child.id NOT IN (75211, 105140, 107772, 135390, 25107, 106082)
         )
         SELECT
@@ -402,12 +402,10 @@ enum Scheme {
 function getRaWSubject(id: number): RawSubject[] {
   switch (id) {
     // Mathematik (Schule)
-    // Chancenwerk 268835 has only created math content so far
     case 5:
     case 23593:
     case 141587:
     case 169580:
-    case 268835:
       return [{ id: '1017', scheme: Scheme.SchoolSubject }]
 
     // Nachhaltigkeit => Biologie, Ethik (Schule)
@@ -516,12 +514,6 @@ function getRaWSubject(id: number): RawSubject[] {
     case 181883:
     case 148619:
       return [{ id: '1043', scheme: Scheme.SchoolSubject }]
-    // Schlau-Werkstatt,  => Mathematik, Deutsch als Zweitsprache (Schule)
-    case 146870:
-      return [
-        { id: '1017', scheme: Scheme.SchoolSubject },
-        { id: '1006', scheme: Scheme.SchoolSubject },
-      ]
     default:
       return []
   }


### PR DESCRIPTION
Had to change the database for handling of the license for chancenwerk

`update license set url = 'https://creativecommons.org/licenses/by-sa/4.0/deed.de' where id = 25;`

Fixes https://linear.app/serlo/issue/PE-215/bug-nodes-cannot-be-added-to-datenraum