### PR TITLE
Fix mysql deadlock

### DIFF
--- a/packages/server/src/schema/uuid/user/resolvers.ts
+++ b/packages/server/src/schema/uuid/user/resolvers.ts
@@ -320,18 +320,6 @@ export const resolvers: Resolvers = {
       if (id == null) {
         throw new UserInputError('no user with given username')
       }
-      await database.mutate(
-        `
-        INSERT INTO role (name)
-        SELECT ?
-        WHERE NOT EXISTS (
-          SELECT 1
-          FROM role
-          WHERE name = ?
-        )
-        `,
-        [generateRole(role, instance), generateRole(role, instance)],
-      )
 
       await database.mutate(
         `


### PR DESCRIPTION
@kulla 

The merging of dependabots is getting stuck because of the deadlock. It is caused by the fact that we trying to do two inserts at the same time in the `addRole` functions, while the mysql is locking the tables.

Although there was [discussion ](https://github.com/serlo/api.serlo.org/pull/1518#discussion_r1615796795) for adding roles that don't exist yet, it seems unnecessary now. So removing the insert of an automatic creation of role will solve it.

As a followup we can throw an error, report and adapt the tests (what can be pretty annoying since the dummy database doesn't have at the moment the used roles in code).