### PR TITLE
feat(db-migrations): update content of every entity_revision to new Editor format

### DIFF
--- a/__tests__/schema/uuid/entity-revision.ts
+++ b/__tests__/schema/uuid/entity-revision.ts
@@ -12,7 +12,7 @@ test('Uuid query for an entity revision', async () => {
       repository: { id: 35295 },
       title: '"falsche Freunde"',
       content:
-        '{"plugin":"rows","state":[{"plugin":"text","state":[{"type":"p","children":[{"text":"wip"}]}],"id":"7165fed8-d729-45fd-a28c-8ea7c2622953"}],"id":"3b4326f6-88c6-4da8-9bea-f0eb4aa5407a"}',
+        '{"id":"a610a1dd-f48f-491a-b59e-0c321823a0aa","type":"https://serlo.org/editor","variant":"serlo-org","domainOrigin":"serlo.org","version":"1","editorVersion":"0.22.0","dateModified":"2025-02-04T15:40:19.868Z","document":{"plugin":"rows","state":[{"plugin":"text","state":[{"type":"p","children":[{"text":"wip"}]}],"id":"7165fed8-d729-45fd-a28c-8ea7c2622953"}],"id":"3b4326f6-88c6-4da8-9bea-f0eb4aa5407a"}}',
       changes: '',
       metaTitle: '',
       metaDescription: '',

--- a/__tests__/schema/uuid/entity-revision.ts
+++ b/__tests__/schema/uuid/entity-revision.ts
@@ -11,8 +11,9 @@ test('Uuid query for an entity revision', async () => {
       date: '2015-02-22T20:29:03.000Z',
       repository: { id: 35295 },
       title: '"falsche Freunde"',
-      content:
-        '{"id":"a610a1dd-f48f-491a-b59e-0c321823a0aa","type":"https://serlo.org/editor","variant":"serlo-org","domainOrigin":"serlo.org","version":"1","editorVersion":"0.22.0","dateModified":"2025-02-04T15:40:19.868Z","document":{"plugin":"rows","state":[{"plugin":"text","state":[{"type":"p","children":[{"text":"wip"}]}],"id":"7165fed8-d729-45fd-a28c-8ea7c2622953"}],"id":"3b4326f6-88c6-4da8-9bea-f0eb4aa5407a"}}',
+      content: expect.stringContaining(
+        '{"plugin":"rows","state":[{"plugin":"text","state":[{"type":"p","children":[{"text":"wip"}]}],"id":"7165fed8-d729-45fd-a28c-8ea7c2622953"}],"id":"3b4326f6-88c6-4da8-9bea-f0eb4aa5407a"}',
+      ) as string,
       changes: '',
       metaTitle: '',
       metaDescription: '',

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/db-migrations",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/db-migrations",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/db-migrations",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "db-migrate": "^0.11.14",
-    "db-migrate-mysql": "^3.0.0"
+    "db-migrate-mysql": "^3.0.0",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.3",

--- a/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
+++ b/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
@@ -38,7 +38,7 @@ function wrapEntityRevisionContentInEditorMetadata(
     type: 'https://serlo.org/editor',
     variant: 'serlo-org',
     domainOrigin: 'serlo.org',
-    version: '1',
+    version: '2',
     editorVersion: '0.22.0',
     dateModified: new Date().toISOString(),
     document: content,
@@ -50,7 +50,7 @@ interface EditorStorageFormat {
   type: 'https://serlo.org/editor'
   variant: 'serlo-org'
   domainOrigin: 'serlo.org'
-  version: '1'
+  version: '2'
   editorVersion: '0.22.0'
   dateModified: string
   document: Plugin

--- a/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
+++ b/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
@@ -1,18 +1,9 @@
 import { v4 as uuidv4 } from 'uuid'
 
-import {
-  ApiCache,
-  Database,
-  migrateSerloEditorContent,
-  Plugin,
-  SlackLogger,
-} from './utils'
+import { ApiCache, Database, migrateSerloEditorContent, Plugin } from './utils'
 
 export async function up(db: Database) {
   const apiCache = new ApiCache()
-  const logger = new SlackLogger(
-    '20250131114300-update-all-entities-to-new-editor-format',
-  )
 
   await migrateSerloEditorContent({
     apiCache,
@@ -24,7 +15,6 @@ export async function up(db: Database) {
     },
   })
 
-  await logger.closeAndSend()
   // To reduce the time between deleting the keys and finishing the DB
   // transaction, this should be the last command
   await apiCache.deleteKeysAndQuit()

--- a/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
+++ b/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
@@ -38,7 +38,7 @@ function wrapEntityRevisionContentInEditorMetadata(
     type: 'https://serlo.org/editor',
     variant: 'serlo-org',
     domainOrigin: 'serlo.org',
-    version: '2',
+    version: 2,
     editorVersion: '0.22.0',
     dateModified: new Date().toISOString(),
     document: content,
@@ -50,7 +50,7 @@ interface EditorStorageFormat {
   type: 'https://serlo.org/editor'
   variant: 'serlo-org'
   domainOrigin: 'serlo.org'
-  version: '2'
+  version: 2
   editorVersion: '0.22.0'
   dateModified: string
   document: Plugin

--- a/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
+++ b/packages/db-migrations/src/20250131114300-update-all-entities-to-new-editor-format.ts
@@ -1,0 +1,57 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import {
+  ApiCache,
+  Database,
+  migrateSerloEditorContent,
+  Plugin,
+  SlackLogger,
+} from './utils'
+
+export async function up(db: Database) {
+  const apiCache = new ApiCache()
+  const logger = new SlackLogger(
+    '20250131114300-update-all-entities-to-new-editor-format',
+  )
+
+  await migrateSerloEditorContent({
+    apiCache,
+    db,
+    migrationName: 'update-all-entities-to-new-editor-format',
+    migrateState: (state) => {
+      const entityRevisionContent = state as Plugin
+      return wrapEntityRevisionContentInEditorMetadata(entityRevisionContent)
+    },
+  })
+
+  await logger.closeAndSend()
+  // To reduce the time between deleting the keys and finishing the DB
+  // transaction, this should be the last command
+  await apiCache.deleteKeysAndQuit()
+}
+
+function wrapEntityRevisionContentInEditorMetadata(
+  content: Plugin,
+): EditorStorageFormat {
+  return {
+    id: uuidv4(),
+    type: 'https://serlo.org/editor',
+    variant: 'serlo-org',
+    domainOrigin: 'serlo.org',
+    version: '1',
+    editorVersion: '0.22.0',
+    dateModified: new Date().toISOString(),
+    document: content,
+  }
+}
+
+interface EditorStorageFormat {
+  id: string
+  type: 'https://serlo.org/editor'
+  variant: 'serlo-org'
+  domainOrigin: 'serlo.org'
+  version: '1'
+  editorVersion: '0.22.0'
+  dateModified: string
+  document: Plugin
+}

--- a/packages/db-migrations/src/utils/create-migration.ts
+++ b/packages/db-migrations/src/utils/create-migration.ts
@@ -112,12 +112,12 @@ async function changeUuidContents({
   log: (message: string) => void
 }) {
   const querySQL = query + ' LIMIT ?'
-  let uuids: Uuid[] = []
+  let lastID = 0
 
-  do {
-    const lastID = uuids.at(-1)?.id ?? 0
+  while (true) {
     log(`Last ID: ${lastID}`)
-    uuids = await db.runSql(querySQL, lastID, 5000)
+    const uuids: Uuid[] = await db.runSql(querySQL, lastID, 5000)
+    lastID = uuids.at(-1)?.id ?? 0
 
     for (const uuid of uuids) {
       let oldState
@@ -159,7 +159,11 @@ async function changeUuidContents({
         })
       }
     }
-  } while (uuids.length > 0)
+
+    if (uuids.length === 0) {
+      break
+    }
+  }
 }
 
 interface Uuid {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5121,6 +5121,7 @@ __metadata:
     ts-unused-exports: ^11.0.1
     tsx: ^4.19.2
     typescript: ^5.7.3
+    uuid: ^11.0.5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Linear: [EDTR-98](https://linear.app/serlo/issue/EDTR-98/use-the-new-migration-algorithm-also-at-serloorg)
Frontend PR: https://github.com/serlo/frontend/pull/4465
Infra PR: https://github.com/serlo/infra/pull/120

Note: Because the new metadata has non-deterministic values, such as `dateModified` and `id`, only test for matching document content.